### PR TITLE
Fix: Library is not installable as dependency via npm (fixes #39)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "h5p-nodejs-library",
-    "version": "v0.1.0",
+    "version": "v0.2.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "url": "https://github.com/Lumieducation/h5p-nodejs-library"
     },
     "scripts": {
-        "postinstall": "examples/install.sh",
+        "prepare": "examples/install.sh",
         "start": "node ./examples/server",
         "clean": "rm -rf build && rm -rf dist",
         "uninstall": "npm run clean && rm -rf node_modules && examples/uninstall.sh",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "h5p-nodejs-library",
-    "version": "v0.2.0",
+    "version": "v0.2.1",
     "description": "The H5P-Nodejs-library is a port of the H5P-PHP-library for Nodejs.",
     "repository": {
         "type": "git",


### PR DESCRIPTION
Hey,
I moved the install-script execution in the package.json from postinstall to prepare.
This installs the H5P-core-files only on `npm install`.
When installing the library as dependency via `npm install --save h5p-nodejs-library` it is not executed. (see [npm-docs](https://docs.npmjs.com/misc/scripts#description))

See #39
