### PR TITLE
Fixed bugs in Express example

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -24,6 +24,7 @@
             "LabeledStatement",
             "WithStatement"
         ],
-        "no-param-reassign": "off"
+        "no-param-reassign": "off",
+        "import/no-extraneous-dependencies": ["error", {"devDependencies": ["test/**.js", "examples/**.js"]}]
     }
 }

--- a/examples/express.js
+++ b/examples/express.js
@@ -1,15 +1,17 @@
-require("babel-core/register");
+require("@babel/core");
 require("babel-polyfill");
 
+const os = require("os");
 const express = require('express');
 const path = require('path');
 const bodyParser = require('body-parser');
 const fileUpload = require('express-fileupload');
 const fs = require('fs');
 const mkdirp = require('mkdirp');
+const shortid = require('shortid');
+
 const InMemoryStorage = require('../test/mockups/in-memory-storage');
 const H5PEditorConfig = require('../build/config');
-const shortid = require('shortid');
 const FileLibraryManager = require('../test/mockups/file-library-manager');
 const User = require('../test/mockups/user');
 const H5PEditor = require('../build');
@@ -39,8 +41,8 @@ const h5pEditor = new H5PEditor(
         saveContentFile: (contentId, field, file) => {
             return new Promise(resolve => {
                 const dir = `${path.resolve()}/h5p/content/${contentId}/content/`;
-                mkdirp(dir, mkdirp_error => {
-                    fs.writeFile(`${dir}${file.name}`, file.data, error => {
+                mkdirp(dir, () => {
+                    fs.writeFile(`${dir}${file.name}`, file.data, () => {
                         resolve();
                     });
                 });
@@ -109,7 +111,7 @@ const h5pEditor = new H5PEditor(
                         `${path.resolve()}/h5p/libraries/${machineName}-${majorVersion}.${minorVersion}/language`,
                         (error, files) => {
                             if (error) {
-                                return resolve([]);
+                                resolve([]);
                             }
                             resolve(
                                 files.map(file => file.replace('.json', ''))
@@ -129,7 +131,7 @@ const h5pEditor = new H5PEditor(
                     stream.pipe(fs.createWriteStream(fullPath))
                         .on('finish', y)))
         },
-        saveContentFile: (id, filePath, stream) => {
+        saveContentFile2: (id, filePath, stream) => {
             const fullPath = `h5p/content/${id}/${filePath}`;
 
             return new Promise(y => fs.mkdir(path.dirname(fullPath), { recursive: true }, y))
@@ -168,7 +170,7 @@ server.use(h5pRoute, express.static(`${path.resolve('')}/h5p`));
 
 server.get('/', (req, res) => {
     if (!req.query.contentId) {
-        return res.redirect(`?contentId=${shortid()}`);
+        res.redirect(`?contentId=${shortid()}`);
     }
     h5pEditor.render().then(h5pEditorPage => {
         res.end(h5pEditorPage);
@@ -181,7 +183,7 @@ server.get('/params', (req, res) => {
         .then(content => {
             res.status(200).json(content);
         })
-        .catch(error => {
+        .catch(() => {
             res.status(404).end();
         });
 });
@@ -286,5 +288,5 @@ server.post('/ajax', (req, res) => {
 });
 
 server.listen(process.env.PORT || 8080, () => {
-    console.log('server running at ', process.env.PORT || 8080);
+    console.log(`server running at http://${os.hostname()}:${process.env.PORT || 8080}`);
 });

--- a/src/index.js
+++ b/src/index.js
@@ -294,7 +294,7 @@ class H5PEditor {
                     const base = entry.path.split('/')[0];
 
                     if (base === 'content' || base === 'h5p.json') {
-                        filesSaves.push(this.storage.saveContentFile(contentId, entry.path, entry));
+                        filesSaves.push(this.storage.saveContentFile2(contentId, entry.path, entry));
                     } else {
                         filesSaves.push(this.storage.saveLibraryFile(entry.path, entry));
                     }


### PR DESCRIPTION
This PR fixes three issues with the Express example:

1. https://github.com/Lumieducation/H5P-Editor-Nodejs-library/pull/54 introduced a bug because saveContentFile existed twice with different parameters. Because of this uploading images was no longer possible.
2. Fixed code issues ESLint complained about.
3. Added example folder to dev-dependencies so that ESLint doesn't complain about the imports.