### PR TITLE
feat: Reduced redudant core api versions and added documentation on core updates

### DIFF
--- a/assets/default_editor_integration.json
+++ b/assets/default_editor_integration.json
@@ -588,6 +588,5 @@
         "css": [],
         "js": []
     },
-    "deleteMessage": "Are you sure you wish to delete this content?",
-    "apiVersion": { "majorVersion": 1, "minorVersion": 19 }
+    "deleteMessage": "Are you sure you wish to delete this content?"
 }

--- a/docs/core-updates.md
+++ b/docs/core-updates.md
@@ -1,0 +1,16 @@
+# Updating the H5P Core
+
+## Introduction
+This library uses components of the "regular" H5P libraries to display the editor and the player. For this purpose, the JavaScript and CSS files that make up the JavasScript client (which is run in the browser) are copied over from Joubel's PHP implementation upon ```npm install```. 
+
+As newer content type versions typically as require a new core version, we need to regularly update the references to the core files.
+
+## Steps
+
+1. Change the script in ```scripts/install.sh``` to download the new H5P versions from GitHub
+2. Change the values of these properties of the editor configuration object (e.g. ```examples/implementation/EditorConfig.ts```):
+   - ```coreApiVersion``` (put in the version H5P now uses in the downloaded core files; typically the version of h5p-editor-php-library without patch version, e.g. 1.24)
+   - ```h5pVersion``` (put in the version of the PHP libraries themselves (includes patch version, e.g.: 1.24.1))
+3. Change the README to reflect the new versions (download links to GitHub)
+4. Check if there are new JavaScript files in the core that are required to run the editor or the player. Add them to the ```H5PPlayer.coreScripts()``` or ```H5PEditor.coreScripts()``` methods in the respective files. 
+5. Run all tests (including test:integration) to check if the everything still works as expected. (for example, inserting scripts might break tests)

--- a/examples/implementation/EditorConfig.ts
+++ b/examples/implementation/EditorConfig.ts
@@ -61,7 +61,7 @@ export default class EditorConfig implements IEditorConfig {
      * It is sent to the H5P Hub when registering there.
      * Not user-configurable and should not be changed by custom implementations.
      */
-    public h5pVersion: string = '1.24';
+    public h5pVersion: string = '1.24.0';
 
     /**
      * Called to fetch information about the content types available at the H5P Hub.

--- a/src/H5PEditor.ts
+++ b/src/H5PEditor.ts
@@ -472,6 +472,10 @@ export default class H5PEditor {
         return {
             ...defaultEditorIntegration,
             ajaxPath: this.ajaxPath,
+            apiVersion: {
+                majorVersion: this.config.coreApiVersion.major,
+                minorVersion: this.config.coreApiVersion.minor
+            },
             assets: {
                 css: [
                     '/core/styles/h5p.css',

--- a/src/types.ts
+++ b/src/types.ts
@@ -130,6 +130,7 @@ export interface IIntegration {
  */
 export interface IEditorIntegration {
     ajaxPath: string;
+    apiVersion: { majorVersion: number; minorVersion: number };
     assets: {
         css: string[];
         js: string[];
@@ -864,6 +865,7 @@ export interface IEditorConfig {
     filesPath: string;
     /**
      * This is the version of the PHP implementation that the NodeJS implementation imitates.
+     * Can be anything like 1.22.1
      * It is sent to the H5P Hub when registering there.
      * Not user-configurable and should not be changed by custom implementations.
      */


### PR DESCRIPTION
I've removed the hardcoded core API in ```default_editor_integration.json``` (see #92) and added documentation on how to update the core files (for future use).