### PR TITLE
Add async library loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,16 @@ const libraryLoader = (
 const h5p = new H5P(libraryLoader);
 ```
 
+You can also load the library asynchronously by returning a promise from libraryLoader. For example:
+
+```ts
+const libraryLoader = (
+    machineName: string,
+    majorVersion: number,
+    minorVersion: number
+) => request(`https://mysite.com/h5p/${machineName}-${majorVersion}.${minorVersion}/library.json`)); // request returns a promise
+```
+
 or see the [express-example](https://github.com/Lumieducation/H5P-Nodejs-library/blob/next/examples/server.js#L37)
 
 #### 2.2 Provide the H5P- and Content-Object and use the renderer

--- a/src/index.js
+++ b/src/index.js
@@ -36,9 +36,10 @@ class H5P {
             customScripts: this.customScripts
         };
 
-        this._loadAssets(h5pObject.preloadedDependencies || [], model);
-
-        return Promise.resolve(this.renderer(model));
+        return this._loadAssets(
+            h5pObject.preloadedDependencies || [],
+            model
+        ).then(() => this.renderer(model));
     }
 
     useRenderer(renderer) {
@@ -99,32 +100,34 @@ class H5P {
     }
 
     _loadAssets(dependencies, assets, loaded = {}) {
-        dependencies.forEach(dependency => {
-            const name = dependency.machineName;
-            const majVer = dependency.majorVersion;
-            const minVer = dependency.minorVersion;
+        return Promise.all(
+            dependencies.map(dependency => {
+                const name = dependency.machineName;
+                const majVer = dependency.majorVersion;
+                const minVer = dependency.minorVersion;
 
-            const key = `${name}-${majVer}.${minVer}`;
+                const key = `${name}-${majVer}.${minVer}`;
 
-            if (key in loaded) return;
-            loaded[key] = true;
+                if (key in loaded) return Promise.resolve();
+                loaded[key] = true;
 
-            const lib = this.libraryLoader(
-                dependency.machineName,
-                dependency.majorVersion,
-                dependency.minorVersion
-            );
-
-            this._loadAssets(lib.preloadedDependencies || [], assets, loaded);
-
-            const path = `${this.libraryUrl}/${key}`;
-            (lib.preloadedCss || []).forEach(asset =>
-                assets.styles.push(`${path}/${asset.path}`)
-            );
-            (lib.preloadedJs || []).forEach(script =>
-                assets.scripts.push(`${path}/${script.path}`)
-            );
-        });
+                return this._loadLibrary(name, majVer, minVer).then(lib =>
+                    this._loadAssets(
+                        lib.preloadedDependencies || [],
+                        assets,
+                        loaded
+                    ).then(() => {
+                        const path = `${this.libraryUrl}/${key}`;
+                        (lib.preloadedCss || []).forEach(asset =>
+                            assets.styles.push(`${path}/${asset.path}`)
+                        );
+                        (lib.preloadedJs || []).forEach(script =>
+                            assets.scripts.push(`${path}/${script.path}`)
+                        );
+                    })
+                );
+            })
+        );
     }
 
     _mainLibraryString(h5pObject) {
@@ -139,6 +142,12 @@ class H5P {
         const minVer = library.minorVersion;
 
         return `${name} ${majVer}.${minVer}`;
+    }
+
+    _loadLibrary(machineName, majorVersion, minorVersion) {
+        return Promise.resolve(
+            this.libraryLoader(machineName, majorVersion, minorVersion)
+        );
     }
 }
 

--- a/test/content.ci.js
+++ b/test/content.ci.js
@@ -41,9 +41,7 @@ server.listen(8080, () => {
                             browser.newPage().then(page => {
                                 page.on('pageerror', msg => {
                                     console.log(
-                                        `${example.library} (${
-                                            example.page
-                                        }): ERROR`,
+                                        `${example.library} (${example.page}): ERROR`,
                                         example,
                                         msg
                                     );
@@ -59,9 +57,7 @@ server.listen(8080, () => {
                                     setTimeout(() => {
                                         page.close();
                                         console.log(
-                                            `${example.library}(${
-                                                example.page
-                                            }): OK`
+                                            `${example.library}(${example.page}): OK`
                                         );
                                         resolve();
                                     }, 1000);

--- a/test/load-dependencies.test.js
+++ b/test/load-dependencies.test.js
@@ -48,6 +48,67 @@ describe('Loading dependencies', () => {
             });
     });
 
+    it('loads asynchronous dependencies', () => {
+        const contentId = 'foo';
+        const contentObject = {};
+        const h5pObject = {
+            mainLibrary: 'Foo',
+            preloadedDependencies: [
+                {
+                    machineName: 'Foo',
+                    majorVersion: 4,
+                    minorVersion: 2
+                },
+                {
+                    machineName: 'Bar',
+                    majorVersion: 2,
+                    minorVersion: 1
+                }
+            ]
+        };
+        const libraryLoader = (name, maj, min) =>
+            new Promise(resolve => {
+                setTimeout(
+                    () =>
+                        resolve(
+                            {
+                                Foo42: {
+                                    preloadedJs: [
+                                        { path: 'foo1.js' },
+                                        { path: 'foo2.js' }
+                                    ],
+                                    preloadedCss: [
+                                        { path: 'foo1.css' },
+                                        { path: 'foo2.css' }
+                                    ]
+                                },
+                                Bar21: {
+                                    preloadedJs: [{ path: 'bar.js' }],
+                                    preloadedCss: [{ path: 'bar.css' }]
+                                }
+                            }[name + maj + min]
+                        ),
+                    100
+                );
+            });
+
+        return new H5P(libraryLoader)
+            .useRenderer(model => model)
+            .render(contentId, contentObject, h5pObject)
+            .then(model => {
+                expect(model.styles.slice(2)).toEqual([
+                    '/h5p/libraries/Foo-4.2/foo1.css',
+                    '/h5p/libraries/Foo-4.2/foo2.css',
+                    '/h5p/libraries/Bar-2.1/bar.css'
+                ]);
+                expect(model.scripts.slice(8)).toEqual([
+                    '/h5p/libraries/Foo-4.2/foo1.js',
+                    '/h5p/libraries/Foo-4.2/foo2.js',
+                    '/h5p/libraries/Bar-2.1/bar.js'
+                ]);
+            });
+    });
+
     it('resolves deep dependencies', () => {
         const contentId = 'foo';
         const contentObject = {};


### PR DESCRIPTION
This PR adds support for libraryLoader to be sync or async. We can return a promise from libraryLoader and it will use the resolved result for the `library.json`.

There aren't any breaking changes since the synchronous libraryLoader still works.