### PR TITLE
Run download-script only when installed via npm isntall (fixes #107)

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     },
     "scripts": {
         "build": "./node_modules/.bin/tsc",
-        "postinstall": "npm run download:content-type-cache && npm run download:content",
+        "prepare": "npm run download:content-type-cache && npm run download:content",
         "uninstall": "rm -rf node_modules && rm -rf test/data/hub-content && rm test/data/content-type-cache/real-content-types.json",
         "download:content": "node scripts/download-examples.js test/data/content-type-cache/real-content-types.json test/data/hub-content",
         "clear": "rm -rf test/data/hub-content",


### PR DESCRIPTION
Hey,

as @sr258 mentioned in issue #107 the postinstall script also runs when installed as dependency. We had the same issue in the Player and fixed it by putting these script into the `prepare` field rather than `postinstall` field. The `prepare` scripts only run when used via `npm install`.