### PR TITLE
[#12] Install library from H5P.org and package via upload

### DIFF
--- a/examples/express.js
+++ b/examples/express.js
@@ -120,6 +120,14 @@ const h5pEditor = new H5PEditor(
                     resolve([]);
                 }
             });
+        },
+        saveLibraryFile: (filePath, stream) => {
+            const fullPath = `h5p/libraries/${filePath}`;
+
+            return new Promise(y => fs.mkdir(path.dirname(fullPath), { recursive: true }, y))
+                .then(() => new Promise(y =>
+                    stream.pipe(fs.createWriteStream(fullPath))
+                        .on('finish', y)))
         }
     },
     {
@@ -233,6 +241,13 @@ server.post('/ajax', (req, res) => {
                 .then(response => {
                     res.status(200).json(response);
                 });
+            break;
+        case 'library-install':
+            h5pEditor.installLibrary(req.query.id)
+                .then(() => h5pEditor.getContentTypeCache()
+                    .then(contentTypeCache => {
+                        res.status(200).json({ success: true, data: contentTypeCache });
+                    }))
             break;
         default:
             res.status(500).end('NOT IMPLEMENTED');

--- a/examples/express.js
+++ b/examples/express.js
@@ -130,7 +130,7 @@ const h5pEditor = new H5PEditor(
                         .on('finish', y)))
         },
         saveContentFile: (id, filePath, stream) => {
-            const fullPath = `examples/h5p/content/${id}/${filePath}`;
+            const fullPath = `h5p/content/${id}/${filePath}`;
 
             return new Promise(y => fs.mkdir(path.dirname(fullPath), { recursive: true }, y))
                 .then(() => new Promise(y =>
@@ -263,7 +263,20 @@ server.post('/ajax', (req, res) => {
 
         case 'library-upload':
             h5pEditor.uploadPackage(req.files.h5p.data)
-                .then(() => res.status(200).json({ success: true }))
+                .then(contentId => Promise.all([
+                    h5pEditor.loadH5P(contentId),
+                    h5pEditor.getContentTypeCache()
+                ])
+
+                    .then(([content, contentTypes]) =>
+                        res.status(200).json({
+                            success: true,
+                            data: {
+                                h5p: content.h5p,
+                                content: content.params,
+                                contentTypes
+                            }
+                        })))
             break;
 
         default:

--- a/examples/express.js
+++ b/examples/express.js
@@ -128,6 +128,14 @@ const h5pEditor = new H5PEditor(
                 .then(() => new Promise(y =>
                     stream.pipe(fs.createWriteStream(fullPath))
                         .on('finish', y)))
+        },
+        saveContentFile: (id, filePath, stream) => {
+            const fullPath = `examples/h5p/content/${id}/${filePath}`;
+
+            return new Promise(y => fs.mkdir(path.dirname(fullPath), { recursive: true }, y))
+                .then(() => new Promise(y =>
+                    stream.pipe(fs.createWriteStream(fullPath))
+                        .on('finish', y)))
         }
     },
     {
@@ -224,11 +232,13 @@ server.post('/', (req, res) => {
 server.post('/ajax', (req, res) => {
     const { action } = req.query;
     switch (action) {
+
         case 'libraries':
             h5pEditor.getLibraryOverview(req.body.libraries).then(libraries => {
                 res.status(200).json(libraries);
             });
             break;
+
         case 'files':
             h5pEditor
                 .saveContentFile(
@@ -242,6 +252,7 @@ server.post('/ajax', (req, res) => {
                     res.status(200).json(response);
                 });
             break;
+
         case 'library-install':
             h5pEditor.installLibrary(req.query.id)
                 .then(() => h5pEditor.getContentTypeCache()
@@ -249,6 +260,12 @@ server.post('/ajax', (req, res) => {
                         res.status(200).json({ success: true, data: contentTypeCache });
                     }))
             break;
+
+        case 'library-upload':
+            h5pEditor.uploadPackage(req.files.h5p.data)
+                .then(() => res.status(200).json({ success: true }))
+            break;
+
         default:
             res.status(500).end('NOT IMPLEMENTED');
             break;

--- a/package-lock.json
+++ b/package-lock.json
@@ -2263,8 +2263,7 @@
         "balanced-match": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-            "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-            "dev": true
+            "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
         },
         "base": {
             "version": "0.11.2",
@@ -2335,12 +2334,31 @@
                 "tweetnacl": "^0.14.3"
             }
         },
+        "big-integer": {
+            "version": "1.6.44",
+            "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.44.tgz",
+            "integrity": "sha512-7MzElZPTyJ2fNvBkPxtFQ2fWIkVmuzw41+BZHSzpEq3ymB2MfeKp1+yXl/tS75xCx+WnyV+yb0kp+K1C3UNwmQ=="
+        },
+        "binary": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
+            "integrity": "sha1-n2BVO8XOjDOG87VTz/R0Yq3sqnk=",
+            "requires": {
+                "buffers": "~0.1.1",
+                "chainsaw": "~0.1.0"
+            }
+        },
         "binary-extensions": {
             "version": "1.13.1",
             "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
             "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
             "dev": true,
             "optional": true
+        },
+        "bluebird": {
+            "version": "3.4.7",
+            "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
+            "integrity": "sha1-9y12C+Cbf3bQjtj66Ysomo0F+rM="
         },
         "body-parser": {
             "version": "1.19.0",
@@ -2400,7 +2418,6 @@
             "version": "1.1.11",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
             "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-            "dev": true,
             "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -2493,6 +2510,16 @@
             "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
             "dev": true
         },
+        "buffer-indexof-polyfill": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/buffer-indexof-polyfill/-/buffer-indexof-polyfill-1.0.1.tgz",
+            "integrity": "sha1-qfuAbOgUXVQoUQznLyeLs2OmOL8="
+        },
+        "buffers": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
+            "integrity": "sha1-skV5w77U1tOWru5tmorn9Ugqt7s="
+        },
         "busboy": {
             "version": "0.2.14",
             "resolved": "https://registry.npmjs.org/busboy/-/busboy-0.2.14.tgz",
@@ -2583,6 +2610,14 @@
             "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
             "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
             "dev": true
+        },
+        "chainsaw": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
+            "integrity": "sha1-XqtQsor+WAdNDVgpE4iCi15fvJg=",
+            "requires": {
+                "traverse": ">=0.3.0 <0.4"
+            }
         },
         "chalk": {
             "version": "2.4.2",
@@ -2835,8 +2870,7 @@
         "concat-map": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-            "dev": true
+            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
         },
         "contains-path": {
             "version": "0.1.0",
@@ -2914,8 +2948,7 @@
         "core-util-is": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-            "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-            "dev": true
+            "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
         },
         "crc": {
             "version": "3.8.0",
@@ -3167,6 +3200,14 @@
             "dev": true,
             "requires": {
                 "webidl-conversions": "^4.0.2"
+            }
+        },
+        "duplexer2": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+            "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
+            "requires": {
+                "readable-stream": "^2.0.2"
             }
         },
         "ecc-jsbn": {
@@ -4123,8 +4164,7 @@
         "fs.realpath": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-            "dev": true
+            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
         },
         "fsevents": {
             "version": "1.2.9",
@@ -4146,7 +4186,8 @@
                 "ansi-regex": {
                     "version": "2.1.1",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "aproba": {
                     "version": "1.2.0",
@@ -4167,12 +4208,14 @@
                 "balanced-match": {
                     "version": "1.0.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "brace-expansion": {
                     "version": "1.1.11",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "balanced-match": "^1.0.0",
                         "concat-map": "0.0.1"
@@ -4187,17 +4230,20 @@
                 "code-point-at": {
                     "version": "1.1.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "concat-map": {
                     "version": "0.0.1",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "console-control-strings": {
                     "version": "1.1.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "core-util-is": {
                     "version": "1.0.2",
@@ -4314,7 +4360,8 @@
                 "inherits": {
                     "version": "2.0.3",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "ini": {
                     "version": "1.3.5",
@@ -4326,6 +4373,7 @@
                     "version": "1.0.0",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "number-is-nan": "^1.0.0"
                     }
@@ -4340,6 +4388,7 @@
                     "version": "3.0.4",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "brace-expansion": "^1.1.7"
                     }
@@ -4347,12 +4396,14 @@
                 "minimist": {
                     "version": "0.0.8",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "minipass": {
                     "version": "2.3.5",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "safe-buffer": "^5.1.2",
                         "yallist": "^3.0.0"
@@ -4371,6 +4422,7 @@
                     "version": "0.5.1",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "minimist": "0.0.8"
                     }
@@ -4451,7 +4503,8 @@
                 "number-is-nan": {
                     "version": "1.0.1",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "object-assign": {
                     "version": "4.1.1",
@@ -4463,6 +4516,7 @@
                     "version": "1.4.0",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "wrappy": "1"
                     }
@@ -4548,7 +4602,8 @@
                 "safe-buffer": {
                     "version": "5.1.2",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "safer-buffer": {
                     "version": "2.1.2",
@@ -4584,6 +4639,7 @@
                     "version": "1.0.2",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "code-point-at": "^1.0.0",
                         "is-fullwidth-code-point": "^1.0.0",
@@ -4603,6 +4659,7 @@
                     "version": "3.0.1",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "ansi-regex": "^2.0.0"
                     }
@@ -4646,13 +4703,26 @@
                 "wrappy": {
                     "version": "1.0.2",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "yallist": {
                     "version": "3.0.3",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 }
+            }
+        },
+        "fstream": {
+            "version": "1.0.12",
+            "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
+            "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
+            "requires": {
+                "graceful-fs": "^4.1.2",
+                "inherits": "~2.0.0",
+                "mkdirp": ">=0.5 0",
+                "rimraf": "2"
             }
         },
         "function-bind": {
@@ -4707,7 +4777,6 @@
             "version": "7.1.3",
             "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
             "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
-            "dev": true,
             "requires": {
                 "fs.realpath": "^1.0.0",
                 "inflight": "^1.0.4",
@@ -4733,6 +4802,7 @@
             "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
             "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
             "dev": true,
+            "optional": true,
             "requires": {
                 "is-glob": "^2.0.0"
             }
@@ -5002,7 +5072,6 @@
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
             "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-            "dev": true,
             "requires": {
                 "once": "^1.3.0",
                 "wrappy": "1"
@@ -5200,7 +5269,8 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
             "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-            "dev": true
+            "dev": true,
+            "optional": true
         },
         "is-finite": {
             "version": "1.0.2",
@@ -5228,6 +5298,7 @@
             "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
             "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
             "dev": true,
+            "optional": true,
             "requires": {
                 "is-extglob": "^1.0.0"
             }
@@ -5326,8 +5397,7 @@
         "isarray": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-            "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-            "dev": true
+            "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
         },
         "isexe": {
             "version": "2.0.0",
@@ -6052,6 +6122,11 @@
                 "type-check": "~0.3.2"
             }
         },
+        "listenercount": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/listenercount/-/listenercount-1.0.1.tgz",
+            "integrity": "sha1-hMinKrWcRyUyFIDJdeZQg0LnCTc="
+        },
         "load-json-file": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
@@ -6250,7 +6325,6 @@
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
             "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-            "dev": true,
             "requires": {
                 "brace-expansion": "^1.1.7"
             }
@@ -6258,8 +6332,7 @@
         "minimist": {
             "version": "0.0.8",
             "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-            "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-            "dev": true
+            "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
         },
         "mixin-deep": {
             "version": "1.3.2",
@@ -6286,7 +6359,6 @@
             "version": "0.5.1",
             "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
             "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-            "dev": true,
             "requires": {
                 "minimist": "0.0.8"
             }
@@ -6564,7 +6636,6 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
             "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-            "dev": true,
             "requires": {
                 "wrappy": "1"
             }
@@ -6758,8 +6829,7 @@
         "path-is-absolute": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-            "dev": true
+            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
         },
         "path-is-inside": {
             "version": "1.0.2",
@@ -6877,8 +6947,7 @@
         "process-nextick-args": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-            "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
-            "dev": true
+            "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
         },
         "progress": {
             "version": "2.0.3",
@@ -7024,7 +7093,6 @@
             "version": "2.3.6",
             "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
             "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-            "dev": true,
             "requires": {
                 "core-util-is": "~1.0.0",
                 "inherits": "~2.0.3",
@@ -7324,7 +7392,6 @@
             "version": "2.6.3",
             "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
             "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
-            "dev": true,
             "requires": {
                 "glob": "^7.1.3"
             }
@@ -7483,6 +7550,11 @@
                     }
                 }
             }
+        },
+        "setimmediate": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+            "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
         },
         "setprototypeof": {
             "version": "1.1.0",
@@ -7843,7 +7915,6 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
             "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-            "dev": true,
             "requires": {
                 "safe-buffer": "~5.1.0"
             }
@@ -8150,6 +8221,11 @@
                 "punycode": "^2.1.0"
             }
         },
+        "traverse": {
+            "version": "0.3.9",
+            "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
+            "integrity": "sha1-cXuPIgzAu3tE5AUUwisui7xw2Lk="
+        },
         "trim-right": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
@@ -8296,6 +8372,22 @@
                 }
             }
         },
+        "unzipper": {
+            "version": "0.10.3",
+            "resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.10.3.tgz",
+            "integrity": "sha512-vH3+KAfi01r2wioCve0djy0NRpQUfjVFoLWdsup8u6xdCId2vn8TEDReRfYGjdGuVQ/2aEDaWgeRJCcPOsRHqw==",
+            "requires": {
+                "big-integer": "^1.6.17",
+                "binary": "~0.3.0",
+                "bluebird": "~3.4.1",
+                "buffer-indexof-polyfill": "~1.0.0",
+                "duplexer2": "~0.1.4",
+                "fstream": "^1.0.12",
+                "listenercount": "~1.0.1",
+                "readable-stream": "~2.3.6",
+                "setimmediate": "~1.0.4"
+            }
+        },
         "uri-js": {
             "version": "4.2.2",
             "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
@@ -8326,8 +8418,7 @@
         "util-deprecate": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-            "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-            "dev": true
+            "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
         },
         "util.promisify": {
             "version": "1.0.0",
@@ -8506,8 +8597,7 @@
         "wrappy": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-            "dev": true
+            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
         },
         "write": {
             "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
         "express": "^4.16.4",
         "fs-extra": "^8.0.1",
         "merge": "^1.2.1",
-        "qs": "^6.7.0"
+        "qs": "^6.7.0",
+        "unzipper": "^0.10.3"
     },
     "devDependencies": {
         "@babel/core": "^7.4.4",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
         "fs-extra": "^8.0.1",
         "merge": "^1.2.1",
         "qs": "^6.7.0",
-        "unzipper": "^0.10.3"
+        "unzipper": "^0.10.3",
+        "shortid": "^2.2.14"
     },
     "devDependencies": {
         "@babel/core": "^7.4.4",
@@ -45,8 +46,7 @@
         "express-fileupload": "^1.1.5",
         "jest": "^24.7.1",
         "mkdirp": "^0.5.1",
-        "mockdate": "^2.0.3",
-        "shortid": "^2.2.14"
+        "mockdate": "^2.0.3"
     },
     "main": "./src/index.js"
 }


### PR DESCRIPTION
This PR does numbers 5, 7, and 8 from #12.

You can either install a library from the H5P.org hub using the "get/install" buttons or upload an .h5p file.

There is no validation, no checks, no error handling, and no test cases. Pretty much a "hack" to make manual testing easier.