### PR TITLE
Fix error with missing editorDependencies

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -71,7 +71,10 @@ class H5PEditor {
                             styles: []
                         };
                         return this.h5p
-                            ._loadAssets(library.editorDependencies, assets)
+                            ._loadAssets(
+                                library.editorDependencies || [],
+                                assets
+                            )
                             .then(() => {
                                 return Promise.resolve({
                                     name: machineName,


### PR DESCRIPTION
Hey,

Libraries like `H5P.Image` do not have editorDependencies. When `undefined` is passed to the h5p._loadAssets-function it crashes. So we pass an empty array instead.