### PR TITLE
Update index.js to export compiled Typescript

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,12 +1,12 @@
 module.exports = {
-    JsonStorage: require('./build/src/JsonStorage'),
-    InMemoryStorage: require('./build/src/InMemoryStorage'),
-    Config: require('./build/src/EditorConfig'),
-    FileLibraryStorage: require('./build/src/FileLibraryStorage'),
-    FileContentStorage: require('./build/src/FileContentStorage'),
-    User: require('./build/src/User'),
-    TranslationService: require('./build/src/TranslationService'),
-    Editor: require('./build/src/H5PEditor'),
-    englishStrings: require('./build/src/translations/en.json'),
-    Library: require('./build/src/Library')
+    JsonStorage: require('./build/src/JsonStorage').default,
+    InMemoryStorage: require('./build/src/InMemoryStorage').default,
+    Config: require('./build/src/EditorConfig').default,
+    FileLibraryStorage: require('./build/src/FileLibraryStorage').default,
+    FileContentStorage: require('./build/src/FileContentStorage').default,
+    User: require('./build/src/User').default,
+    TranslationService: require('./build/src/TranslationService').default,
+    Editor: require('./build/src/H5PEditor').default,
+    englishStrings: require('./build/src/translations/en.json').default,
+    Library: require('./build/src/Library').default
 };


### PR DESCRIPTION
Hey,

in order to prepare the first release (v0.0.4) we have to export the generated Typescript files correctly, so I updated the `index.js` according to https://stackoverflow.com/questions/52992813/typescript-typeerror-app-is-not-a-constructor and added a `.default` to every export. 