### PR TITLE
CI: Run tests on travis-ci

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
         "clean": "rm -rf build && rm -rf dist",
         "uninstall": "npm run clean && rm -rf node_modules",
         "build": "",
-        "ci": "npm run lint",
+        "ci": "npm run lint && npm run test",
         "lint": "eslint ./src",
         "test": "jest",
         "test:watch": "jest --watch"


### PR DESCRIPTION
Hey,

I noticed that travis runs only the linter. This PR adds the `npm run test` command to our CI-script and runs all tests on travis.

