### PR TITLE
getLibraryData: resolve editorDependencies within javascript field

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3427,6 +3427,11 @@
             "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
             "dev": true
         },
+        "h5p-nodejs-library": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/h5p-nodejs-library/-/h5p-nodejs-library-0.2.1.tgz",
+            "integrity": "sha512-GjbUVCLcn3cYlGBZKgI+yiPvL5hcFXqL3W6q4tMPuXhyhzEc/N0bOhu79VFsvlYk+yGoRK75OlzGLHbKkYGTSw=="
+        },
         "handlebars": {
             "version": "4.1.2",
             "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.2.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3428,9 +3428,9 @@
             "dev": true
         },
         "h5p-nodejs-library": {
-            "version": "0.2.1",
-            "resolved": "https://registry.npmjs.org/h5p-nodejs-library/-/h5p-nodejs-library-0.2.1.tgz",
-            "integrity": "sha512-GjbUVCLcn3cYlGBZKgI+yiPvL5hcFXqL3W6q4tMPuXhyhzEc/N0bOhu79VFsvlYk+yGoRK75OlzGLHbKkYGTSw=="
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/h5p-nodejs-library/-/h5p-nodejs-library-0.3.0.tgz",
+            "integrity": "sha512-StJ57x6523Fg7OQxn8yHUOQst+emwE2ipZJU3HW/TiiSZQAkSI2TLTPIBd8+sqVM0vJaEf7GMTPV5IysObVrIQ=="
         },
         "handlebars": {
             "version": "4.1.2",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,9 @@
         "test:watch": "jest --watch"
     },
     "author": "Jan Philip Schellenberg",
-    "dependencies": {},
+    "dependencies": {
+        "h5p-nodejs-library": "^0.2.1"
+    },
     "devDependencies": {
         "@babel/core": "^7.4.4",
         "@babel/preset-env": "^7.4.4",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     },
     "author": "Jan Philip Schellenberg",
     "dependencies": {
-        "h5p-nodejs-library": "^0.2.1"
+        "h5p-nodejs-library": "^0.3.0"
     },
     "devDependencies": {
         "@babel/core": "^7.4.4",

--- a/src/index.js
+++ b/src/index.js
@@ -40,31 +40,32 @@ class H5PEditor {
         return this.storage
             .loadSemantics(machineName, majorVersion, minorVersion)
             .then(semantics => {
-                const library = this.storage.loadLibrary(
-                    machineName,
-                    majorVersion,
-                    minorVersion
-                );
-
-                const assets = {
-                    scripts: [],
-                    styles: []
-                };
-                this.h5p._loadAssets(library.editorDependencies, assets);
-                return Promise.resolve({
-                    name: machineName,
-                    version: {
-                        major: majorVersion,
-                        minor: minorVersion
-                    },
-                    semantics,
-                    language: null,
-                    defaultLanguage: null,
-                    javascript: assets.scripts,
-                    css: assets.styles,
-                    translations: [],
-                    languages: []
-                });
+                return this.storage
+                    .loadLibrary(machineName, majorVersion, minorVersion)
+                    .then(library => {
+                        const assets = {
+                            scripts: [],
+                            styles: []
+                        };
+                        return this.h5p
+                            ._loadAssets(library.editorDependencies, assets)
+                            .then(() => {
+                                return Promise.resolve({
+                                    name: machineName,
+                                    version: {
+                                        major: majorVersion,
+                                        minor: minorVersion
+                                    },
+                                    semantics,
+                                    language: null,
+                                    defaultLanguage: null,
+                                    javascript: assets.scripts,
+                                    css: assets.styles,
+                                    translations: [],
+                                    languages: []
+                                });
+                            });
+                    });
             });
     }
 

--- a/src/index.js
+++ b/src/index.js
@@ -40,32 +40,31 @@ class H5PEditor {
         return this.storage
             .loadSemantics(machineName, majorVersion, minorVersion)
             .then(semantics => {
-                return this.storage
-                    .loadLibrary(machineName, majorVersion, minorVersion)
-                    .then(library => {
-                        const assets = {
-                            scripts: [],
-                            styles: []
-                        };
-                        this.h5p._loadAssets(
-                            library.editorDependencies,
-                            assets
-                        );
-                        return Promise.resolve({
-                            name: machineName,
-                            version: {
-                                major: majorVersion,
-                                minor: minorVersion
-                            },
-                            semantics,
-                            language: null,
-                            defaultLanguage: null,
-                            javascript: assets.scripts,
-                            css: assets.styles,
-                            translations: [],
-                            languages: []
-                        });
-                    });
+                const library = this.storage.loadLibrary(
+                    machineName,
+                    majorVersion,
+                    minorVersion
+                );
+
+                const assets = {
+                    scripts: [],
+                    styles: []
+                };
+                this.h5p._loadAssets(library.editorDependencies, assets);
+                return Promise.resolve({
+                    name: machineName,
+                    version: {
+                        major: majorVersion,
+                        minor: minorVersion
+                    },
+                    semantics,
+                    language: null,
+                    defaultLanguage: null,
+                    javascript: assets.scripts,
+                    css: assets.styles,
+                    translations: [],
+                    languages: []
+                });
             });
     }
 

--- a/test/getLibraryData.test.js
+++ b/test/getLibraryData.test.js
@@ -4,10 +4,11 @@ describe('aggregating data from library folders for the editor', () => {
     it('returns empty data', () => {
         const h5pEditor = new H5PEditor({
             loadSemantics: () => Promise.resolve([]),
-            loadLibrary: () =>
-                Promise.resolve({
+            loadLibrary: () => {
+                return {
                     editorDependencies: []
-                })
+                };
+            }
         });
 
         return expect(h5pEditor.getLibraryData('Foo', 1, 2)).resolves.toEqual({
@@ -36,10 +37,11 @@ describe('aggregating data from library folders for the editor', () => {
                     arbitrary: 'content'
                 });
             },
-            loadLibrary: () =>
-                Promise.resolve({
+            loadLibrary: () => {
+                return {
                     editorDependencies: []
-                })
+                };
+            }
         };
 
         return new H5PEditor(storage)
@@ -60,15 +62,21 @@ describe('aggregating data from library folders for the editor', () => {
             loadLibrary: machineName => {
                 switch (machineName) {
                     case 'H5PEditor.Test':
-                        return Promise.resolve({
+                        return {
+                            machineName: 'H5PEditor.test',
+                            majorVersion: 1,
+                            minorVersion: 0,
                             preloadedJs: [
                                 {
-                                    path: '/path/to/test.js'
+                                    path: 'path/to/test.js'
                                 }
                             ]
-                        });
+                        };
                     default:
-                        return Promise.resolve({
+                        return {
+                            machineName: 'Foo',
+                            majorVersion: 1,
+                            minorVersion: 2,
                             editorDependencies: [
                                 {
                                     machineName: 'H5PEditor.Test',
@@ -76,7 +84,7 @@ describe('aggregating data from library folders for the editor', () => {
                                     minorVersion: 0
                                 }
                             ]
-                        });
+                        };
                 }
             }
         };
@@ -84,7 +92,9 @@ describe('aggregating data from library folders for the editor', () => {
         return new H5PEditor(storage)
             .getLibraryData('Foo', 1, 2)
             .then(libraryData => {
-                expect(libraryData.javascript).toEqual(['/path/to/test.js']);
+                expect(libraryData.javascript).toEqual([
+                    '/h5p/libraries/H5PEditor.Test-1.0/path/to/test.js'
+                ]);
             });
     });
 });

--- a/test/getLibraryData.test.js
+++ b/test/getLibraryData.test.js
@@ -5,9 +5,9 @@ describe('aggregating data from library folders for the editor', () => {
         const h5pEditor = new H5PEditor({
             loadSemantics: () => Promise.resolve([]),
             loadLibrary: () => {
-                return {
+                return Promise.resolve({
                     editorDependencies: []
-                };
+                });
             }
         });
 
@@ -38,9 +38,9 @@ describe('aggregating data from library folders for the editor', () => {
                 });
             },
             loadLibrary: () => {
-                return {
+                return Promise.resolve({
                     editorDependencies: []
-                };
+                });
             }
         };
 
@@ -62,7 +62,7 @@ describe('aggregating data from library folders for the editor', () => {
             loadLibrary: machineName => {
                 switch (machineName) {
                     case 'H5PEditor.Test':
-                        return {
+                        return Promise.resolve({
                             machineName: 'H5PEditor.test',
                             majorVersion: 1,
                             minorVersion: 0,
@@ -71,9 +71,9 @@ describe('aggregating data from library folders for the editor', () => {
                                     path: 'path/to/test.js'
                                 }
                             ]
-                        };
+                        });
                     default:
-                        return {
+                        return Promise.resolve({
                             machineName: 'Foo',
                             majorVersion: 1,
                             minorVersion: 2,
@@ -84,7 +84,7 @@ describe('aggregating data from library folders for the editor', () => {
                                     minorVersion: 0
                                 }
                             ]
-                        };
+                        });
                 }
             }
         };


### PR DESCRIPTION
Hey,

I noticed, that the getLibraryData method needs to resolve the editor-dependencies, which are found in a `library.json` under the `editorDependencies`-field and attach them under the `javascript`-field.

At the moment the tests fail and I can not figure out why.
@rtens do you see my mistake? 