### PR TITLE
Add customisable integration, content and customScripts to interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,13 @@
 [![Build Status](https://travis-ci.org/Lumieducation/H5P-Nodejs-library.svg?branch=next)](https://travis-ci.org/Lumieducation/H5P-Nodejs-library)
 
 The H5P-Nodejs-library is a port of the [H5P-PHP-library](https://github.com/h5p/h5p-php-library) for Nodejs.
-Please note that this project is in a very early and experimental stage. If you have questions or want to contribute, feel free to open issues or pull requests.
+Please note that this project is in an experimental stage. If you have questions or want to contribute, feel free to open issues or pull requests.
 
 This package provides a framework-agnostic function that returns a promise, which resolves to a string. The string is the equivalent to what the H5P-PHP-library would generate and can be integrated via iframe. You will also have to serve the H5P-Core-files.
 
-## How to use
+## Quickstart
+
+This will show you the very basics on how to use this library. For more detailed information and integration-options see the interface-section below.
 
 ### 1. Provide H5P-Core files and libraries
 
@@ -47,14 +49,7 @@ const libraryLoader = (
     return require(`/the_path_to_your_libraries/${machineName}-${majorVersion}.${minorVersion}/library.json`);
 };
 
-const urls = {
-    baseUrl: '/h5p', // your base URL - used in the integration object
-    libraryUrl: `/h5p/libraries`, // URL where your libraries can be found
-    stylesUrl: `/h5p/core/styles`, // URL where the core styles can be found
-    scriptUrl: `/h5p/core/js` // URL where the core scripts can be found
-};
-
-const h5p = new H5P(libraryLoader, urls);
+const h5p = new H5P(libraryLoader);
 ```
 
 or see the [express-example](https://github.com/Lumieducation/H5P-Nodejs-library/blob/next/examples/server.js#L37)
@@ -78,6 +73,70 @@ h5p.render('test', contentObject, h5pObject).then(h5pPage =>
 ### Adapters
 
 We will provide adapters for express and meteor in the future. If you would like to see another adapter, please make a issue.
+
+## Interface
+
+```ts
+interface H5P(
+    libraryLoader: (machineName: string, majorVersion: number, minorVersion: number) => LibraryJSON,
+    urls?: {
+        baseUrL: string;
+        libraryUrl: string;
+        stylesUrl: string;
+        scriptUrl: string;
+    },
+    integration?: object,
+    content?: object,
+    customScripts?: string
+})
+```
+
+### libraryLoader
+
+A [H5P-Library](https://h5p.org/library-definition) is a folder that contains a `library.json` and the corresponding js/css files. H5P-Libraries can usualy be found in the root folder of a .h5p-file.
+The library loader is a function that loads the `library.json` of a specific H5P-library. The easiest way would be a function that uses nodejs-require for loading the library.json within a H5P-Library.
+The library-loader takes three arguments:
+
+1. machineName: string - the folder name in which the library can be found
+2. majorVersion: number
+3. minorVersion: number
+
+For example:
+
+```ts
+const libraryLoader = (
+    machineName: string,
+    majorVersion: number,
+    minorVersion: number
+) => {
+    return require(`/the_path_to_your_libraries/${machineName}-${majorVersion}.${minorVersion}/library.json`);
+};
+```
+
+### URLs (optional)
+
+The URLs-object can be used to configure the location of your libraries, scripts and styles.
+
+```ts
+const urls = {
+    baseUrl: '/h5p', // your base URL - used in the integration object
+    libraryUrl: `/h5p/libraries`, // URL where your libraries can be found
+    stylesUrl: `/h5p/core/styles`, // URL where the core styles can be found
+    scriptUrl: `/h5p/core/js` // URL where the core scripts can be found
+};
+```
+
+### Integration (optional)
+
+An object that is used as the `H5PIntegration`-object. (See [https://h5p.org/creating-your-own-h5p-plugin](https://h5p.org/creating-your-own-h5p-plugin) for more information.) It is merged with a [default integration object](https://github.com/Lumieducation/H5P-Nodejs-library/blob/next/src/index.js#L51) via `Object.assign()`.
+
+### Content (optional)
+
+An object that is used as the `H5PIntegration.contents['cid-contentId']`-object (See [https://h5p.org/creating-your-own-h5p-plugin](https://h5p.org/creating-your-own-h5p-plugin) for more information.) It is merged with a [default integration object](https://github.com/Lumieducation/H5P-Nodejs-library/blob/next/src/index.js#L60) via `Object.assign()`.
+
+### customScripts (optional)
+
+customScripts can be inserted as a string and are injected behind the `H5PIntegration`-definition-script in the [template](https://github.com/Lumieducation/H5P-Nodejs-library/blob/next/src/renderers/default.js#L15). These scripts can be used to furhter load information.
 
 ## Development & Testing
 

--- a/src/index.js
+++ b/src/index.js
@@ -2,10 +2,14 @@ const defaultRenderer = require('./renderers/default');
 const defaultTranslation = require('./translations/en.json');
 
 class H5P {
-    constructor(libraryLoader, urls) {
+    constructor(libraryLoader, urls, integration, content, customScripts = '') {
         this.libraryLoader = libraryLoader;
         this.renderer = defaultRenderer;
         this.translation = defaultTranslation;
+
+        this.integration = integration;
+        this.content = content;
+        this.customScripts = customScripts;
 
         this.urls = Object.assign(
             {
@@ -28,7 +32,8 @@ class H5P {
             contentId,
             styles: this._coreStyles(),
             scripts: this._coreScripts(),
-            integration: this._integration(contentId, contentObject, h5pObject)
+            integration: this._integration(contentId, contentObject, h5pObject),
+            customScripts: this.customScripts
         };
 
         this._loadAssets(h5pObject.preloadedDependencies || [], model);
@@ -43,29 +48,35 @@ class H5P {
 
     _integration(contentId, contentObject, h5pObject) {
         // see https://h5p.org/creating-your-own-h5p-plugin
-        return {
-            url: this.baseUrl,
-            postUserStatistics: false,
-            saveFreq: false,
-            l10n: {
-                H5P: this.translation
-            },
-            contents: {
-                [`cid-${contentId}`]: {
-                    library: this._mainLibraryString(h5pObject),
-                    jsonContent: JSON.stringify(contentObject),
-                    fullScreen: false,
-                    displayOptions: {
-                        frame: false,
-                        export: false,
-                        embed: false,
-                        copyright: false,
-                        icon: false,
-                        copy: false
-                    }
+        return Object.assign(
+            {
+                url: this.baseUrl,
+                postUserStatistics: false,
+                saveFreq: false,
+                l10n: {
+                    H5P: this.translation
+                },
+                contents: {
+                    [`cid-${contentId}`]: Object.assign(
+                        {
+                            library: this._mainLibraryString(h5pObject),
+                            jsonContent: JSON.stringify(contentObject),
+                            fullScreen: false,
+                            displayOptions: {
+                                frame: false,
+                                export: false,
+                                embed: false,
+                                copyright: false,
+                                icon: false,
+                                copy: false
+                            }
+                        },
+                        this.content
+                    )
                 }
-            }
-        };
+            },
+            this.integration
+        );
     }
 
     _coreStyles() {

--- a/src/renderers/default.js
+++ b/src/renderers/default.js
@@ -12,7 +12,7 @@ module.exports = model => `<!doctype html>
 
     <script>
         H5PIntegration = ${JSON.stringify(model.integration, null, 2)};
-    </script>
+    </script>${model.customScripts}
 </head>
 <body>
     <div class="h5p-content" data-content-id="${model.contentId}"></div>

--- a/test/render-html-page.test.js
+++ b/test/render-html-page.test.js
@@ -116,4 +116,161 @@ describe('Rendering the HTML page', () => {
                 );
             });
     });
+
+    it('includes custom scripts', () => {
+        const contentId = 'foo';
+        const contentObject = {};
+        const h5pObject = {};
+
+        return new H5P(
+            () => {
+                return {};
+            },
+            {},
+            {},
+            {},
+            '<script src="/test" />'
+        )
+            .useRenderer(model => model)
+            .render(contentId, contentObject, h5pObject)
+            .then(model => {
+                expect(model.customScripts).toBe('<script src="/test" />');
+            });
+    });
+
+    it('includes custom integration', () => {
+        const contentId = 'foo';
+        const contentObject = {};
+        const h5pObject = {};
+
+        return new H5P(
+            () => {
+                return {};
+            },
+            {},
+            { integration: 'test' }
+        )
+            .useRenderer(model => model)
+            .render(contentId, contentObject, h5pObject)
+            .then(model => {
+                expect(model.integration.integration).toBe('test');
+            });
+    });
+
+    it('includes custom content', () => {
+        const contentId = 'foo';
+        const contentObject = {};
+        const h5pObject = {};
+
+        return new H5P(
+            () => {
+                return {};
+            },
+            {},
+            {},
+            { test: 'test' }
+        )
+            .useRenderer(model => model)
+            .render(contentId, contentObject, h5pObject)
+            .then(model => {
+                expect(model.integration.contents['cid-foo'].test).toBe('test');
+            });
+    });
+
+    it('includes custom scripts in the generated html', () => {
+        const contentId = 'foo';
+        const contentObject = {
+            my: 'content'
+        };
+        const h5pObject = {};
+
+        return new H5P(
+            () => {
+                return {};
+            },
+            {},
+            {},
+            {},
+            '<script src="/test" />'
+        )
+            .render(contentId, contentObject, h5pObject)
+            .then(html => {
+                expect(html).toBe(
+                    `<!doctype html>
+<html class="h5p-iframe">
+<head>
+    <meta charset="utf-8">
+    
+    <link rel="stylesheet" href="/h5p/core/styles/h5p.css"/>
+    <link rel="stylesheet" href="/h5p/core/styles/h5p-confirmation-dialog.css"/>
+    <script src="/h5p/core/js/jquery.js"></script>
+    <script src="/h5p/core/js/h5p.js"></script>
+    <script src="/h5p/core/js/h5p-event-dispatcher.js"></script>
+    <script src="/h5p/core/js/h5p-x-api-event.js"></script>
+    <script src="/h5p/core/js/h5p-x-api.js"></script>
+    <script src="/h5p/core/js/h5p-content-type.js"></script>
+    <script src="/h5p/core/js/h5p-confirmation-dialog.js"></script>
+    <script src="/h5p/core/js/h5p-action-bar.js"></script>
+
+    <script>
+        H5PIntegration = {
+  "url": "/h5p",
+  "postUserStatistics": false,
+  "saveFreq": false,
+  "l10n": {
+    "H5P": {
+      "fullscreen": "Fullscreen",
+      "disableFullscreen": "Disable fullscreen",
+      "download": "Download",
+      "copyrights": "Rights of use",
+      "embed": "Embed",
+      "size": "Size",
+      "showAdvanced": "Show advanced",
+      "hideAdvanced": "Hide advanced",
+      "advancedHelp": "Include this script on your website if you want dynamic sizing of the embedded content:",
+      "copyrightInformation": "Rights of use",
+      "close": "Close",
+      "title": "Title",
+      "author": "Author",
+      "year": "Year",
+      "source": "Source",
+      "license": "License",
+      "thumbnail": "Thumbnail",
+      "noCopyrights": "No copyright information available for this content.",
+      "downloadDescription": "Download this content as a H5P file.",
+      "copyrightsDescription": "View copyright information for this content.",
+      "embedDescription": "View the embed code for this content.",
+      "h5pDescription": "Visit H5P.org to check out more cool content.",
+      "contentChanged": "This content has changed since you last used it.",
+      "startingOver": "You'll be starting over.",
+      "by": "by",
+      "showMore": "Show more",
+      "showLess": "Show less",
+      "subLevel": "Sublevel"
+    }
+  },
+  "contents": {
+    "cid-foo": {
+      "jsonContent": "{\\"my\\":\\"content\\"}",
+      "fullScreen": false,
+      "displayOptions": {
+        "frame": false,
+        "export": false,
+        "embed": false,
+        "copyright": false,
+        "icon": false,
+        "copy": false
+      }
+    }
+  }
+};
+    </script><script src="/test" />
+</head>
+<body>
+    <div class="h5p-content" data-content-id="foo"></div>
+</body>
+</html>`
+                );
+            });
+    });
 });


### PR DESCRIPTION
Hey,

this PR further updates the interface to include customisable integration and content-objects as well as customScripts.

```ts
interface H5P(
    libraryLoader: (machineName: string, majorVersion: number, minorVersion: number) => LibraryJSON,
    urls?: {
        baseUrL: string;
        libraryUrl: string;
        stylesUrl: string;
        scriptUrl: string;
    },
    integration?: object,
    content?: object,
    customScripts?: string
})
```

### Integration (optional)

An object that is used as the `H5PIntegration`-object. (See [https://h5p.org/creating-your-own-h5p-plugin](https://h5p.org/creating-your-own-h5p-plugin) for more information.) It is merged with a [default integration object](https://github.com/Lumieducation/H5P-Nodejs-library/blob/next/src/index.js#L51) via `Object.assign()`.

### Content (optional)

An object that is used as the `H5PIntegration.contents['cid-contentId']`-object (See [https://h5p.org/creating-your-own-h5p-plugin](https://h5p.org/creating-your-own-h5p-plugin) for more information.) It is merged with a [default integration object](https://github.com/Lumieducation/H5P-Nodejs-library/blob/next/src/index.js#L60) via `Object.assign()`.

### customScripts (optional)

customScripts can be inserted as a string and are injected behind the `H5PIntegration`-definition-script in the [template](https://github.com/Lumieducation/H5P-Nodejs-library/blob/next/src/renderers/default.js#L15). These scripts can be used to furhter load information.