### PR TITLE
feat(example): added link to example player to download packages

### DIFF
--- a/examples/express.js
+++ b/examples/express.js
@@ -10,11 +10,16 @@ const index = require('./index');
 const H5PEditor = require('../');
 const H5PPlayer = H5PEditor.Player;
 
-const InMemoryStorage = require('../build/examples/implementation/InMemoryStorage').default;
-const JsonStorage = require('../build/examples/implementation/JsonStorage').default;
-const EditorConfig = require('../build/examples/implementation/EditorConfig').default;
-const FileLibraryStorage = require('../build/examples/implementation/FileLibraryStorage').default;
-const FileContentStorage = require('../build/examples/implementation/FileContentStorage').default;
+const InMemoryStorage = require('../build/examples/implementation/InMemoryStorage')
+    .default;
+const JsonStorage = require('../build/examples/implementation/JsonStorage')
+    .default;
+const EditorConfig = require('../build/examples/implementation/EditorConfig')
+    .default;
+const FileLibraryStorage = require('../build/examples/implementation/FileLibraryStorage')
+    .default;
+const FileContentStorage = require('../build/examples/implementation/FileContentStorage')
+    .default;
 const User = require('../build/examples/implementation/User').default;
 
 const examples = require('./examples.json');
@@ -104,6 +109,30 @@ const start = async () => {
                 .render(req.query.contentId, contentObject, h5pObject)
                 .then(h5p_page => res.end(h5p_page))
                 .catch(error => res.status(500).end(error.message))
+        );
+    });
+
+    server.get('/download', async (req, res) => {
+        if (!req.query.contentId) {
+            return res.redirect('/');
+        }
+
+        const packageExporter = new H5PEditor.PackageExporter(
+            h5pEditor.libraryManager,
+            h5pEditor.translationService,
+            h5pEditor.config,
+            h5pEditor.contentManager
+        );
+        
+        // set filename for the package with .h5p extension
+        res.setHeader(
+            'Content-disposition',
+            `attachment; filename=${req.query.contentId}.h5p`
+        );
+        await packageExporter.createPackage(
+            req.query.contentId,
+            res,
+            new User()
         );
     });
 

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ module.exports = {
     TranslationService: require('./build/src/TranslationService').default,
     Editor: require('./build/src/H5PEditor').default,
     englishStrings: require('./build/src/translations/translations/en.json'),
+    PackageExporter: require('./build/src/PackageExporter').default,
     Player: require('./build/src/H5PPlayer').default,
     Library: require('./build/src/Library').default
 };

--- a/src/H5PEditor.ts
+++ b/src/H5PEditor.ts
@@ -46,11 +46,11 @@ export default class H5PEditor {
             libraryUrl: '/h5p/editor/'
         },
         keyValueStorage: IKeyValueStorage,
-        config: IEditorConfig,
+        public config: IEditorConfig,
         libraryStorage: ILibraryStorage,
         contentStorage: IContentStorage,
-        user: IUser,
-        translationService: TranslationService
+        private user: IUser,
+        public translationService: TranslationService
     ) {
         this.renderer = defaultRenderer;
         this.baseUrl = urls.baseUrl;
@@ -69,9 +69,6 @@ export default class H5PEditor {
             user,
             translationService
         );
-        this.translationService = translationService;
-        this.config = config;
-        this.user = user;
         this.packageImporter = new PackageImporter(
             this.libraryManager,
             this.translationService,
@@ -84,7 +81,6 @@ export default class H5PEditor {
 
     private ajaxPath: string;
     private baseUrl: string;
-    private config: IEditorConfig;
     private contentManager: ContentManager;
     private contentTypeCache: ContentTypeCache;
     private contentTypeRepository: ContentTypeInformationRepository;
@@ -93,8 +89,6 @@ export default class H5PEditor {
     private packageImporter: PackageImporter;
     private renderer: any;
     private translation: any;
-    private translationService: TranslationService;
-    private user: any;
 
     public getContentTypeCache(): Promise<any> {
         return this.contentTypeRepository.get();

--- a/src/H5PPlayer.ts
+++ b/src/H5PPlayer.ts
@@ -17,6 +17,7 @@ export default class H5PPlayer {
         libraryLoader: ILibraryLoader,
         urls: {
             baseUrl?: string;
+            downloadUrl?: string;
             libraryUrl?: string;
             scriptUrl?: string;
             stylesUrl?: string;
@@ -35,6 +36,7 @@ export default class H5PPlayer {
 
         this.urls = {
             baseUrl: '/h5p',
+            downloadUrl: '/download',
             libraryUrl: `/h5p/libraries`,
             scriptUrl: `/h5p/core/js`,
             stylesUrl: `/h5p/core/styles`,
@@ -59,6 +61,7 @@ export default class H5PPlayer {
     private translation: any;
     private urls: {
         baseUrl?: string;
+        downloadUrl?: string;
         libraryUrl?: string;
         scriptUrl?: string;
         stylesUrl?: string;
@@ -125,6 +128,7 @@ export default class H5PPlayer {
         const model = {
             contentId,
             customScripts: this.customScripts,
+            downloadPath: this.generateDownloadPath(contentId),
             integration: this.generateIntegration(
                 contentId,
                 contentObject,
@@ -152,6 +156,10 @@ export default class H5PPlayer {
     public useRenderer(renderer: any): H5PPlayer {
         this.renderer = renderer;
         return this;
+    }
+
+    private generateDownloadPath(contentId: ContentId): string {
+        return `${this.urls.downloadUrl}?contentId=${contentId}`;
     }
 
     private loadAssets(

--- a/src/PackageExporter.ts
+++ b/src/PackageExporter.ts
@@ -6,7 +6,6 @@ import yazl from 'yazl';
 import ContentManager from './ContentManager';
 import DependencyGetter from './DependencyGetter';
 import H5pError from './helpers/H5pError';
-import Library from './Library';
 import LibraryManager from './LibraryManager';
 import {
     ContentId,

--- a/src/renderers/player.ts
+++ b/src/renderers/player.ts
@@ -16,5 +16,6 @@ export default model => `<!doctype html>
 </head>
 <body>
     <div class="h5p-content" data-content-id="${model.contentId}"></div>
+    <a href="${model.downloadPath}">Download</button>
 </body>
 </html>`;

--- a/test/H5PPlayer.renderHtmlPage.test.ts
+++ b/test/H5PPlayer.renderHtmlPage.test.ts
@@ -85,6 +85,7 @@ describe('Rendering the HTML page', () => {
                 </head>
                 <body>
                     <div class="h5p-content" data-content-id="foo"></div>
+                    <a href="/download?contentId=foo">Download</button>
                 </body>
                 </html>`.replace(/ /g, '')
                 );
@@ -280,6 +281,7 @@ describe('Rendering the HTML page', () => {
                     </head>
                     <body>
                         <div class="h5p-content" data-content-id="foo"></div>
+                        <a href="/download?contentId=foo">Download</button>
                     </body>
                     </html>`.replace(/ /g, '')
                 );


### PR DESCRIPTION
With this PR, users can download H5P packages when they display them: I've added a link in the player that allows downloads using PackageExporter. In the future, this download link will have to be put into a proper frame ("reuse") and the server has to evaluate whether the user playing the content has download privileges, but for the time being this should be fine.