### PR TITLE
Add getLibraryFileUrl to library-manager (closes #97)

### DIFF
--- a/src/library-manager.js
+++ b/src/library-manager.js
@@ -200,6 +200,20 @@ class LibraryManager {
     }
 
     /**
+     * Returns an URL where the requested file can be accessed.
+     * @param {Library} library 
+     * @param {string} filename
+     * @returns {string} the url
+     */
+    getLibraryFileUrl(library, filename) {
+        try {
+            return `${library.machineName}-${library.majorVersion}.${library.minorVersion}/${filename}`;
+        } catch(error) {
+            return undefined;
+        }
+    }
+
+    /**
      * Updates the library to a new version. 
      * REMOVES THE LIBRARY IF THERE IS AN ERROR!!!
      * @param {number} installedLibraryId The id of the installed library

--- a/test/library-manager.test.js
+++ b/test/library-manager.test.js
@@ -130,4 +130,18 @@ describe('basic file library manager functionality', () => {
             expect((await fs.readdir(tempDirPath))).toEqual([]);
         }, { keep: false, unsafeCleanup: true });
     });
+
+     it('returns the list of installed library in demo directory', async () => {
+        const libManager = new LibraryManager(new FileLibraryStorage(`${path.resolve('')}/test/data/libraries`));
+
+        const testLibrary = {
+            machineName: 'test',
+            majorVersion: 1,
+            minorVersion: 2
+        }
+
+        const url = libManager.getLibraryFileUrl(testLibrary, 'test.png');
+
+        expect(url).toEqual('test-1.2/test.png');
+    });
 });


### PR DESCRIPTION
Hey,

I noticed that the getLibraryFileUrl-method of the libraryManager does not exist. It is used within the [content-type-information-repository](https://github.com/Lumieducation/H5P-Editor-Nodejs-library/blob/master/src/content-type-information-repository.js#L135) to determine the URL of the icon.svg. 