### PR TITLE
Make URLs configurable (closes #49 and closes #50)

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,14 @@ const libraryLoader = (machine_name: string, major_version: number, minor_versio
     return new Promise(resolve => { resolve(require(`/the_path_to_your_libraries/${machine_name}-${major_version}.${minor_version}/library.json`); }))
 };
 
-const H5P = new h5p(libraryLoader);
+const urls = {
+    baseUrl: '/h5p', // your base URL - used in the integration object
+    libraryUrl: `/h5p/libraries`, // URL where your libraries can be found
+    stylesUrl: `/h5p/core/styles`, // URL where the core styles can be found
+    scriptUrl: `/h5p/core/js` // URL where the core scripts can be found
+};
+
+const H5P = new h5p(libraryLoader, urls);
 
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "h5p-nodejs-library",
-    "version": "v0.2.1",
+    "version": "v0.3.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -2837,8 +2837,7 @@
                 "ansi-regex": {
                     "version": "2.1.1",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 },
                 "aproba": {
                     "version": "1.2.0",
@@ -2859,14 +2858,12 @@
                 "balanced-match": {
                     "version": "1.0.0",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 },
                 "brace-expansion": {
                     "version": "1.1.11",
                     "bundled": true,
                     "dev": true,
-                    "optional": true,
                     "requires": {
                         "balanced-match": "^1.0.0",
                         "concat-map": "0.0.1"
@@ -2881,20 +2878,17 @@
                 "code-point-at": {
                     "version": "1.1.0",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 },
                 "concat-map": {
                     "version": "0.0.1",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 },
                 "console-control-strings": {
                     "version": "1.1.0",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 },
                 "core-util-is": {
                     "version": "1.0.2",
@@ -3011,8 +3005,7 @@
                 "inherits": {
                     "version": "2.0.3",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 },
                 "ini": {
                     "version": "1.3.5",
@@ -3024,7 +3017,6 @@
                     "version": "1.0.0",
                     "bundled": true,
                     "dev": true,
-                    "optional": true,
                     "requires": {
                         "number-is-nan": "^1.0.0"
                     }
@@ -3039,7 +3031,6 @@
                     "version": "3.0.4",
                     "bundled": true,
                     "dev": true,
-                    "optional": true,
                     "requires": {
                         "brace-expansion": "^1.1.7"
                     }
@@ -3047,14 +3038,12 @@
                 "minimist": {
                     "version": "0.0.8",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 },
                 "minipass": {
                     "version": "2.3.5",
                     "bundled": true,
                     "dev": true,
-                    "optional": true,
                     "requires": {
                         "safe-buffer": "^5.1.2",
                         "yallist": "^3.0.0"
@@ -3073,7 +3062,6 @@
                     "version": "0.5.1",
                     "bundled": true,
                     "dev": true,
-                    "optional": true,
                     "requires": {
                         "minimist": "0.0.8"
                     }
@@ -3154,8 +3142,7 @@
                 "number-is-nan": {
                     "version": "1.0.1",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 },
                 "object-assign": {
                     "version": "4.1.1",
@@ -3167,7 +3154,6 @@
                     "version": "1.4.0",
                     "bundled": true,
                     "dev": true,
-                    "optional": true,
                     "requires": {
                         "wrappy": "1"
                     }
@@ -3253,8 +3239,7 @@
                 "safe-buffer": {
                     "version": "5.1.2",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 },
                 "safer-buffer": {
                     "version": "2.1.2",
@@ -3290,7 +3275,6 @@
                     "version": "1.0.2",
                     "bundled": true,
                     "dev": true,
-                    "optional": true,
                     "requires": {
                         "code-point-at": "^1.0.0",
                         "is-fullwidth-code-point": "^1.0.0",
@@ -3310,7 +3294,6 @@
                     "version": "3.0.1",
                     "bundled": true,
                     "dev": true,
-                    "optional": true,
                     "requires": {
                         "ansi-regex": "^2.0.0"
                     }
@@ -3354,14 +3337,12 @@
                 "wrappy": {
                     "version": "1.0.2",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 },
                 "yallist": {
                     "version": "3.0.3",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 }
             }
         },
@@ -4902,7 +4883,7 @@
         },
         "minimist": {
             "version": "0.0.8",
-            "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
             "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
             "dev": true
         },
@@ -4929,7 +4910,7 @@
         },
         "mkdirp": {
             "version": "0.5.1",
-            "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
             "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
             "dev": true,
             "requires": {
@@ -5241,7 +5222,7 @@
         },
         "os-tmpdir": {
             "version": "1.0.2",
-            "resolved": "http://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+            "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
             "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
             "dev": true
         },
@@ -5346,7 +5327,7 @@
         },
         "path-is-absolute": {
             "version": "1.0.1",
-            "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
             "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
             "dev": true
         },

--- a/src/index.js
+++ b/src/index.js
@@ -2,13 +2,25 @@ const defaultRenderer = require('./renderers/default');
 const defaultTranslation = require('./translations/en.json');
 
 class H5P {
-    constructor(libraryLoader, baseUrl = '/h5p') {
+    constructor(libraryLoader, urls) {
         this.libraryLoader = libraryLoader;
         this.renderer = defaultRenderer;
         this.translation = defaultTranslation;
 
-        this.baseUrl = baseUrl;
-        this.coreUrl = `${baseUrl}/core`;
+        this.urls = Object.assign(
+            {
+                baseUrl: '/h5p',
+                libraryUrl: `/h5p/libraries`,
+                stylesUrl: `/h5p/core/styles`,
+                scriptUrl: `/h5p/core/js`
+            },
+            urls
+        );
+
+        this.baseUrl = this.urls.baseUrl;
+        this.libraryUrl = this.urls.libraryUrl;
+        this.stylesUrl = this.urls.stylesUrl;
+        this.scriptUrl = this.urls.scriptUrl;
     }
 
     render(contentId, contentObject, h5pObject) {
@@ -27,11 +39,6 @@ class H5P {
 
     useRenderer(renderer) {
         this.renderer = renderer;
-        return this;
-    }
-
-    setCoreUrl(coreUrl) {
-        this.coreUrl = coreUrl;
         return this;
     }
 
@@ -63,7 +70,7 @@ class H5P {
     }
 
     _coreStyles() {
-        return ['h5p.css'].map(file => `${this.coreUrl}/styles/${file}`);
+        return ['h5p.css'].map(file => `${this.stylesUrl}/${file}`);
     }
 
     _coreScripts() {
@@ -75,7 +82,7 @@ class H5P {
             'h5p-x-api.js',
             'h5p-content-type.js',
             'h5p-action-bar.js'
-        ].map(file => `${this.coreUrl}/js/${file}`);
+        ].map(file => `${this.scriptUrl}/${file}`);
     }
 
     _loadAssets(dependencies, assets, loaded = {}) {
@@ -96,7 +103,7 @@ class H5P {
                         assets,
                         loaded
                     ).then(() => {
-                        const path = `${this.baseUrl}/libraries/${key}`;
+                        const path = `${this.libraryUrl}/${key}`;
                         (lib.preloadedCss || []).forEach(asset =>
                             assets.styles.push(`${path}/${asset.path}`)
                         );


### PR DESCRIPTION
Hey,
Instead of a string to configure the baseUrl, the constructor now takes an object as second argument. This object contains four different configurable URLs: 
- baseUrl (used in the Integration-object)
- libraryUrl (where the libraries are)
- stylesUrl (core styles)
- scriptUrl (core scripts)
The coreUrl has been deprecated, because it was only used to build the stylesUrl and scriptsUrl and is now replaced by the stylesUrl and scriptsUrl.

See [readme](https://github.com/Lumieducation/H5P-Nodejs-library/pull/51/commits/6402ba439de5c7f794a95dd33b8de9a01fc0537e?short_path=04c6e90#diff-04c6e90faac2675aa89e2176d2eec7d8)