### PR TITLE
Fix invalid uberName in getLibraryOverview (fixes #28)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -108,7 +108,7 @@ class H5PEditor {
                     .loadLibrary(machineName, majorVersion, minorVersion)
                     .then(library => {
                         return {
-                            uberName: `${library.machineName}-${
+                            uberName: `${library.machineName} ${
                                 library.majorVersion
                             }.${library.minorVersion}`,
                             name: library.machineName,

--- a/test/getLibraryOverview.test.js
+++ b/test/getLibraryOverview.test.js
@@ -1,23 +1,23 @@
 const H5PEditor = require('../src');
 
 describe('getting overview about multiple libraries', () => {
-
     it('returns basic information about single library', () => {
         return new H5PEditor({
-            loadLibrary: (machineName, majorVersion, minorVersion) => Promise.resolve({
-                machineName,
-                majorVersion,
-                minorVersion,
-                title: 'the title',
-                runnable: 'the runnable',
-            })
+            loadLibrary: (machineName, majorVersion, minorVersion) =>
+                Promise.resolve({
+                    machineName,
+                    majorVersion,
+                    minorVersion,
+                    title: 'the title',
+                    runnable: 'the runnable'
+                })
         })
             .getLibraryOverview(['Foo.Bar 4.2'])
 
             .then(libraries =>
                 expect(libraries).toEqual([
                     {
-                        uberName: 'Foo.Bar-4.2',
+                        uberName: 'Foo.Bar 4.2',
                         name: 'Foo.Bar',
                         majorVersion: '4',
                         minorVersion: '2',
@@ -27,8 +27,9 @@ describe('getting overview about multiple libraries', () => {
                         restricted: false,
                         metadataSettings: null
                     }
-                ]))
-    })
+                ])
+            );
+    });
 
     it('return information about multiple libraries', () => {
         return new H5PEditor({
@@ -39,8 +40,8 @@ describe('getting overview about multiple libraries', () => {
 
             .then(libraries => {
                 expect(libraries.map(l => l.uberName)).toEqual([
-                    'H5P.Image-1.1',
-                    'H5P.Video-1.5'
+                    'H5P.Image 1.1',
+                    'H5P.Video 1.5'
                 ]);
             });
     });


### PR DESCRIPTION
Hey,

this PR fixes the invalid uberName in the getLibraryOverview-function. 
The uberName needs a space between the name and version, not a dash.