### PR TITLE
Separate the default H5P-Integration

### DIFF
--- a/src/default_integration.json
+++ b/src/default_integration.json
@@ -1,0 +1,47 @@
+{
+    "baseUrl": "/",
+    "url": "/",
+    "postUserStatistics": true,
+    "ajaxPath": "/path/to/h5p-ajax",
+    "ajax": {
+        "setFinished": "/interactive-contents/123/results/new",
+        "contentUserData": "/interactive-contents/:contentId/user-data?data_type=:dataType&subContentId=:subContentId"
+    },
+    "saveFreq": 30,
+    "user": {
+        "name": "User Name",
+        "mail": "user@mysite.com"
+    },
+    "l10n": {
+        "H5P": {
+            "fullscreen": "Fullscreen",
+            "disableFullscreen": "Disable fullscreen",
+            "download": "Download",
+            "copyrights": "Rights of use",
+            "embed": "Embed",
+            "size": "Size",
+            "showAdvanced": "Show advanced",
+            "hideAdvanced": "Hide advanced",
+            "advancedHelp": "Include this script on your website if you want dynamic sizing of the embedded content:",
+            "copyrightInformation": "Rights of use",
+            "close": "Close",
+            "title": "Title",
+            "author": "Author",
+            "year": "Year",
+            "source": "Source",
+            "license": "License",
+            "thumbnail": "Thumbnail",
+            "noCopyrights": "No copyright information available for this content.",
+            "downloadDescription": "Download this content as a H5P file.",
+            "copyrightsDescription": "View copyright information for this content.",
+            "embedDescription": "View the embed code for this content.",
+            "h5pDescription": "Visit H5P.org to check out more cool content.",
+            "contentChanged": "This content has changed since you last used it.",
+            "startingOver": "You'll be starting over.",
+            "by": "by",
+            "showMore": "Show more",
+            "showLess": "Show less",
+            "subLevel": "Sublevel"
+        }
+    }
+}

--- a/src/h5p.js
+++ b/src/h5p.js
@@ -1,4 +1,5 @@
 const resolve_dependencies = require('./resolve_dependencies');
+const default_integration = require('./default_integration');
 
 function h5p(
     content_id,
@@ -47,75 +48,14 @@ function h5p(
                 .reduce((p, c) => p + c, '')}
           <script>
           H5PIntegration = ${JSON.stringify(
-              Object.assign(
-                  {
-                      baseUrl: '/', // No trailing slash
-                      url: '/', // Relative to web root
-                      postUserStatistics: true, // Only if user is logged in
-                      ajaxPath: '/path/to/h5p-ajax', // Only used by older Content Types
-                      ajax: {
-                          // Where to post user results
-                          setFinished: '/interactive-contents/123/results/new',
-                          // Words beginning with : are placeholders
-                          contentUserData:
-                              '/interactive-contents/:contentId/user-data?data_type=:dataType&subContentId=:subContentId'
-                      },
-                      saveFreq: 30, // How often current content state should be saved. false to disable.
-                      user: {
-                          // Only if logged in !
-                          name: 'User Name',
-                          mail: 'user@mysite.com'
-                      },
-                      //   siteUrl: req.protocol + '://' + req.headers.host, // Only if NOT logged in!
-                      l10n: {
-                          // Text string translations
-                          H5P: {
-                              fullscreen: 'Fullscreen',
-                              disableFullscreen: 'Disable fullscreen',
-                              download: 'Download',
-                              copyrights: 'Rights of use',
-                              embed: 'Embed',
-                              size: 'Size',
-                              showAdvanced: 'Show advanced',
-                              hideAdvanced: 'Hide advanced',
-                              advancedHelp:
-                                  'Include this script on your website if you want dynamic sizing of the embedded content:',
-                              copyrightInformation: 'Rights of use',
-                              close: 'Close',
-                              title: 'Title',
-                              author: 'Author',
-                              year: 'Year',
-                              source: 'Source',
-                              license: 'License',
-                              thumbnail: 'Thumbnail',
-                              noCopyrights:
-                                  'No copyright information available for this content.',
-                              downloadDescription:
-                                  'Download this content as a H5P file.',
-                              copyrightsDescription:
-                                  'View copyright information for this content.',
-                              embedDescription:
-                                  'View the embed code for this content.',
-                              h5pDescription:
-                                  'Visit H5P.org to check out more cool content.',
-                              contentChanged:
-                                  'This content has changed since you last used it.',
-                              startingOver: "You'll be starting over.",
-                              by: 'by',
-                              showMore: 'Show more',
-                              showLess: 'Show less',
-                              subLevel: 'Sublevel'
-                          }
-                      },
-                      loadedJs: dependencies.js,
-                      loadedCss: dependencies.css,
-                      core: {
-                          scripts: dependencies.js,
-                          styles: dependencies.css
-                      }
-                  },
-                  options.integration
-              )
+              Object.assign(default_integration, options.integration, {
+                  loadedJs: dependencies.js,
+                  loadedCss: dependencies.css,
+                  core: {
+                      scripts: dependencies.js,
+                      styles: dependencies.css
+                  }
+              })
           )};
         </script>
 


### PR DESCRIPTION
Hey,

this PR separates the default H5P-Integration into `src/default_integration.json`, so the h5p-function looks a lot cleaner.