### PR TITLE
CI: Run npm install

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
         "clean": "rm -rf build && rm -rf dist",
         "uninstall": "npm run clean && rm -rf node_modules",
         "build": "",
-        "ci": "npm run lint && npm run test",
+        "ci": "npm run lint && npm run test && npm install",
         "lint": "eslint ./src",
         "test": "jest",
         "test:watch": "jest --watch"


### PR DESCRIPTION
Hey,

does it make sense to run `npm install` in our ci-script on travis-ci to catch install-errors?