### PR TITLE
ci(config): remove build-stage and rename install to install+build (closes #182)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2
 jobs:
-    install:
+    install+build:
         docker:
             - image: circleci/node:10-browsers-legacy
         steps:
@@ -12,19 +12,6 @@ jobs:
                   key: dependency-cache-{{ checksum "package.json" }}
                   paths:
                       - ./node_modules
-    build:
-        docker:
-            - image: circleci/node:10-browsers-legacy
-        steps:
-            - checkout
-            - restore_cache: # special step to restore the dependency cache
-                  key: dependency-cache-{{ checksum "package.json" }}
-            - run: npm ci
-            - save_cache: # special step to save the dependency cache
-                  key: dependency-cache-{{ checksum "package.json" }}
-                  paths:
-                      - ./node_modules
-            - run: npm run build
     lint:
         docker:
             - image: circleci/node:10-browsers-legacy
@@ -81,10 +68,7 @@ workflows:
     version: 2
     h5peditor:
         jobs:
-            - install
-            - build:
-                  requires:
-                      - install
+            - install+build
             - lint
             - format
             - unit-tests


### PR DESCRIPTION
Hey,

as discussed in #192 I removed the build-stage and renamed the install-stage to install+build, so the build is not executed twice.