### PR TITLE
fix: remove deprecated h5p-editor.js (closes #188)

### DIFF
--- a/src/H5PEditor.ts
+++ b/src/H5PEditor.ts
@@ -378,8 +378,7 @@ export default class H5PEditor {
             '/editor/scripts/h5peditor-metadata-author-widget.js',
             '/editor/scripts/h5peditor-metadata-changelog-widget.js',
             '/editor/scripts/h5peditor-pre-save.js',
-            '/editor/ckeditor/ckeditor.js',
-            '/editor/wp/h5p-editor.js'
+            '/editor/ckeditor/ckeditor.js'
         ].map((file: string) => `${this.baseUrl}${file}`);
     }
 


### PR DESCRIPTION
/editor/wp/h5p-editor.js was the client-side implementation of the editor. It initialized the editor via new ns.Editor(undefined, undefined, $editor[0]); which is now done in the default renderer.