### PR TITLE
[closes #70] Find dependencies in content

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "h5p-editor",
-    "version": "v0.0.0",
+    "version": "v0.0.1",
     "description": "The H5P-Editor-Nodejs-library is a port of the H5P-Editor-PHP-library for Nodejs.",
     "repository": {
         "type": "git",

--- a/src/h5p-editor.js
+++ b/src/h5p-editor.js
@@ -73,7 +73,7 @@ class H5PEditor {
         if (typeof object !== 'object') return collect;
 
         Object.keys(object).forEach(key => {
-            if (key === 'library' && object[key].match(/\w \d+\.\d+/)) {
+            if (key === 'library' && object[key].match(/.+ \d+\.\d+/)) {
                 const [name, version] = object[key].split(' ');
                 const [major, minor] = version.split('.');
 

--- a/src/h5p-editor.js
+++ b/src/h5p-editor.js
@@ -79,8 +79,8 @@ class H5PEditor {
 
                 collect[object[key]] = {
                     machineName: name,
-                    majorVersion: parseInt(major),
-                    minorVersion: parseInt(minor)
+                    majorVersion: parseInt(major, 10),
+                    minorVersion: parseInt(minor, 10)
                 };
             } else {
                 this._findLibraries(object[key], collect);


### PR DESCRIPTION
See #70 

In order to find libraries that a content depends on, the editor goes through the entier content objects and adds the value of any `library` key that matches `/.+ \d+\.\d+/` to the `preloadedDependencies`.