### PR TITLE
Typescript references now also work in tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ npm-debug.log*
 
 # Compiled files
 build
+build-ide
 h5p
 coverage
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "scripts": {
         "start": "node examples/express.js",
         "prepare": "npm run download:content-type-cache && npm run download:content && npm run download:core && npm run build",
-        "build": "./node_modules/.bin/tsc && cp -r src/schemas build/src/schemas && cp -r src/translations build/src/translations",
+        "build": "npx tsc -p ./tsconfig.build.json && cp -r src/schemas build/src/schemas && cp -r src/translations build/src/translations",
         "uninstall": "rm -rf node_modules && rm -rf test/data/hub-content && rm test/data/content-type-cache/real-content-types.json && rm -rf h5p && rm -rf build",
         "download:content": "node scripts/download-examples.js test/data/content-type-cache/real-content-types.json test/data/hub-content",
         "download:core": "sh scripts/install.sh",

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,16 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "emitDecoratorMetadata": true,
+        "esModuleInterop": true,
+        "experimentalDecorators": true,
+        "removeComments": false,
+        "noImplicitAny": false,
+        "allowJs": true,
+        "sourceMap": true,
+        "baseUrl": "./",
+        "resolveJsonModule": true
+    },
+    "exclude": ["node_modules"]
+}

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,7 @@
+{
+    "extends": "./tsconfig.base.json",
+    "include": ["src/**/*.ts"],
+    "compilerOptions": {
+        "outDir": "./build"
+    }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,18 +1,7 @@
 {
+    "extends": "./tsconfig.base.json",    
+    "include": ["src/**/*.ts", "test/**/*.ts", "examples/**/*.ts"],
     "compilerOptions": {
-        "module": "commonjs",
-        "moduleResolution": "node",
-        "emitDecoratorMetadata": true,
-        "esModuleInterop": true,
-        "experimentalDecorators": true,
-        "removeComments": false,
-        "noImplicitAny": false,
-        "allowJs": true,
-        "sourceMap": true,
-        "baseUrl": "./",
-        "outDir": "./build",
-        "resolveJsonModule": true
-    },
-    "include": ["src/**/*"],
-    "exclude": ["node_modules"]
+        "outDir": "./build-ide"
+    }
 }


### PR DESCRIPTION
This PR solves the problem mentioned in https://github.com/Lumieducation/H5P-Nodejs-library/pull/156 that TS references don't work across the ```test``` and ```src``` directory. Now IDEs will resolve references across these directories (for ts files, references in ```express.js``` can't be resolved):

- src
- test
- examples

The approach I took was the one explained in [the accepted answer here](https://stackoverflow.com/questions/35470511/setting-up-tsconfig-with-spec-test-folder): I've split up the old tsconfig.files into a base file that includes all common settings, one file that the IDE uses (tsconfig.json) and one that the npm build script uses (tsconfig.build.json). The tsconfig.json has its own ```outDir```, which is used in case somebody runs tsc directly.

Now TSLint also works in the test directory!