### PR TITLE
Fix missing translations

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,6 @@ module.exports = {
     User: require('./build/src/User').default,
     TranslationService: require('./build/src/TranslationService').default,
     Editor: require('./build/src/H5PEditor').default,
-    englishStrings: require('./build/src/translations/en.json').default,
+    englishStrings: require('./build/src/translations/en.json'),
     Library: require('./build/src/Library').default
 };


### PR DESCRIPTION
Hey,

I accidentally added a wrong `.default` to the englishStrings json in the `index.js` so the translations were missing.