### PR TITLE
ci(config): add integration-tests to workflow (closes #228)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,3 +86,4 @@ workflows:
             - format
             - unit-tests
             - player-e2e-test
+            - integration-tests


### PR DESCRIPTION
Hey,

I think you (@sr258 ) forgot to add the `integration-tests` to the circleci workflow. This is why they did not run.