### PR TITLE
Enforce Code-style (closes #42)

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -16,6 +16,9 @@
     },
     "rules": {
         "global-require": "off",
-        "import/no-dynamic-require": "off"
+        "import/no-dynamic-require": "off",
+        "no-underscore-dangle": "off",
+        "no-param-reassign": "off",
+        "class-methods-use-this": "off"
     }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -14,7 +14,6 @@
         "sourceType": "module"
     },
     "rules": {
-        "camelcase": 0,
         "global-require": "off",
         "import/no-dynamic-require": "off"
     }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,7 +4,8 @@
         "es6": true,
         "node": true
     },
-    "extends": ["airbnb-base", "prettier"],
+    "plugins": ["jest"],
+    "extends": ["airbnb-base", "prettier", "plugin:jest/recommended"],
     "globals": {
         "Atomics": "readonly",
         "SharedArrayBuffer": "readonly"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: node_js
 node_js:
     - node
-script: npm run lint
-script: npm run test
+script: npm run lint && npm run test
 cache:
     directories:
         - node_modules

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 node_js:
     - node
+script: npm run lint
 script: npm run test
 cache:
     directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js:
     - node
-script: npm run lint && npm run test
+script: npm run ci
 cache:
     directories:
         - node_modules

--- a/README.md
+++ b/README.md
@@ -39,11 +39,11 @@ The library-loader takes three arguments:
 For example:
 
 ```ts
-const library_loader = (machine_name: string, major_version: number, minor_version: number) => {
+const libraryLoader = (machine_name: string, major_version: number, minor_version: number) => {
     return require(`/the_path_to_your_libraries/${machine_name}-${major_version}.${minor_version}/library.json`
 };
 
-const H5P = new h5p(library_loader);
+const H5P = new h5p(libraryLoader);
 
 ```
 
@@ -58,9 +58,9 @@ The Content-Object can be found the the /content folder of a .h5p-file.
 Use the `.render`-method of the H5P-Nodejs-Library, which generates a H5P Page that can be embedded via iframe.
 
 ```ts
-const h5p_object = require(`test/h5p.json`);
-const content_object = require(`test/content/content.json`);
-H5P.render('test', content_object, h5p_object).then(h5p_page =>
+const h5pObject = require(`test/h5p.json`);
+const contentObject = require(`test/content/content.json`);
+H5P.render('test', contentObject, h5pObject).then(h5p_page =>
     send(h5p_page);
 );
 ```
@@ -84,7 +84,7 @@ $ npm install
 $ npm start
 ```
 
-### Usage 
+### Usage
 
 Open `http://localhost:8080` in your browser. You will see a list of examples. By clicking on an example you download the corresponding .h5p-file and render it in the browser. See [express-example](https://github.com/Lumieducation/H5P-Nodejs-library/blob/next/examples/server.js) for the implementation.
 

--- a/examples/server.js
+++ b/examples/server.js
@@ -6,19 +6,23 @@ const express = require('express');
 const server = express();
 
 const H5P = require('../src');
-const examples = require('./examples.json')
+const examples = require('./examples.json');
 
 server.use('/favicon.ico', express.static(`${__dirname}/favicon.ico`));
 server.use('/h5p/core', express.static(`${__dirname}/core`));
 
 server.get('/', (req, res) => {
-    res.append('Content-Type', 'text/html')
-    res.end(examples
-        .map((example, i) => `
+    res.append('Content-Type', 'text/html');
+    res.end(
+        examples
+            .map(
+                (example, i) => `
             <a href="examples/${i}">${example.library}: ${example.name}</a> 
-            | <a href="${example.page}">original</a>`)
-        .join('<br>'))
-})
+            | <a href="${example.page}">original</a>`
+            )
+            .join('<br>')
+    );
+});
 
 server.get('/examples/:key', (req, res) => {
     let key = req.params.key;
@@ -31,21 +35,24 @@ server.get('/examples/:key', (req, res) => {
 
     let first = Promise.resolve();
     if (!fs.existsSync(dir)) {
-        first = exec(`examples/download-example.sh ${examples[key].h5p}`)
+        first = exec(`examples/download-example.sh ${examples[key].h5p}`);
     }
 
-    const library_loader = (lib, maj, min) => require(`./contents/${name}/${lib}-${maj}.${min}/library.json`)
+    const libraryLoader = (lib, maj, min) =>
+        require(`./contents/${name}/${lib}-${maj}.${min}/library.json`);
 
     first
         .then(() => {
-            const h5p_object = require(`${dir}/h5p.json`);
-            const content_object = require(`${dir}/content/content.json`);
-            return new H5P(library_loader).render(name, content_object, h5p_object)
+            const h5pObject = require(`${dir}/h5p.json`);
+            const contentObject = require(`${dir}/content/content.json`);
+            return new H5P(libraryLoader).render(
+                name,
+                contentObject,
+                h5pObject
+            );
         })
-        .then(h5p_page =>
-            res.end(h5p_page))
-        .catch(error =>
-            res.status(500).end(error.message));
+        .then(h5p_page => res.end(h5p_page))
+        .catch(error => res.status(500).end(error.message));
 });
 
 let port = process.env.PORT || 8080;

--- a/package-lock.json
+++ b/package-lock.json
@@ -2283,6 +2283,12 @@
                 }
             }
         },
+        "eslint-plugin-jest": {
+            "version": "22.6.4",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-22.6.4.tgz",
+            "integrity": "sha512-36OqnZR/uMCDxXGmTsqU4RwllR0IiB/XF8GW3ODmhsjiITKuI0GpgultWFt193ipN3HARkaIcKowpE6HBvRHNg==",
+            "dev": true
+        },
         "eslint-restricted-globals": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/eslint-restricted-globals/-/eslint-restricted-globals-0.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
         "clean": "rm -rf build && rm -rf dist",
         "uninstall": "npm run clean && rm -rf node_modules && examples/uninstall.sh",
         "build": "",
-        "lint": "./node_modules/.bin/eslint ./src ./test ./examples",
+        "lint": "./node_modules/.bin/eslint ./src ./test",
         "test": "./node_modules/.bin/jest",
         "test:watch": "./node_modules/.bin/jest --watch"
     },
@@ -26,6 +26,7 @@
         "eslint-config-airbnb-base": "^13.1.0",
         "eslint-config-prettier": "^4.2.0",
         "eslint-plugin-import": "^2.17.2",
+        "eslint-plugin-jest": "^22.6.4",
         "express": "^4.17.0",
         "jest": "^24.7.1",
         "jsdom": "^15.1.0",

--- a/package.json
+++ b/package.json
@@ -12,9 +12,10 @@
         "clean": "rm -rf build && rm -rf dist",
         "uninstall": "npm run clean && rm -rf node_modules && examples/uninstall.sh",
         "build": "",
-        "lint": "./node_modules/.bin/eslint ./src ./test",
-        "test": "./node_modules/.bin/jest",
-        "test:watch": "./node_modules/.bin/jest --watch"
+        "ci": "npm run lint && npm run test",
+        "lint": "eslint ./src ./test",
+        "test": "jest",
+        "test:watch": "jest --watch"
     },
     "author": "Jan Philip Schellenberg",
     "dependencies": {},

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
         "clean": "rm -rf build && rm -rf dist",
         "uninstall": "npm run clean && rm -rf node_modules && examples/uninstall.sh",
         "build": "",
-        "lint": "./node_modules/.bin/eslint ./src",
+        "lint": "./node_modules/.bin/eslint ./src ./test ./examples",
         "test": "./node_modules/.bin/jest",
         "test:watch": "./node_modules/.bin/jest --watch"
     },

--- a/src/index.js
+++ b/src/index.js
@@ -86,7 +86,7 @@ class H5P {
             if (key in loaded) return;
             loaded[key] = true;
 
-            const lib = this.library_loader(
+            const lib = this.libraryLoader(
                 dependency.machineName,
                 dependency.majorVersion,
                 dependency.minorVersion

--- a/src/index.js
+++ b/src/index.js
@@ -2,8 +2,8 @@ const defaultRenderer = require('./renderers/default');
 const defaultTranslation = require('./translations/en.json');
 
 class H5P {
-    constructor(library_loader, baseUrl = '/h5p') {
-        this.library_loader = library_loader;
+    constructor(libraryLoader, baseUrl = '/h5p') {
+        this.libraryLoader = libraryLoader;
         this.renderer = defaultRenderer;
         this.translation = defaultTranslation;
 
@@ -11,61 +11,58 @@ class H5P {
         this.coreUrl = `${baseUrl}/core`;
     }
 
-    render(content_id, content_object, h5p_object) {
+    render(contentId, contentObject, h5pObject) {
         const model = {
-            content_id,
+            contentId,
             styles: this._coreStyles(),
             scripts: this._coreScripts(),
-            integration: this._integration(content_id, content_object, h5p_object),
+            integration: this._integration(contentId, contentObject, h5pObject)
         };
 
-        this._loadAssets(h5p_object.preloadedDependencies || [], model);
+        this._loadAssets(h5pObject.preloadedDependencies || [], model);
 
-        return Promise.resolve(this.renderer(model))
+        return Promise.resolve(this.renderer(model));
     }
 
     useRenderer(renderer) {
         this.renderer = renderer;
-        return this
+        return this;
     }
 
     setCoreUrl(coreUrl) {
         this.coreUrl = coreUrl;
-        return this
+        return this;
     }
 
-    _integration(content_id, content_object, h5p_object) {
+    _integration(contentId, contentObject, h5pObject) {
         // see https://h5p.org/creating-your-own-h5p-plugin
         return {
-            "url": this.baseUrl,
-            "postUserStatistics": false,
-            "saveFreq": false,
-            "l10n": {
-                "H5P": this.translation
+            url: this.baseUrl,
+            postUserStatistics: false,
+            saveFreq: false,
+            l10n: {
+                H5P: this.translation
             },
-            "contents": {
-                [`cid-${content_id}`]: {
-                    "library": this._mainLibraryString(h5p_object),
-                    "jsonContent": JSON.stringify(content_object),
-                    "fullScreen": false,
-                    "displayOptions": {
-                        "frame": false,
-                        "export": false,
-                        "embed": false,
-                        "copyright": false,
-                        "icon": false,
-                        "copy": false
+            contents: {
+                [`cid-${contentId}`]: {
+                    library: this._mainLibraryString(h5pObject),
+                    jsonContent: JSON.stringify(contentObject),
+                    fullScreen: false,
+                    displayOptions: {
+                        frame: false,
+                        export: false,
+                        embed: false,
+                        copyright: false,
+                        icon: false,
+                        copy: false
                     }
                 }
             }
-        }
+        };
     }
 
     _coreStyles() {
-        return [
-            'h5p.css'
-        ]
-            .map(file => `${this.coreUrl}/styles/${file}`)
+        return ['h5p.css'].map(file => `${this.coreUrl}/styles/${file}`);
     }
 
     _coreScripts() {
@@ -77,34 +74,46 @@ class H5P {
             'h5p-x-api.js',
             'h5p-content-type.js',
             'h5p-action-bar.js'
-        ]
-            .map(file => `${this.coreUrl}/js/${file}`)
+        ].map(file => `${this.coreUrl}/js/${file}`);
     }
 
     _loadAssets(dependencies, assets, loaded = {}) {
         dependencies.forEach(dependency => {
-            const key = `${dependency.machineName}-${dependency.majorVersion}.${dependency.minorVersion}`;
+            const key = `${dependency.machineName}-${dependency.majorVersion}.${
+                dependency.minorVersion
+            }`;
 
             if (key in loaded) return;
             loaded[key] = true;
 
-            const lib = this.library_loader(dependency.machineName, dependency.majorVersion, dependency.minorVersion);
+            const lib = this.library_loader(
+                dependency.machineName,
+                dependency.majorVersion,
+                dependency.minorVersion
+            );
 
             this._loadAssets(lib.preloadedDependencies || [], assets, loaded);
 
             const path = `${this.baseUrl}/libraries/${key}`;
-            (lib.preloadedCss || []).forEach(asset => assets.styles.push(`${path}/${asset.path}`));
-            (lib.preloadedJs || []).forEach(script => assets.scripts.push(`${path}/${script.path}`));
+            (lib.preloadedCss || []).forEach(asset =>
+                assets.styles.push(`${path}/${asset.path}`)
+            );
+            (lib.preloadedJs || []).forEach(script =>
+                assets.scripts.push(`${path}/${script.path}`)
+            );
         });
     }
 
-    _mainLibraryString(h5p_object) {
-        let lib = (h5p_object.preloadedDependencies || [])
-            .find(lib => lib.machineName == h5p_object.mainLibrary);
+    _mainLibraryString(h5pObject) {
+        const library = (h5pObject.preloadedDependencies || []).find(
+            lib => lib.machineName === h5pObject.mainLibrary
+        );
 
-        if (!lib) return undefined;
+        if (!library) return undefined;
 
-        return `${lib.machineName} ${lib.majorVersion}.${lib.minorVersion}`
+        return `${library.machineName} ${library.majorVersion}.${
+            library.minorVersion
+        }`;
     }
 }
 

--- a/src/renderers/default.js
+++ b/src/renderers/default.js
@@ -3,16 +3,18 @@ module.exports = model => `<!doctype html>
 <head>
     <meta charset="utf-8">
     
-    ${model.styles.map(style =>
-        `<link rel="stylesheet" href="${style}"/>`).join('\n    ')}
-    ${model.scripts.map(script =>
-        `<script src="${script}"></script>`).join('\n    ')}
+    ${model.styles
+        .map(style => `<link rel="stylesheet" href="${style}"/>`)
+        .join('\n    ')}
+    ${model.scripts
+        .map(script => `<script src="${script}"></script>`)
+        .join('\n    ')}
 
     <script>
         H5PIntegration = ${JSON.stringify(model.integration, null, 2)};
     </script>
 </head>
 <body>
-    <div class="h5p-content" data-content-id="${model.content_id}"></div>
+    <div class="h5p-content" data-content-id="${model.contentId}"></div>
 </body>
 </html>`;

--- a/test/load-dependencies.test.js
+++ b/test/load-dependencies.test.js
@@ -1,11 +1,10 @@
 const H5P = require('../src');
 
 describe('Loading dependencies', () => {
-
     it('resolves main dependencies', () => {
-        const content_id = 'foo';
-        const content_object = {};
-        const h5p_object = {
+        const contentId = 'foo';
+        const contentObject = {};
+        const h5pObject = {
             mainLibrary: 'Foo',
             preloadedDependencies: [
                 {
@@ -20,48 +19,39 @@ describe('Loading dependencies', () => {
                 }
             ]
         };
-        const library_loader = (name, maj, min) => ({
-            Foo42: {
-                "preloadedJs": [
-                    { "path": "foo1.js" },
-                    { "path": "foo2.js" }
-                ],
-                "preloadedCss": [
-                    { "path": "foo1.css" },
-                    { "path": "foo2.css" }
-                ]
-            },
-            Bar21: {
-                "preloadedJs": [
-                    { "path": "bar.js" },
-                ],
-                "preloadedCss": [
-                    { "path": "bar.css" }
-                ]
-            }
-        }[name + maj + min]);
+        const libraryLoader = (name, maj, min) =>
+            ({
+                Foo42: {
+                    preloadedJs: [{ path: 'foo1.js' }, { path: 'foo2.js' }],
+                    preloadedCss: [{ path: 'foo1.css' }, { path: 'foo2.css' }]
+                },
+                Bar21: {
+                    preloadedJs: [{ path: 'bar.js' }],
+                    preloadedCss: [{ path: 'bar.css' }]
+                }
+            }[name + maj + min]);
 
-        return new H5P(library_loader)
+        return new H5P(libraryLoader)
             .useRenderer(model => model)
-            .render(content_id, content_object, h5p_object)
+            .render(contentId, contentObject, h5pObject)
             .then(model => {
                 expect(model.styles.slice(1)).toEqual([
-                    "/h5p/libraries/Foo-4.2/foo1.css",
-                    "/h5p/libraries/Foo-4.2/foo2.css",
-                    "/h5p/libraries/Bar-2.1/bar.css"
-                ])
+                    '/h5p/libraries/Foo-4.2/foo1.css',
+                    '/h5p/libraries/Foo-4.2/foo2.css',
+                    '/h5p/libraries/Bar-2.1/bar.css'
+                ]);
                 expect(model.scripts.slice(7)).toEqual([
-                    "/h5p/libraries/Foo-4.2/foo1.js",
-                    "/h5p/libraries/Foo-4.2/foo2.js",
-                    "/h5p/libraries/Bar-2.1/bar.js"
-                ])
-            })
-    })
+                    '/h5p/libraries/Foo-4.2/foo1.js',
+                    '/h5p/libraries/Foo-4.2/foo2.js',
+                    '/h5p/libraries/Bar-2.1/bar.js'
+                ]);
+            });
+    });
 
     it('resolves deep dependencies', () => {
-        const content_id = 'foo';
-        const content_object = {};
-        const h5p_object = {
+        const contentId = 'foo';
+        const contentObject = {};
+        const h5pObject = {
             mainLibrary: 'Foo',
             preloadedDependencies: [
                 {
@@ -71,68 +61,57 @@ describe('Loading dependencies', () => {
                 }
             ]
         };
-        const library_loader = (name, maj, min) => ({
-            Foo42: {
-                "preloadedJs": [
-                    { "path": "foo.js" }
-                ],
-                "preloadedCss": [
-                    { "path": "foo.css" }
-                ],
-                "preloadedDependencies": [
-                  {
-                    "machineName": "Bar",
-                    "majorVersion": 2,
-                    "minorVersion": 1
-                  }
-                ]
-            },
-            Bar21: {
-                "preloadedJs": [
-                    { "path": "bar.js" },
-                ],
-                "preloadedCss": [
-                    { "path": "bar.css" }
-                ],
-                "preloadedDependencies": [
-                  {
-                    "machineName": "Baz",
-                    "majorVersion": 3,
-                    "minorVersion": 3
-                  }
-                ]
-            },
-            Baz33: {
-                "preloadedJs": [
-                    { "path": "baz.js" },
-                ],
-                "preloadedCss": [
-                    { "path": "baz.css" }
-                ]
-            }
-        }[name + maj + min]);
+        const libraryLoader = (name, maj, min) =>
+            ({
+                Foo42: {
+                    preloadedJs: [{ path: 'foo.js' }],
+                    preloadedCss: [{ path: 'foo.css' }],
+                    preloadedDependencies: [
+                        {
+                            machineName: 'Bar',
+                            majorVersion: 2,
+                            minorVersion: 1
+                        }
+                    ]
+                },
+                Bar21: {
+                    preloadedJs: [{ path: 'bar.js' }],
+                    preloadedCss: [{ path: 'bar.css' }],
+                    preloadedDependencies: [
+                        {
+                            machineName: 'Baz',
+                            majorVersion: 3,
+                            minorVersion: 3
+                        }
+                    ]
+                },
+                Baz33: {
+                    preloadedJs: [{ path: 'baz.js' }],
+                    preloadedCss: [{ path: 'baz.css' }]
+                }
+            }[name + maj + min]);
 
-        return new H5P(library_loader)
+        return new H5P(libraryLoader)
             .useRenderer(model => model)
-            .render(content_id, content_object, h5p_object)
+            .render(contentId, contentObject, h5pObject)
             .then(model => {
                 expect(model.styles.slice(1)).toEqual([
-                    "/h5p/libraries/Baz-3.3/baz.css",
-                    "/h5p/libraries/Bar-2.1/bar.css",
-                    "/h5p/libraries/Foo-4.2/foo.css"
-                ])
+                    '/h5p/libraries/Baz-3.3/baz.css',
+                    '/h5p/libraries/Bar-2.1/bar.css',
+                    '/h5p/libraries/Foo-4.2/foo.css'
+                ]);
                 expect(model.scripts.slice(7)).toEqual([
-                    "/h5p/libraries/Baz-3.3/baz.js",
-                    "/h5p/libraries/Bar-2.1/bar.js",
-                    "/h5p/libraries/Foo-4.2/foo.js"
-                ])
-            })
-    })
+                    '/h5p/libraries/Baz-3.3/baz.js',
+                    '/h5p/libraries/Bar-2.1/bar.js',
+                    '/h5p/libraries/Foo-4.2/foo.js'
+                ]);
+            });
+    });
 
     it('de-duplicates dependencies', () => {
-        const content_id = 'foo';
-        const content_object = {};
-        const h5p_object = {
+        const contentId = 'foo';
+        const contentObject = {};
+        const h5pObject = {
             mainLibrary: 'Foo',
             preloadedDependencies: [
                 {
@@ -142,66 +121,55 @@ describe('Loading dependencies', () => {
                 }
             ]
         };
-        const library_loader = (name, maj, min) => ({
-            Foo42: {
-                "preloadedJs": [
-                    { "path": "foo.js" }
-                ],
-                "preloadedCss": [
-                    { "path": "foo.css" }
-                ],
-                "preloadedDependencies": [
-                  {
-                    "machineName": "Bar",
-                    "majorVersion": 2,
-                    "minorVersion": 1
-                  },
-                  {
-                    "machineName": "Baz",
-                    "majorVersion": 3,
-                    "minorVersion": 3
-                  }
-                ]
-            },
-            Bar21: {
-                "preloadedJs": [
-                    { "path": "bar.js" },
-                ],
-                "preloadedCss": [
-                    { "path": "bar.css" }
-                ],
-                "preloadedDependencies": [
-                  {
-                    "machineName": "Baz",
-                    "majorVersion": 3,
-                    "minorVersion": 3
-                  }
-                ]
-            },
-            Baz33: {
-                "preloadedJs": [
-                    { "path": "baz.js" },
-                ],
-                "preloadedCss": [
-                    { "path": "baz.css" }
-                ]
-            }
-        }[name + maj + min]);
+        const libraryLoader = (name, maj, min) =>
+            ({
+                Foo42: {
+                    preloadedJs: [{ path: 'foo.js' }],
+                    preloadedCss: [{ path: 'foo.css' }],
+                    preloadedDependencies: [
+                        {
+                            machineName: 'Bar',
+                            majorVersion: 2,
+                            minorVersion: 1
+                        },
+                        {
+                            machineName: 'Baz',
+                            majorVersion: 3,
+                            minorVersion: 3
+                        }
+                    ]
+                },
+                Bar21: {
+                    preloadedJs: [{ path: 'bar.js' }],
+                    preloadedCss: [{ path: 'bar.css' }],
+                    preloadedDependencies: [
+                        {
+                            machineName: 'Baz',
+                            majorVersion: 3,
+                            minorVersion: 3
+                        }
+                    ]
+                },
+                Baz33: {
+                    preloadedJs: [{ path: 'baz.js' }],
+                    preloadedCss: [{ path: 'baz.css' }]
+                }
+            }[name + maj + min]);
 
-        return new H5P(library_loader)
+        return new H5P(libraryLoader)
             .useRenderer(model => model)
-            .render(content_id, content_object, h5p_object)
+            .render(contentId, contentObject, h5pObject)
             .then(model => {
                 expect(model.styles.slice(1)).toEqual([
-                    "/h5p/libraries/Baz-3.3/baz.css",
-                    "/h5p/libraries/Bar-2.1/bar.css",
-                    "/h5p/libraries/Foo-4.2/foo.css"
-                ])
+                    '/h5p/libraries/Baz-3.3/baz.css',
+                    '/h5p/libraries/Bar-2.1/bar.css',
+                    '/h5p/libraries/Foo-4.2/foo.css'
+                ]);
                 expect(model.scripts.slice(7)).toEqual([
-                    "/h5p/libraries/Baz-3.3/baz.js",
-                    "/h5p/libraries/Bar-2.1/bar.js",
-                    "/h5p/libraries/Foo-4.2/foo.js"
-                ])
-            })
-    })
-})
+                    '/h5p/libraries/Baz-3.3/baz.js',
+                    '/h5p/libraries/Bar-2.1/bar.js',
+                    '/h5p/libraries/Foo-4.2/foo.js'
+                ]);
+            });
+    });
+});

--- a/test/render-html-page.test.js
+++ b/test/render-html-page.test.js
@@ -1,16 +1,15 @@
 const H5P = require('../src');
 
 describe('Rendering the HTML page', () => {
-
     it('uses default renderer and integration values', () => {
-        const content_id = 'foo';
-        const content_object = {
+        const contentId = 'foo';
+        const contentObject = {
             my: 'content'
         };
-        const h5p_object = {};
+        const h5pObject = {};
 
         return new H5P()
-            .render(content_id, content_object, h5p_object)
+            .render(contentId, contentObject, h5pObject)
             .then(html => {
                 expect(html).toBe(
                     `<!doctype html>
@@ -84,14 +83,15 @@ describe('Rendering the HTML page', () => {
 <body>
     <div class="h5p-content" data-content-id="foo"></div>
 </body>
-</html>`)
-            })
-    })
+</html>`
+                );
+            });
+    });
 
     it('resolves the main library', () => {
-        const content_id = 'foo';
-        const content_object = {};
-        const h5p_object = {
+        const contentId = 'foo';
+        const contentObject = {};
+        const h5pObject = {
             mainLibrary: 'Foo',
             preloadedDependencies: [
                 {
@@ -107,9 +107,11 @@ describe('Rendering the HTML page', () => {
 
         return new H5P(() => ({}))
             .useRenderer(model => model)
-            .render(content_id, content_object, h5p_object)
+            .render(contentId, contentObject, h5pObject)
             .then(model => {
-                expect(model.integration.contents['cid-foo'].library).toBe('Foo 4.2')
-            })
-    })
-})
+                expect(model.integration.contents['cid-foo'].library).toBe(
+                    'Foo 4.2'
+                );
+            });
+    });
+});


### PR DESCRIPTION
Hey,

as discussed in #42 I changed all function and variable-names to camelCase.
To enforce this code-style I added the linter to travis-ci, so if anything does not comply to our code-style, the lint-test will fail and the PR is not mergeable.

Right now, dangeling underscores are not allowed by our code-style, but we used them in our class. Should we allow it or change the names of the member-functions?
What do you think?