### PR TITLE
Allow undefined preloadedDependencies for libraries (closes #164)

### DIFF
--- a/src/H5PEditor.ts
+++ b/src/H5PEditor.ts
@@ -487,7 +487,7 @@ export default class H5PEditor {
                         mainLibrary: library.machineName,
                         preloadedDependencies: [
                             ...contentDependencies,
-                            ...library.preloadedDependencies,
+                            ...(library.preloadedDependencies || []), // empty array should preloadedDependencies be undefined
                             {
                                 machineName: library.machineName,
                                 majorVersion: library.majorVersion,

--- a/src/Library.ts
+++ b/src/Library.ts
@@ -27,7 +27,7 @@ export default class Library implements IDependency {
     public majorVersion: number;
     public minorVersion: number;
     public patchVersion: number;
-    public preloadedDependencies: IDependency[];
+    public preloadedDependencies?: IDependency[];
     public restricted: boolean;
     public runnable: boolean;
     public title: string;


### PR DESCRIPTION
The PR is a minor fix to get libraries without preloadedDependencies working.