### PR TITLE
fixed metadata persistence (closes #152)

### DIFF
--- a/src/ContentManager.ts
+++ b/src/ContentManager.ts
@@ -9,8 +9,8 @@ import { streamToString } from './helpers/StreamHelpers';
 import {
     Content,
     ContentId,
+    IContentMetadata,
     IContentStorage,
-    IH5PJson,
     IUser,
     Permission
 } from './types';
@@ -73,7 +73,7 @@ export default class ContentManager {
         user: IUser,
         contentId?: ContentId
     ): Promise<ContentId> {
-        const metadata: IH5PJson = await fsExtra.readJSON(
+        const metadata: IContentMetadata = await fsExtra.readJSON(
             path.join(packageDirectory, 'h5p.json')
         );
         const content: Content = await fsExtra.readJSON(
@@ -123,7 +123,7 @@ export default class ContentManager {
      * @returns {Promise<string>} The newly assigned content id
      */
     public async createContent(
-        metadata: IH5PJson,
+        metadata: IContentMetadata,
         content: Content,
         user: IUser,
         contentId: ContentId
@@ -205,7 +205,7 @@ export default class ContentManager {
     public async loadH5PJson(
         contentId: ContentId,
         user: IUser
-    ): Promise<IH5PJson> {
+    ): Promise<IContentMetadata> {
         return this.getFileJson(contentId, 'h5p.json', user);
     }
 

--- a/src/FileContentStorage.ts
+++ b/src/FileContentStorage.ts
@@ -5,7 +5,13 @@ import path from 'path';
 import promisepipe from 'promisepipe';
 
 import { Stream } from 'stream';
-import { ContentId, IContentStorage, IUser, Permission } from './types';
+import {
+    ContentId,
+    IContentMetadata,
+    IContentStorage,
+    IUser,
+    Permission
+} from './types';
 
 /**
  * Persists content to the disk.
@@ -84,7 +90,7 @@ export default class FileContentStorage implements IContentStorage {
      * @returns {Promise<ContentId>} The newly assigned content id
      */
     public async createContent(
-        metadata: any,
+        metadata: IContentMetadata,
         content: any,
         user: IUser,
         id?: ContentId

--- a/src/H5PEditor.ts
+++ b/src/H5PEditor.ts
@@ -12,7 +12,6 @@ import defaultRenderer from './renderers/default';
 
 import ContentManager from './ContentManager';
 import ContentTypeCache from './ContentTypeCache';
-// tslint:disable-next-line: import-name
 import ContentTypeInformationRepository from './ContentTypeInformationRepository';
 import H5pError from './helpers/H5pError';
 import Library from './Library';
@@ -26,16 +25,15 @@ import {
     Content,
     ContentId,
     IAssets,
+    IContentMetadata,
     IContentStorage,
     IDependency,
     IEditorIntegration,
-    IH5PJson,
     IIntegration,
     IKeyValueStorage,
     ILibraryData,
     ILibraryInfo,
     ILibraryStorage,
-    IMetadata,
     IURLConfig,
     IUser
 } from './types';
@@ -181,10 +179,10 @@ export default class H5PEditor {
         contentId: ContentId,
         user?: IUser
     ): Promise<{
-        h5p: IH5PJson;
+        h5p: IContentMetadata;
         library: string;
         params: {
-            metadata: IH5PJson;
+            metadata: IContentMetadata;
             params: Content;
         };
     }> {
@@ -230,10 +228,10 @@ export default class H5PEditor {
     public async saveH5P(
         contentId: ContentId,
         content: Content,
-        metadata: IMetadata,
+        metadata: IContentMetadata,
         libraryName: string
     ): Promise<ContentId> {
-        const h5pJson: IH5PJson = await this.generateH5PJSON(
+        const h5pJson: IContentMetadata = await this.generateH5PJSON(
             metadata,
             libraryName,
             this.findLibraries(content)
@@ -440,19 +438,17 @@ export default class H5PEditor {
     }
 
     private generateH5PJSON(
-        metadata: IMetadata,
+        metadata: IContentMetadata,
         libraryName: string,
         contentDependencies: IDependency[] = []
-    ): Promise<IH5PJson> {
-        return new Promise((resolve: (value: IH5PJson) => void) => {
+    ): Promise<IContentMetadata> {
+        return new Promise((resolve: (value: IContentMetadata) => void) => {
             this.libraryManager
                 .loadLibrary(
                     Library.createFromName(libraryName.replace(' ', '-'))
                 )
                 .then((library: Library) => {
-                    const h5pJson: IH5PJson = {
-                        language: '',
-                        license: '',
+                    const h5pJson: IContentMetadata = {
                         ...metadata,
                         mainLibrary: library.machineName,
                         preloadedDependencies: [
@@ -463,15 +459,14 @@ export default class H5PEditor {
                                 majorVersion: library.majorVersion,
                                 minorVersion: library.minorVersion
                             }
-                        ],
-                        title: ''
+                        ]
                     };
                     resolve(h5pJson);
                 });
         });
     }
 
-    private getUbernameFromH5pJson(h5pJson: IH5PJson): string {
+    private getUbernameFromH5pJson(h5pJson: IContentMetadata): string {
         const library: IDependency = (
             h5pJson.preloadedDependencies || []
         ).filter(

--- a/src/H5PPlayer.ts
+++ b/src/H5PPlayer.ts
@@ -1,8 +1,8 @@
 import {
     ContentId,
     IAssets,
+    IContentMetadata,
     IDependency,
-    IH5PJson,
     IIntegration,
     ILibraryJson,
     ILibraryLoader
@@ -86,7 +86,7 @@ export default class H5PPlayer {
     public generateIntegration(
         contentId: ContentId,
         contentObject: any,
-        h5pObject: IH5PJson
+        h5pObject: IContentMetadata
     ): IIntegration {
         // see https://h5p.org/creating-your-own-h5p-plugin
         return {
@@ -120,7 +120,7 @@ export default class H5PPlayer {
     public render(
         contentId: ContentId,
         contentObject: any,
-        h5pObject: IH5PJson
+        h5pObject: IContentMetadata
     ): Promise<string> {
         const model = {
             contentId,
@@ -228,7 +228,7 @@ export default class H5PPlayer {
         );
     }
 
-    private mainLibraryString(h5pObject: IH5PJson): string {
+    private mainLibraryString(h5pObject: IContentMetadata): string {
         const library = (h5pObject.preloadedDependencies || []).find(
             lib => lib.machineName === h5pObject.mainLibrary
         );

--- a/src/PackageExporter.ts
+++ b/src/PackageExporter.ts
@@ -11,7 +11,7 @@ import Library from './Library';
 import LibraryManager from './LibraryManager';
 import {
     ContentId,
-    IH5PJson,
+    IContentMetadata,
     ITranslationService,
     IUser,
     Permission
@@ -103,7 +103,7 @@ export default class PackageExporter {
      * Adds the library files to the zip file that are required for the content to be playable.
      */
     private async addLibraryFiles(
-        metadata: IH5PJson,
+        metadata: IContentMetadata,
         outputZipFile: yazl.ZipFile
     ): Promise<void> {
         {
@@ -184,9 +184,9 @@ export default class PackageExporter {
     private async getMetadata(
         contentId: ContentId,
         user: IUser
-    ): Promise<{ metadata: IH5PJson; metadataStream: Readable }> {
+    ): Promise<{ metadata: IContentMetadata; metadataStream: Readable }> {
         let metadataStream: Readable;
-        let metadata: IH5PJson;
+        let metadata: IContentMetadata;
         try {
             metadata = await this.contentManager.loadH5PJson(contentId, user);
             metadataStream = new Readable();

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,18 +24,50 @@ export interface IDependency {
     minorVersion: number;
 }
 
-export interface IMetadata extends IDependency {
-    patchVersion: number;
+/**
+ * This is an author inside content metadata.
+ */
+export interface IContentAuthor {
+    name?: string;
+    role?: string;
 }
 
-export interface IH5PJson extends IDependency {
+/**
+ * This is a change inside content metadata.
+ */
+export interface IContentChange {
+    author?: string;
+    date?: string;
+    log?: string;
+}
+
+/**
+ * This is the structure of the object received by the editor client when saving content.
+ * It is also used when creating h5p.json files for .h5p packages.
+ */
+export interface IContentMetadata {
+    author?: string;
+    authors?: IContentAuthor[];
+    autorComments?: string;
+    changes?: IContentChange[];
+    contentType?: string;
     dynamicDependencies?: IDependency[];
     editorDependencies?: IDependency[];
+    embedTypes?: 'iframe' | 'div';
+    h?: string;
     language: string;
-    license: string;
+    license?: string;
+    licenseExtras?: string;
+    licenseVersion?: string;
     mainLibrary: string;
-    preloadedDependencies?: IDependency[];
+    metaDescription?: string;
+    metaKeywords?: string;
+    preloadedDependencies: IDependency[];
+    source?: string;
     title: string;
+    w?: string;
+    yearsFrom?: string;
+    yearsTo?: string;
 }
 
 export interface IIntegration {

--- a/src/types.ts
+++ b/src/types.ts
@@ -157,7 +157,7 @@ export interface IContentStorage {
     ): Promise<void>;
     contentExists(contentId: ContentId): Promise<boolean>;
     createContent(
-        metadata: any,
+        metadata: IContentMetadata,
         content: any,
         user: IUser,
         contentId?: ContentId

--- a/test/FileContentStorage.test.ts
+++ b/test/FileContentStorage.test.ts
@@ -3,16 +3,35 @@ import { withDir } from 'tmp-promise';
 
 import { Readable } from 'stream';
 import FileContentStorage from '../src/FileContentStorage';
+import { IContentMetadata } from '../src/types';
 import User from '../src/User';
 
 describe('FileContentStorage (repository that saves content objects to a local directory)', () => {
+    function createMetadataMock(): IContentMetadata {
+        return {
+            language: '',
+            mainLibrary: '',
+            preloadedDependencies: [],
+            title: ''
+        };
+    }
+
     it('assigns a new id for new content', async () => {
         await withDir(
             async ({ path: tempDirPath }) => {
                 const storage = new FileContentStorage(tempDirPath);
-                let id = await storage.createContent({}, {}, new User());
+                let id = await storage.createContent(
+                    createMetadataMock(),
+                    {},
+                    new User()
+                );
                 expect(typeof id).toBe('number');
-                id = await storage.createContent({}, {}, new User(), null);
+                id = await storage.createContent(
+                    createMetadataMock(),
+                    {},
+                    new User(),
+                    null
+                );
                 expect(typeof id).toBe('number');
             },
             { keep: false, unsafeCleanup: true }
@@ -22,7 +41,7 @@ describe('FileContentStorage (repository that saves content objects to a local d
     it('throws an error if the passed path is not writable', async () => {
         const storage = new FileContentStorage('/*:%illegal-path');
         await expect(
-            storage.createContent({}, {}, new User())
+            storage.createContent(createMetadataMock(), {}, new User())
         ).rejects.toBeInstanceOf(Error);
     });
 
@@ -33,7 +52,11 @@ describe('FileContentStorage (repository that saves content objects to a local d
                 const filename = 'test.png';
                 const user = new User();
 
-                const id = await storage.createContent({}, {}, user);
+                const id = await storage.createContent(
+                    createMetadataMock(),
+                    {},
+                    user
+                );
                 await expect(
                     storage.addContentFile(id + 1, 'test.png', null, user)
                 ).rejects.toEqual(
@@ -52,7 +75,11 @@ describe('FileContentStorage (repository that saves content objects to a local d
             async ({ path: tempDirPath }) => {
                 const user = new User();
                 const storage = new FileContentStorage(tempDirPath);
-                const id = await storage.createContent({}, {}, user);
+                const id = await storage.createContent(
+                    createMetadataMock(),
+                    {},
+                    user
+                );
                 expect((await fsExtra.readdir(tempDirPath)).length).toEqual(1);
                 await storage.deleteContent(id, user);
                 expect((await fsExtra.readdir(tempDirPath)).length).toEqual(0);
@@ -82,7 +109,11 @@ describe('FileContentStorage (repository that saves content objects to a local d
             async ({ path: tempDirPath }) => {
                 const user = new User();
                 const storage = new FileContentStorage(tempDirPath);
-                const id = await storage.createContent({}, {}, user);
+                const id = await storage.createContent(
+                    createMetadataMock(),
+                    {},
+                    user
+                );
                 await expect(storage.contentExists(id)).resolves.toEqual(true);
                 const unusedId = await storage.createContentId();
                 await expect(storage.contentExists(unusedId)).resolves.toEqual(
@@ -98,7 +129,11 @@ describe('FileContentStorage (repository that saves content objects to a local d
             async ({ path: tempDirPath }) => {
                 const user = new User();
                 const storage = new FileContentStorage(tempDirPath);
-                const id = await storage.createContent({}, {}, user);
+                const id = await storage.createContent(
+                    createMetadataMock(),
+                    {},
+                    user
+                );
                 const stream1 = new Readable();
                 stream1._read = () => {
                     return;


### PR DESCRIPTION
The reason why the title wasn't saved is that it was overridden by the '' literal [here](https://github.com/Lumieducation/H5P-Nodejs-library/blob/master/src/H5PEditor.ts#L467). I've removed the (unneeded) literals, as the values are already in the metadata received from the editor client. 

I also cleaned up the interface structure of content metadata. The metadata received from the client is exactly the same as the data in h5p.json, so I've merged the interfaces and added all attributes according to h5p-schema.json, which I deduced from the PHP validator some time ago. We need the interface to be complete, as IContentStorage implementations need to persist all attributes. If a relational database is used the implementor must know which columns are needed.

Now, adding metadata through the metadata button also works and the data is persisted.