### PR TITLE
Draft: Libraries are sometimes loaded multiple times

### DIFF
--- a/test/load-dependencies.test.js
+++ b/test/load-dependencies.test.js
@@ -177,6 +177,45 @@ describe('Loading dependencies', () => {
             });
     });
 
+    it('avoid loading the same library twice', () => {
+        const contentId = 'foo';
+        const contentObject = {};
+        const h5pObject = {
+            mainLibrary: 'Foo',
+            preloadedDependencies: [{ machineName: 'Foo' }]
+        };
+        const loaded = [];
+
+        const libraryLoader = name => {
+            loaded.push(name);
+
+            return Promise.resolve(
+                {
+                    Foo: {
+                        preloadedDependencies: [
+                            { machineName: 'Bar' },
+                            { machineName: 'Baz' }
+                        ]
+                    },
+                    Bar: {
+                        preloadedDependencies: [{ machineName: 'Jaz' }]
+                    },
+                    Baz: {
+                        preloadedDependencies: [{ machineName: 'Jaz' }]
+                    },
+                    Jaz: {}
+                }[name]
+            );
+        };
+
+        return new H5P(libraryLoader)
+            .useRenderer(model => model)
+            .render(contentId, contentObject, h5pObject)
+            .then(() => {
+                expect(loaded).toEqual(['Foo', 'Bar', 'Baz', 'Jaz']);
+            });
+    });
+
     it('resolves deep dependencies', () => {
         const contentId = 'foo';
         const contentObject = {};


### PR DESCRIPTION
Working on [dependency resolution in the editor](https://github.com/Lumieducation/H5P-Editor-Nodejs-library/pull/53), I discovered that while the viewer makes sure that each asset is loaded only once, it could happen that a library is loaded multiple times.

Basically just wanted to document that. I'm hesitant to change @danielrudn's implementation because it is quite elegant and this might only be a small performance issue.

What do you think?