### PR TITLE
Missing libraries are now dealt with accordingly (closes #159)

### DIFF
--- a/examples/express.js
+++ b/examples/express.js
@@ -48,7 +48,7 @@ const start = async () => {
 
     server.get(`${h5pRoute}/libraries/:uberName/:file(*)`, async (req, res) => {
         const stream = h5pEditor.libraryManager.getFileStream(
-            H5PEditor.Library.createFromName(req.params.uberName),
+            H5PEditor.Library.createFromUberName(req.params.uberName),
             req.params.file
         );
         stream.on('end', () => {

--- a/src/DependencyGetter.ts
+++ b/src/DependencyGetter.ts
@@ -37,7 +37,9 @@ export default class DependencyGetter {
                 dependencies
             );
         }
-        return Array.from(dependencies).map(str => Library.createFromName(str));
+        return Array.from(dependencies).map(str =>
+            Library.createFromUberName(str)
+        );
     }
 
     /**

--- a/src/FileLibraryStorage.ts
+++ b/src/FileLibraryStorage.ts
@@ -122,7 +122,7 @@ export default class FileLibraryStorage implements ILibraryStorage {
         return libraryDirectories
             .filter(name => nameRegex.test(name))
             .map(name => {
-                return Library.createFromName(name);
+                return Library.createFromUberName(name);
             })
             .filter(
                 lib =>

--- a/test/Library.test.ts
+++ b/test/Library.test.ts
@@ -1,0 +1,59 @@
+import H5pError from '../src/helpers/H5pError';
+import Library from '../src/Library';
+
+describe('Library model', () => {
+    it('creates library classes from uber names', async () => {
+        expect(Library.createFromUberName('H5P.Example-1.0')).toMatchObject({
+            machineName: 'H5P.Example',
+            majorVersion: 1,
+            minorVersion: 0
+        });
+
+        expect(
+            Library.createFromUberName('H5P.Example-1.0', { useHyphen: true })
+        ).toMatchObject({
+            machineName: 'H5P.Example',
+            majorVersion: 1,
+            minorVersion: 0
+        });
+
+        expect(
+            Library.createFromUberName('H5P.Example 1.0', {
+                useWhitespace: true
+            })
+        ).toMatchObject({
+            machineName: 'H5P.Example',
+            majorVersion: 1,
+            minorVersion: 0
+        });
+
+        expect(
+            Library.createFromUberName('H5P.Example-1.0', {
+                useHyphen: true,
+                useWhitespace: true
+            })
+        ).toMatchObject({
+            machineName: 'H5P.Example',
+            majorVersion: 1,
+            minorVersion: 0
+        });
+
+        expect(
+            Library.createFromUberName('H5P.Example 1.0', {
+                useHyphen: true,
+                useWhitespace: true
+            })
+        ).toMatchObject({
+            machineName: 'H5P.Example',
+            majorVersion: 1,
+            minorVersion: 0
+        });
+
+        expect(() => {
+            Library.createFromUberName('H5P.Example-1.0', {
+                useHyphen: false,
+                useWhitespace: false
+            });
+        }).toThrow();
+    });
+});


### PR DESCRIPTION
The reason why the content type "Column" didn't work as reported in #159 was that some libraries weren't installed, but used in Column. This broke the editor server.

I've fixed the issue and also centeralized the parsing of "uberNames".