### PR TITLE
Allow customized content-integration

### DIFF
--- a/src/get_main_library.js
+++ b/src/get_main_library.js
@@ -1,0 +1,11 @@
+function get_main_library(main_library, dependencies) {
+    return `${main_library} ${
+        dependencies.filter(dep => dep.machineName === main_library)[0]
+            .majorVersion
+    }.${
+        dependencies.filter(dep => dep.machineName === main_library)[0]
+            .minorVersion
+    }`;
+}
+
+module.exports = get_main_library;

--- a/src/h5p.js
+++ b/src/h5p.js
@@ -122,23 +122,26 @@ function h5p(
 
         <script>window.H5PIntegration.contents = window.H5PIntegration.contents || {}; </script>
         <script>window.H5PIntegration.contents["cid-${content_id}"] = ${JSON.stringify(
-            {
-                library: get_main_library(
-                    h5p_json.mainLibrary,
-                    h5p_json.preloadedDependencies
-                ),
-                jsonContent: JSON.stringify(content_json),
-                fullScreen: false,
-                displayOptions: {
-                    frame: false,
-                    export: false,
-                    embed: false,
-                    copyright: true,
-                    icon: false
+            Object.assign(
+                {
+                    library: get_main_library(
+                        h5p_json.mainLibrary,
+                        h5p_json.preloadedDependencies
+                    ),
+                    jsonContent: JSON.stringify(content_json),
+                    fullScreen: false,
+                    displayOptions: {
+                        frame: false,
+                        export: false,
+                        embed: false,
+                        copyright: false,
+                        icon: false
+                    },
+                    styles: dependencies.css,
+                    scripts: dependencies.js
                 },
-                styles: dependencies.css,
-                scripts: dependencies.js
-            }
+                options.content
+            )
         )}
         </script>
 

--- a/src/h5p.js
+++ b/src/h5p.js
@@ -1,4 +1,5 @@
 const resolve_dependencies = require('./resolve_dependencies');
+const get_main_library = require('./get_main_library');
 
 function h5p(
     content_id,
@@ -122,26 +123,18 @@ function h5p(
         <script>window.H5PIntegration.contents = window.H5PIntegration.contents || {}; </script>
         <script>window.H5PIntegration.contents["cid-${content_id}"] = ${JSON.stringify(
             {
-                // library: h5p.get_mainLibrary(),
-                library: `${h5p_json.mainLibrary} ${
-                    h5p_json.preloadedDependencies.filter(
-                        dep => dep.machineName === h5p_json.mainLibrary
-                    )[0].majorVersion
-                }.${
-                    h5p_json.preloadedDependencies.filter(
-                        dep => dep.machineName === h5p_json.mainLibrary
-                    )[0].minorVersion
-                }`,
+                library: get_main_library(
+                    h5p_json.mainLibrary,
+                    h5p_json.preloadedDependencies
+                ),
                 jsonContent: JSON.stringify(content_json),
                 fullScreen: false,
-                // "exportUrl": "/path/to/download.h5p",
-                // "embedCode": "<iframe src=\"https://mysite.com${url_prefix}/1234/embed\" width=\":w\" height=\":h\" frameborder=\"0\" allowfullscreen=\"allowfullscreen\"></iframe>",
                 displayOptions: {
-                    frame: false, // Show frame and buttons below H5P
-                    export: false, // Display download button
-                    embed: false, // Display embed button
-                    copyright: true, // Display copyright button
-                    icon: false // Display H5P icon
+                    frame: false,
+                    export: false,
+                    embed: false,
+                    copyright: true,
+                    icon: false
                 },
                 styles: dependencies.css,
                 scripts: dependencies.js


### PR DESCRIPTION
Hey, 

the content (in window.H5PINtegration.contents[<content_id>]) should be customizable. This pr allows to provide a custom implementation via `options.content`.