### PR TITLE
Add getLibraryOverview (closes #7)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -53,6 +53,44 @@ class H5PEditor {
             });
     }
 
+    getLibraryOverview(libraries) {
+        return Promise.all(
+            libraries.map(libraryName => {
+                const {
+                    machineName,
+                    majorVersion,
+                    minorVersion
+                } = this._parseLibraryString(libraryName);
+                return this.storage
+                    .loadLibrary(machineName, majorVersion, minorVersion)
+                    .then(library => {
+                        return {
+                            uberName: `${library.machineName}-${
+                                library.majorVersion
+                            }.${library.minorVersion}`,
+                            name: library.machineName,
+                            majorVersion: library.majorVersion,
+                            minorVersion: library.minorVersion,
+                            tutorialUrl: '',
+                            title: library.title,
+                            runnable: library.runnable,
+                            restricted: false,
+                            metadataSettings: null
+                        };
+                    });
+            })
+        );
+    }
+
+    // eslint-disable-next-line class-methods-use-this
+    _parseLibraryString(libraryName) {
+        return {
+            machineName: libraryName.split(' ')[0],
+            majorVersion: libraryName.split(' ')[1].split('.')[0],
+            minorVersion: libraryName.split(' ')[1].split('.')[1]
+        };
+    }
+
     contentTypeCache() {
         return new Promise(resolve => {
             resolve(this.defaultContentTypeCache);

--- a/test/getLibraryOverview.test.js
+++ b/test/getLibraryOverview.test.js
@@ -1,0 +1,85 @@
+const H5PEditor = require('../src');
+
+describe('getLibraryOverview: response', () => {
+    it('includes the uberName', done => {
+        const h5pEditor = new H5PEditor({
+            loadLibrary: () =>
+                Promise.resolve({
+                    machineName: 'H5P.Image',
+                    majorVersion: '1',
+                    minorVersion: '1'
+                })
+        });
+
+        h5pEditor.getLibraryOverview(['H5P.Image 1.1']).then(libraries => {
+            expect(libraries[0].uberName).toBe('H5P.Image-1.1');
+            done();
+        });
+    });
+
+    it('includes the majorVersion', done => {
+        const h5pEditor = new H5PEditor({
+            loadLibrary: () =>
+                Promise.resolve({
+                    machineName: 'H5P.Image',
+                    majorVersion: '1',
+                    minorVersion: '1'
+                })
+        });
+
+        h5pEditor.getLibraryOverview(['H5P.Image 1.1']).then(libraries => {
+            expect(libraries[0].majorVersion).toBe('1');
+            done();
+        });
+    });
+
+    it('includes the minorVersion', done => {
+        const h5pEditor = new H5PEditor({
+            loadLibrary: () =>
+                Promise.resolve({
+                    machineName: 'H5P.Image',
+                    majorVersion: '1',
+                    minorVersion: '1'
+                })
+        });
+
+        h5pEditor.getLibraryOverview(['H5P.Image 1.1']).then(libraries => {
+            expect(libraries[0].minorVersion).toBe('1');
+            done();
+        });
+    });
+
+    it('includes the machineName as name', done => {
+        const h5pEditor = new H5PEditor({
+            loadLibrary: () =>
+                Promise.resolve({
+                    machineName: 'H5P.Image',
+                    majorVersion: '1',
+                    minorVersion: '1'
+                })
+        });
+
+        h5pEditor.getLibraryOverview(['H5P.Image 1.1']).then(libraries => {
+            expect(libraries[0].name).toBe('H5P.Image');
+            done();
+        });
+    });
+
+    it('resolves multiple libraries', done => {
+        const h5pEditor = new H5PEditor({
+            loadLibrary: (machineName, majorVersion, minorVersion) =>
+                Promise.resolve({
+                    machineName,
+                    majorVersion,
+                    minorVersion
+                })
+        });
+
+        h5pEditor
+            .getLibraryOverview(['H5P.Image 1.1', 'H5P.Video 1.5'])
+            .then(libraries => {
+                expect(libraries.length).toBe(2);
+                done();
+            });
+    });
+});

--- a/test/getLibraryOverview.test.js
+++ b/test/getLibraryOverview.test.js
@@ -1,85 +1,47 @@
 const H5PEditor = require('../src');
 
-describe('getLibraryOverview: response', () => {
-    it('includes the uberName', done => {
-        const h5pEditor = new H5PEditor({
-            loadLibrary: () =>
-                Promise.resolve({
-                    machineName: 'H5P.Image',
-                    majorVersion: '1',
-                    minorVersion: '1'
-                })
-        });
+describe('getting overview about multiple libraries', () => {
 
-        h5pEditor.getLibraryOverview(['H5P.Image 1.1']).then(libraries => {
-            expect(libraries[0].uberName).toBe('H5P.Image-1.1');
-            done();
-        });
-    });
+    it('returns basic information about single library', () => {
+        return new H5PEditor({
+            loadLibrary: (machineName, majorVersion, minorVersion) => Promise.resolve({
+                machineName,
+                majorVersion,
+                minorVersion,
+                title: 'the title',
+                runnable: 'the runnable',
+            })
+        })
+            .getLibraryOverview(['Foo.Bar 4.2'])
 
-    it('includes the majorVersion', done => {
-        const h5pEditor = new H5PEditor({
-            loadLibrary: () =>
-                Promise.resolve({
-                    machineName: 'H5P.Image',
-                    majorVersion: '1',
-                    minorVersion: '1'
-                })
-        });
+            .then(libraries =>
+                expect(libraries).toEqual([
+                    {
+                        uberName: 'Foo.Bar-4.2',
+                        name: 'Foo.Bar',
+                        majorVersion: '4',
+                        minorVersion: '2',
+                        tutorialUrl: '',
+                        title: 'the title',
+                        runnable: 'the runnable',
+                        restricted: false,
+                        metadataSettings: null
+                    }
+                ]))
+    })
 
-        h5pEditor.getLibraryOverview(['H5P.Image 1.1']).then(libraries => {
-            expect(libraries[0].majorVersion).toBe('1');
-            done();
-        });
-    });
-
-    it('includes the minorVersion', done => {
-        const h5pEditor = new H5PEditor({
-            loadLibrary: () =>
-                Promise.resolve({
-                    machineName: 'H5P.Image',
-                    majorVersion: '1',
-                    minorVersion: '1'
-                })
-        });
-
-        h5pEditor.getLibraryOverview(['H5P.Image 1.1']).then(libraries => {
-            expect(libraries[0].minorVersion).toBe('1');
-            done();
-        });
-    });
-
-    it('includes the machineName as name', done => {
-        const h5pEditor = new H5PEditor({
-            loadLibrary: () =>
-                Promise.resolve({
-                    machineName: 'H5P.Image',
-                    majorVersion: '1',
-                    minorVersion: '1'
-                })
-        });
-
-        h5pEditor.getLibraryOverview(['H5P.Image 1.1']).then(libraries => {
-            expect(libraries[0].name).toBe('H5P.Image');
-            done();
-        });
-    });
-
-    it('resolves multiple libraries', done => {
-        const h5pEditor = new H5PEditor({
+    it('return information about multiple libraries', () => {
+        return new H5PEditor({
             loadLibrary: (machineName, majorVersion, minorVersion) =>
-                Promise.resolve({
-                    machineName,
-                    majorVersion,
-                    minorVersion
-                })
-        });
-
-        h5pEditor
+                Promise.resolve({ machineName, majorVersion, minorVersion })
+        })
             .getLibraryOverview(['H5P.Image 1.1', 'H5P.Video 1.5'])
+
             .then(libraries => {
-                expect(libraries.length).toBe(2);
-                done();
+                expect(libraries.map(l => l.uberName)).toEqual([
+                    'H5P.Image-1.1',
+                    'H5P.Video-1.5'
+                ]);
             });
     });
 });


### PR DESCRIPTION
Hey,

this PR adds the getLibraryOverview function which is used by the editor to get information about multiple libraries via `POST /ajaxPath` with the library names as array in the body.