### PR TITLE
Remove duplicate client-script

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -316,7 +316,6 @@ class H5PEditor {
             '/core/js/h5p-action-bar.js',
             '/editor/scripts/h5p-hub-client.js',
             '/editor/scripts/h5peditor-editor.js',
-            '/editor/wp/h5p-editor.js',
             '/editor/scripts/h5peditor.js',
             '/editor/scripts/h5peditor-semantic-structure.js',
             '/editor/scripts/h5peditor-library-selector.js',


### PR DESCRIPTION
Remove the duplicate of the `/editor/wp/h5p-editor.js`-client script. This caused the editor to load params twice and overwrite the editor.