### PR TITLE
refactor(H5PEditor)!: Moved user from constructor of H5PEditor to method calls (closes issue 158)

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,7 +399,7 @@ Requests available content types. Respond with
 
 ```js
 h5pEditor
-    .getContentTypeCache()
+    .getContentTypeCache(user)
     .then(types => /** send types to browser **/)
 ```
 
@@ -458,8 +458,8 @@ Requests for the given library to be installed. Handle with
 
 ```js
 h5pEditor
-    .installLibrary(libraryId)
-    .then(() => h5pEditor.getContentTypeCache())
+    .installLibrary(libraryId, user)
+    .then(() => h5pEditor.getContentTypeCache(user))
     .then(contentTypeCache => ({ success: true, data: contentTypeCache }))
     .then(response => /** send response to browser **/)
 ```
@@ -473,10 +473,10 @@ is used to upload a `.h5p` file, and install the containing libraries and conten
 Handle with
 
 ```js
-h5pEditor.uploadPackage(query.contentId, files.h5p.data)
+h5pEditor.uploadPackage(query.contentId, files.h5p.data, user)
     .then(() => Promise.all([
         h5pEditor.loadH5P(query.contentId),
-        h5pEditor.getContentTypeCache()
+        h5pEditor.getContentTypeCache(user)
     ]))
     .then(([content, contentTypes]) => ({
         success: true,

--- a/examples/express.js
+++ b/examples/express.js
@@ -10,11 +10,16 @@ const index = require('./index');
 const H5PEditor = require('../');
 const H5PPlayer = H5PEditor.Player;
 
-const InMemoryStorage = require('../build/examples/implementation/InMemoryStorage').default;
-const JsonStorage = require('../build/examples/implementation/JsonStorage').default;
-const EditorConfig = require('../build/examples/implementation/EditorConfig').default;
-const FileLibraryStorage = require('../build/examples/implementation/FileLibraryStorage').default;
-const FileContentStorage = require('../build/examples/implementation/FileContentStorage').default;
+const InMemoryStorage = require('../build/examples/implementation/InMemoryStorage')
+    .default;
+const JsonStorage = require('../build/examples/implementation/JsonStorage')
+    .default;
+const EditorConfig = require('../build/examples/implementation/EditorConfig')
+    .default;
+const FileLibraryStorage = require('../build/examples/implementation/FileLibraryStorage')
+    .default;
+const FileContentStorage = require('../build/examples/implementation/FileContentStorage')
+    .default;
 const User = require('../build/examples/implementation/User').default;
 
 const examples = require('./examples.json');
@@ -33,9 +38,10 @@ const start = async () => {
         ).load(),
         new FileLibraryStorage(`${path.resolve('')}/h5p/libraries`),
         new FileContentStorage(`${path.resolve('')}/h5p/content`),
-        new User(),
         new H5PEditor.TranslationService(H5PEditor.englishStrings)
     );
+
+    const user = new User();
 
     const server = express();
 
@@ -170,7 +176,7 @@ const start = async () => {
 
         switch (action) {
             case 'content-type-cache':
-                h5pEditor.getContentTypeCache().then(contentTypeCache => {
+                h5pEditor.getContentTypeCache(user).then(contentTypeCache => {
                     res.status(200).json(contentTypeCache);
                 });
                 break;
@@ -241,8 +247,8 @@ const start = async () => {
                 break;
 
             case 'library-install':
-                h5pEditor.installLibrary(req.query.id).then(() =>
-                    h5pEditor.getContentTypeCache().then(contentTypeCache => {
+                h5pEditor.installLibrary(req.query.id, user).then(() =>
+                    h5pEditor.getContentTypeCache(user).then(contentTypeCache => {
                         res.status(200).json({
                             success: true,
                             data: contentTypeCache
@@ -253,11 +259,15 @@ const start = async () => {
 
             case 'library-upload':
                 h5pEditor
-                    .uploadPackage(req.files.h5p.data, req.query.contentId)
+                    .uploadPackage(
+                        req.files.h5p.data,
+                        req.query.contentId,
+                        user
+                    )
                     .then(contentId =>
                         Promise.all([
                             h5pEditor.loadH5P(contentId),
-                            h5pEditor.getContentTypeCache()
+                            h5pEditor.getContentTypeCache(user)
                         ]).then(([content, contentTypes]) =>
                             res.status(200).json({
                                 success: true,

--- a/src/H5PEditor.ts
+++ b/src/H5PEditor.ts
@@ -49,7 +49,6 @@ export default class H5PEditor {
         config: IEditorConfig,
         libraryStorage: ILibraryStorage,
         contentStorage: IContentStorage,
-        user: IUser,
         translationService: TranslationService
     ) {
         this.renderer = defaultRenderer;
@@ -66,12 +65,10 @@ export default class H5PEditor {
             keyValueStorage,
             this.libraryManager,
             config,
-            user,
             translationService
         );
         this.translationService = translationService;
         this.config = config;
-        this.user = user;
         this.packageImporter = new PackageImporter(
             this.libraryManager,
             this.translationService,
@@ -94,10 +91,9 @@ export default class H5PEditor {
     private renderer: any;
     private translation: any;
     private translationService: TranslationService;
-    private user: any;
 
-    public getContentTypeCache(): Promise<any> {
-        return this.contentTypeRepository.get();
+    public getContentTypeCache(user: IUser): Promise<any> {
+        return this.contentTypeRepository.get(user);
     }
 
     public getLibraryData(
@@ -203,8 +199,8 @@ export default class H5PEditor {
      * @param {string} id The name of the content type to install (e.g. H5P.Test-1.0)
      * @returns {Promise<true>} true if successful. Will throw errors if something goes wrong.
      */
-    public async installLibrary(id: string): Promise<boolean> {
-        return this.contentTypeRepository.install(id);
+    public async installLibrary(id: string, user: IUser): Promise<boolean> {
+        return this.contentTypeRepository.install(id, user);
     }
 
     public loadH5P(
@@ -289,7 +285,8 @@ export default class H5PEditor {
      */
     public async uploadPackage(
         data: Buffer,
-        contentId: ContentId
+        contentId: ContentId,
+        user: IUser
     ): Promise<ContentId> {
         const dataStream: any = new stream.PassThrough();
         dataStream.end(data);
@@ -311,7 +308,7 @@ export default class H5PEditor {
 
                 newContentId = await this.packageImporter.addPackageLibrariesAndContent(
                     tempPackagePath,
-                    this.user,
+                    user,
                     contentId
                 );
             },

--- a/test/ContentTypeInformationRepository.test.ts
+++ b/test/ContentTypeInformationRepository.test.ts
@@ -42,10 +42,9 @@ describe('Content type information repository (= connection to H5P Hub)', () => 
             storage,
             libManager,
             config,
-            new User(),
             new TranslationService({})
         );
-        const content = await repository.get();
+        const content = await repository.get(new User());
         expect(content.outdated).toBe(false);
         expect(content.libraries.length).toEqual(
             require('./data/content-type-cache/real-content-types.json')
@@ -75,10 +74,9 @@ describe('Content type information repository (= connection to H5P Hub)', () => 
             storage,
             libManager,
             config,
-            new User(),
             new TranslationService({})
         );
-        const content = await repository.get();
+        const content = await repository.get(new User());
         expect(content.outdated).toBe(false);
         expect(content.libraries.length).toEqual(
             require('./data/content-type-cache/real-content-types.json')
@@ -109,10 +107,9 @@ describe('Content type information repository (= connection to H5P Hub)', () => 
             storage,
             libManager,
             config,
-            new User(),
             new TranslationService({})
         );
-        const content = await repository.get();
+        const content = await repository.get(new User());
         expect(content.libraries.length).toEqual(2);
     });
 
@@ -139,10 +136,9 @@ describe('Content type information repository (= connection to H5P Hub)', () => 
             storage,
             libManager,
             config,
-            new User(),
             new TranslationService({})
         );
-        const content = await repository.get();
+        const content = await repository.get(new User());
         expect(content.libraries.length).toEqual(2);
         expect(content.libraries[0].installed).toEqual(true);
         expect(content.libraries[0].isUpToDate).toEqual(false);
@@ -166,10 +162,9 @@ describe('Content type information repository (= connection to H5P Hub)', () => 
             storage,
             libManager,
             config,
-            new User(),
             new TranslationService({})
         );
-        const content = await repository.get();
+        const content = await repository.get(new User());
         expect(content.libraries.length).toEqual(2);
     });
 
@@ -196,10 +191,9 @@ describe('Content type information repository (= connection to H5P Hub)', () => 
             storage,
             libManager,
             config,
-            user,
             new TranslationService({})
         );
-        const content = await repository.get();
+        const content = await repository.get(user);
         expect(content.libraries.length).toEqual(2);
         expect(
             content.libraries.find(l => l.machineName === 'H5P.Example1')
@@ -236,17 +230,16 @@ describe('Content type information repository (= connection to H5P Hub)', () => 
             storage,
             libManager,
             config,
-            new User(),
             new TranslationService({
                 'hub-install-invalid-content-type':
                     'hub-install-invalid-content-type',
                 'hub-install-no-content-type': 'hub-install-no-content-type'
             })
         );
-        await expect(repository.install(undefined)).rejects.toThrow(
+        await expect(repository.install(undefined, new User())).rejects.toThrow(
             'hub-install-no-content-type'
         );
-        await expect(repository.install('asd')).rejects.toThrow(
+        await expect(repository.install('asd', new User())).rejects.toThrow(
             'hub-install-invalid-content-type'
         );
     });
@@ -277,7 +270,6 @@ describe('Content type information repository (= connection to H5P Hub)', () => 
             storage,
             libManager,
             config,
-            user,
             new TranslationService({
                 'hub-install-denied': 'hub-install-denied'
             })
@@ -285,14 +277,14 @@ describe('Content type information repository (= connection to H5P Hub)', () => 
 
         user.canInstallRecommended = false;
         user.canUpdateAndInstallLibraries = false;
-        await expect(repository.install('H5P.Blanks')).rejects.toThrow(
+        await expect(repository.install('H5P.Blanks', user)).rejects.toThrow(
             'hub-install-denied'
         );
 
         user.canInstallRecommended = true;
         user.canUpdateAndInstallLibraries = false;
         await expect(
-            repository.install('H5P.ImageHotspotQuestion')
+            repository.install('H5P.ImageHotspotQuestion', user)
         ).rejects.toThrow('hub-install-denied');
     });
 
@@ -327,13 +319,12 @@ describe('Content type information repository (= connection to H5P Hub)', () => 
                     storage,
                     libManager,
                     config,
-                    user,
                     new TranslationService({})
                 );
 
                 axiosMock.restore(); // TODO: It would be nicer if the download of the Hub File could be mocked as well, but this is not possible as axios-mock-adapter doesn't support stream yet ()
                 await expect(
-                    repository.install('H5P.DragText')
+                    repository.install('H5P.DragText', user)
                 ).resolves.toEqual(true);
                 const libs = await libManager.getInstalled();
                 expect(Object.keys(libs).length).toEqual(11); // TODO: must be adapted to changes in the Hub file

--- a/test/getLibraryData.test.ts
+++ b/test/getLibraryData.test.ts
@@ -4,7 +4,7 @@ import LibraryManager from '../src/LibraryManager';
 
 describe('aggregating data from library folders for the editor', () => {
     it('returns empty data', () => {
-        const h5pEditor = new H5PEditor({}, null, null, null, null, null, null);
+        const h5pEditor = new H5PEditor({}, null, null, null, null, null);
         const libraryManager = new LibraryManager(new FileLibraryStorage(''));
 
         Object.assign(libraryManager, {
@@ -37,7 +37,7 @@ describe('aggregating data from library folders for the editor', () => {
     });
 
     it('includes the semantics.json content', () => {
-        const h5pEditor = new H5PEditor({}, null, null, null, null, null, null);
+        const h5pEditor = new H5PEditor({}, null, null, null, null, null);
         const libraryManager = new LibraryManager(new FileLibraryStorage(''));
 
         Object.assign(libraryManager, {
@@ -73,7 +73,6 @@ describe('aggregating data from library folders for the editor', () => {
     it('includes assets of preloaded and editor dependencies', () => {
         const h5pEditor = new H5PEditor(
             { baseUrl: '/h5p' },
-            null,
             null,
             null,
             null,
@@ -163,7 +162,6 @@ describe('aggregating data from library folders for the editor', () => {
     it('includes dependencies of dependencies in the javascript field', () => {
         const h5pEditor = new H5PEditor(
             { baseUrl: '/h5p' },
-            null,
             null,
             null,
             null,
@@ -260,7 +258,7 @@ describe('aggregating data from library folders for the editor', () => {
             return Promise.resolve({ arbitrary: 'languageObject' });
         }) as jest.Mocked<any>;
 
-        const h5pEditor = new H5PEditor({}, null, null, null, null, null, null);
+        const h5pEditor = new H5PEditor({}, null, null, null, null, null);
         const libraryManager = new LibraryManager(new FileLibraryStorage(''));
 
         Object.assign(libraryManager, {
@@ -329,7 +327,7 @@ describe('aggregating data from library folders for the editor', () => {
             return Promise.resolve(['array', 'with', 'languages']);
         }) as jest.Mock<any>;
 
-        const h5pEditor = new H5PEditor({}, null, null, null, null, null, null);
+        const h5pEditor = new H5PEditor({}, null, null, null, null, null);
         const libraryManager = new LibraryManager(new FileLibraryStorage(''));
 
         Object.assign(libraryManager, {
@@ -394,7 +392,6 @@ describe('aggregating data from library folders for the editor', () => {
     it('lists dependencies in correct order', () => {
         const h5pEditor = new H5PEditor(
             { baseUrl: '/h5p' },
-            null,
             null,
             null,
             null,

--- a/test/getLibraryOverview.test.ts
+++ b/test/getLibraryOverview.test.ts
@@ -1,7 +1,6 @@
 import path from 'path';
 import FileLibraryStorage from '../examples/implementation/FileLibraryStorage';
 import H5PEditor from '../src/H5PEditor';
-import LibraryManager from '../src/LibraryManager';
 
 describe('getting overview about multiple libraries', () => {
     it('returns basic information about single library', () => {
@@ -10,7 +9,6 @@ describe('getting overview about multiple libraries', () => {
             null,
             null,
             new FileLibraryStorage(path.resolve('test/data/libraries')),
-            null,
             null,
             null
         )
@@ -38,7 +36,6 @@ describe('getting overview about multiple libraries', () => {
             null,
             null,
             new FileLibraryStorage(path.resolve('test/data/libraries')),
-            null,
             null,
             null
         )


### PR DESCRIPTION
This PR removes the user from the constructor of H5PEditor and ContenTypeInformationRepository. Intead the user must be passed directly to the methods that require a user object now. This change is necessary as I originally added the user object to the constructors when I imitated how the PHP library works. However, the PHP library constructs new objects per session, but our H5PEditor and ContentTypeInformationRepository objects exist as long as the server is running. This means that each method call can be from a different user and the user must be passed to each method call.

This obviously means introducing breaking changes, as the signature of H5PEditor is changed. I've updated the docs accordingly.