### PR TITLE
Replace Travis with  CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,7 +51,7 @@ jobs:
                   paths:
                       - ./node_modules
             - run: npm run format:check
-    jest-tests:
+    unit-tests:
         docker:
             - image: circleci/node:10-browsers-legacy
         steps:
@@ -72,3 +72,6 @@ workflows:
             - build:
                   requires:
                       - install
+            - lint
+            - format
+            - unit-tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,9 +25,48 @@ jobs:
                   paths:
                       - ./node_modules
             - run: npm run build
+    lint:
+        docker:
+            - image: circleci/node:10-browsers-legacy
+        steps:
+            - checkout
+            - restore_cache: # special step to restore the dependency cache
+                  key: dependency-cache-{{ checksum "package.json" }}
+            - run: npm ci
+            - save_cache: # special step to save the dependency cache
+                  key: dependency-cache-{{ checksum "package.json" }}
+                  paths:
+                      - ./node_modules
+            - run: npm run lint
+    format:
+        docker:
+            - image: circleci/node:10-browsers-legacy
+        steps:
+            - checkout
+            - restore_cache: # special step to restore the dependency cache
+                  key: dependency-cache-{{ checksum "package.json" }}
+            - run: npm ci
+            - save_cache: # special step to save the dependency cache
+                  key: dependency-cache-{{ checksum "package.json" }}
+                  paths:
+                      - ./node_modules
+            - run: npm run format:check
+    jest-tests:
+        docker:
+            - image: circleci/node:10-browsers-legacy
+        steps:
+            - checkout
+            - restore_cache: # special step to restore the dependency cache
+                  key: dependency-cache-{{ checksum "package.json" }}
+            - run: npm ci
+            - save_cache: # special step to save the dependency cache
+                  key: dependency-cache-{{ checksum "package.json" }}
+                  paths:
+                      - ./node_modules
+            - run: npm run test
 workflows:
     version: 2
-    one_and_two:
+    h5peditor:
         jobs:
             - install
             - build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,35 @@
+version: 2
+jobs:
+    install:
+        docker:
+            - image: circleci/node:10-browsers-legacy
+        steps:
+            - checkout
+            - restore_cache: # special step to restore the dependency cache
+                  key: dependency-cache-{{ checksum "package.json" }}
+            - run: npm ci
+            - save_cache: # special step to save the dependency cache
+                  key: dependency-cache-{{ checksum "package.json" }}
+                  paths:
+                      - ./node_modules
+    build:
+        docker:
+            - image: circleci/node:10-browsers-legacy
+        steps:
+            - checkout
+            - restore_cache: # special step to restore the dependency cache
+                  key: dependency-cache-{{ checksum "package.json" }}
+            - run: npm ci
+            - save_cache: # special step to save the dependency cache
+                  key: dependency-cache-{{ checksum "package.json" }}
+                  paths:
+                      - ./node_modules
+            - run: npm run build
+workflows:
+    version: 2
+    one_and_two:
+        jobs:
+            - install
+            - build:
+                  requires:
+                      - install

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,0 @@
-language: node_js
-node_js:
-    - node
-script: npm run ci
-cache:
-    directories:
-        - node_modules


### PR DESCRIPTION
Hey,

I figured out that CircleCI allows you to configure multiple stages in your ci, which show up in GitHubs PRs: 
![Screenshot 2019-09-24 at 13 36 31](https://user-images.githubusercontent.com/9697985/65508353-5446ca00-ded0-11e9-8228-a25abdac6ea5.png)
I find it useful to see in the PR at which stages the ci fails and would recommend to switch to circleci. What do you think?
