### PR TITLE
listLanguages: return empty array if language folder does not exist (closes #98)

### DIFF
--- a/src/library-manager.js
+++ b/src/library-manager.js
@@ -161,7 +161,12 @@ class LibraryManager {
      * @returns {Promise<string[]>} the language codes for translations of this library
      */
     async listLanguages(library) {
-        return this._libraryStorage.getLanguageFiles(library).catch(error => [])
+        try {
+            return await this._libraryStorage.getLanguageFiles(library);
+        }
+        catch (error) {
+            return [];
+        }
     }
 
     /**

--- a/src/library-manager.js
+++ b/src/library-manager.js
@@ -161,8 +161,7 @@ class LibraryManager {
      * @returns {Promise<string[]>} the language codes for translations of this library
      */
     async listLanguages(library) {
-        return this._libraryStorage.getLanguageFiles(library);
-
+        return this._libraryStorage.getLanguageFiles(library).catch(error => [])
     }
 
     /**

--- a/test/library-manager.test.js
+++ b/test/library-manager.test.js
@@ -5,6 +5,8 @@ const { withDir } = require('tmp-promise');
 const LibraryManager = require('../src/library-manager');
 const FileLibraryStorage = require('../src/file-library-storage');
 
+const Library = require('../src/library');
+
 describe('basic file library manager functionality', () => {
     it('returns the list of installed library in demo directory', async () => {
         const libManager = new LibraryManager(new FileLibraryStorage(`${path.resolve('')}/test/data/libraries`));
@@ -130,4 +132,15 @@ describe('basic file library manager functionality', () => {
             expect((await fs.readdir(tempDirPath))).toEqual([]);
         }, { keep: false, unsafeCleanup: true });
     });
+
+});
+
+describe('listLanguages()', () => {
+    it("returns an empty array if the language folder does not exist", async () => {
+        const libManager = new LibraryManager(new FileLibraryStorage(`${path.resolve('')}/test/data/libraries`));
+
+        const library = new Library('H5P.Example2', 1, 2, 0);
+
+        await expect(libManager.listLanguages(library)).resolves.toEqual([]);
+    })
 });


### PR DESCRIPTION
The libraryManager listLanguages-method should return an empty array if no langauge-folder can be found within the library.