### PR TITLE
fix(h5p-editor): Improved error messages

### DIFF
--- a/src/ContentStorer.ts
+++ b/src/ContentStorer.ts
@@ -5,9 +5,8 @@ import { ContentFileScanner, IFileReference } from './ContentFileScanner';
 import ContentManager from './ContentManager';
 import Logger from './helpers/Logger';
 import LibraryManager from './LibraryManager';
-import LibraryName from './LibraryName';
 import TemporaryFileManager from './TemporaryFileManager';
-import { ContentId, IContentMetadata, IUser } from './types';
+import { ContentId, IContentMetadata, ILibraryName, IUser } from './types';
 
 const log = new Logger('ContentStorer');
 
@@ -32,14 +31,14 @@ export default class ContentStorer {
      * @param contentId the contentId (can be undefined if previously unsaved)
      * @param parameters the parameters of teh content (= content.json)
      * @param metadata = content of h5p.json
-     * @param mainLibraryUberName use whitespace as separated (e.g. H5P.Example 1.0)
+     * @param mainLibraryName the library name
      * @param user the user who wants to save the file
      */
     public async saveOrUpdateContent(
         contentId: ContentId,
         parameters: any,
         metadata: IContentMetadata,
-        mainLibraryUberName: string,
+        mainLibraryName: ILibraryName,
         user: IUser
     ): Promise<ContentId> {
         const isUpdate = contentId !== undefined;
@@ -55,9 +54,7 @@ export default class ContentStorer {
         // were deleted in the editor by the user.
         const fileReferencesInNewParams = await this.contentFileScanner.scanForFiles(
             parameters,
-            LibraryName.fromUberName(mainLibraryUberName, {
-                useWhitespace: true
-            })
+            mainLibraryName
         );
         const filesToCopyFromTemporaryStorage = await this.determineFilesToCopyFromTemporaryStorage(
             fileReferencesInNewParams,

--- a/src/ContentTypeInformationRepository.ts
+++ b/src/ContentTypeInformationRepository.ts
@@ -53,15 +53,6 @@ export default class ContentTypeInformationRepository {
     public async get(user: IUser): Promise<any> {
         log.info(`getting information about available content types`);
         let cachedHubInfo = await this.contentTypeCache.get();
-        if (!cachedHubInfo) {
-            // try updating cache if it is empty for some reason
-            await this.contentTypeCache.updateIfNecessary();
-            cachedHubInfo = await this.contentTypeCache.get();
-        }
-        if (!cachedHubInfo) {
-            // if the H5P Hub is unreachable use empty array (so that local libraries can be added)
-            cachedHubInfo = [];
-        }
         cachedHubInfo = await this.addUserAndInstallationSpecificInfo(
             cachedHubInfo,
             user

--- a/src/H5PEditor.ts
+++ b/src/H5PEditor.ts
@@ -384,9 +384,19 @@ export default class H5PEditor {
             log.info('saving new content');
         }
 
+        // validate library name
+        let parsedLibraryName: ILibraryName;
+        try {
+            parsedLibraryName = LibraryName.fromUberName(mainLibraryName, {
+                useWhitespace: true
+            });
+        } catch (error) {
+            throw new H5pError(`mainLibraryName is invalid: ${error.message}`);
+        }
+
         const h5pJson: IContentMetadata = await this.generateH5PJSON(
             metadata,
-            mainLibraryName,
+            parsedLibraryName,
             this.findLibraries(parameters)
         );
 
@@ -394,7 +404,7 @@ export default class H5PEditor {
             contentId,
             parameters,
             h5pJson,
-            mainLibraryName,
+            parsedLibraryName,
             user
         );
         return newContentId;
@@ -603,17 +613,13 @@ export default class H5PEditor {
 
     private generateH5PJSON(
         metadata: IContentMetadata,
-        libraryName: string,
+        libraryName: ILibraryName,
         contentDependencies: ILibraryName[] = []
     ): Promise<IContentMetadata> {
         log.info(`generating h5p.json`);
         return new Promise((resolve: (value: IContentMetadata) => void) => {
             this.libraryManager
-                .loadLibrary(
-                    LibraryName.fromUberName(libraryName, {
-                        useWhitespace: true
-                    })
-                )
+                .loadLibrary(libraryName)
                 .then((library: InstalledLibrary) => {
                     const h5pJson: IContentMetadata = {
                         ...metadata,

--- a/src/LibraryManager.ts
+++ b/src/LibraryManager.ts
@@ -78,7 +78,9 @@ export default class LibraryManager {
      * @returns {Promise<any>} An object which has properties with the existing library machine names. The properties'
      * values are arrays of Library objects, which represent the different versions installed of this library.
      */
-    public async getInstalled(machineNames?: string[]): Promise<any> {
+    public async getInstalled(
+        machineNames?: string[]
+    ): Promise<{ [key: string]: IInstalledLibrary[] }> {
         log.verbose(`checking if libraries ${machineNames} are installed`);
         let libraries = await this.libraryStorage.getInstalled(...machineNames);
         libraries = (
@@ -199,6 +201,25 @@ export default class LibraryManager {
             }
         }
         return false;
+    }
+
+    /**
+     * Checks if a library was installed.
+     * @param library the library to check
+     * @returns true if the library has been installed
+     */
+    public async libraryExists(library: LibraryName): Promise<boolean> {
+        const installed = await this.getInstalled([library.machineName]);
+        if (!installed || !installed[library.machineName]) {
+            return false;
+        }
+        return (
+            installed[library.machineName].find(
+                l =>
+                    l.majorVersion === library.majorVersion &&
+                    l.minorVersion === l.minorVersion
+            ) !== undefined
+        );
     }
 
     /**

--- a/src/LibraryName.ts
+++ b/src/LibraryName.ts
@@ -38,10 +38,21 @@ export default class LibraryName implements ILibraryName {
                 ? /([^\s]+)-(\d+)\.(\d+)/
                 : /([^\s]+)\s(\d+)\.(\d+)/;
 
-        const result: RegExpExecArray = nameRegex.exec(libraryName);
+        const result = nameRegex.exec(libraryName);
 
         if (!result) {
-            return undefined;
+            let example = '';
+            if (options.useHyphen && options.useWhitespace) {
+                example = 'H5P.Example-1.0 or H5P.Example 1.0';
+            } else if (options.useHyphen && !options.useWhitespace) {
+                example = 'H5P.Example-1.0';
+            } else {
+                example = 'H5P.Example 1.0';
+            }
+
+            throw new Error(
+                `'${libraryName} is not a valid H5P library name ("ubername"). You must follow this pattern: ${example}'`
+            );
         }
 
         return new LibraryName(

--- a/test/ContentTypeCache.test.ts
+++ b/test/ContentTypeCache.test.ts
@@ -51,7 +51,7 @@ describe('getting H5P Hub content types', () => {
         const cache = new ContentTypeCache(config, storage);
 
         const cached = await cache.get();
-        expect(cached).toBeUndefined();
+        expect(cached).toEqual([]);
     });
     it('loads content type information from the H5P Hub', async () => {
         const storage = new InMemoryStorage();

--- a/test/H5PEditor.getLibraryData.test.ts
+++ b/test/H5PEditor.getLibraryData.test.ts
@@ -1,3 +1,5 @@
+import { withDir } from 'tmp-promise';
+
 import EditorConfig from '../examples/implementation/EditorConfig';
 import FileLibraryStorage from '../examples/implementation/FileLibraryStorage';
 import H5PEditor from '../src/H5PEditor';
@@ -17,6 +19,7 @@ describe('aggregating data from library folders for the editor', () => {
         const libraryManager = new LibraryManager(new FileLibraryStorage(''));
 
         Object.assign(libraryManager, {
+            libraryExists: () => Promise.resolve(true),
             listLanguages: () => Promise.resolve([]),
             loadLanguage: () => Promise.resolve(null),
             loadLibrary: () => {
@@ -59,6 +62,7 @@ describe('aggregating data from library folders for the editor', () => {
         const libraryManager = new LibraryManager(new FileLibraryStorage(''));
 
         Object.assign(libraryManager, {
+            libraryExists: () => Promise.resolve(true),
             listLanguages: () => Promise.resolve([]),
             loadLanguage: () => Promise.resolve(null),
             loadLibrary: () => {
@@ -102,6 +106,7 @@ describe('aggregating data from library folders for the editor', () => {
         const libraryManager = new LibraryManager(new FileLibraryStorage(''));
 
         Object.assign(libraryManager, {
+            libraryExists: () => Promise.resolve(true),
             listLanguages: () => Promise.resolve([]),
             loadLanguage: () => Promise.resolve(null),
             loadLibrary: ({ machineName }) => {
@@ -112,6 +117,7 @@ describe('aggregating data from library folders for the editor', () => {
                                 {
                                     machineName: 'EditorDependency',
                                     majorVersion: 1,
+
                                     minorVersion: 0
                                 }
                             ],
@@ -193,6 +199,7 @@ describe('aggregating data from library folders for the editor', () => {
         const libraryManager = new LibraryManager(new FileLibraryStorage(''));
 
         Object.assign(libraryManager, {
+            libraryExists: () => Promise.resolve(true),
             listLanguages: () => Promise.resolve([]),
             loadLanguage: () => Promise.resolve(null),
             loadLibrary: ({ machineName }) => {
@@ -292,6 +299,7 @@ describe('aggregating data from library folders for the editor', () => {
         const libraryManager = new LibraryManager(new FileLibraryStorage(''));
 
         Object.assign(libraryManager, {
+            libraryExists: () => Promise.resolve(true),
             listLanguages: () => Promise.resolve([]),
             loadLanguage,
             loadLibrary: ({ _machineName }) => {
@@ -369,6 +377,7 @@ describe('aggregating data from library folders for the editor', () => {
         const libraryManager = new LibraryManager(new FileLibraryStorage(''));
 
         Object.assign(libraryManager, {
+            libraryExists: () => Promise.resolve(true),
             listLanguages,
             loadLibrary: ({ _machineName }) => {
                 switch (_machineName) {
@@ -441,6 +450,7 @@ describe('aggregating data from library folders for the editor', () => {
         const libraryManager = new LibraryManager(new FileLibraryStorage(''));
 
         Object.assign(libraryManager, {
+            libraryExists: () => Promise.resolve(true),
             listLanguages: () => Promise.resolve([]),
             loadLanguage: () => Promise.resolve(null),
             loadLibrary: ({ machineName }) => {
@@ -545,5 +555,26 @@ describe('aggregating data from library folders for the editor', () => {
                 '/h5p/libraries/Foo-1.0/script.js'
             ]);
         });
+    });
+
+    it('throws a helpful error message when using an uninstalled library name', async () => {
+        await withDir(
+            async ({ path: tempDirPath }) => {
+                const h5pEditor = new H5PEditor(
+                    null,
+                    new EditorConfig(null),
+                    new FileLibraryStorage(tempDirPath),
+                    null,
+                    null,
+                    (library, name) => '',
+                    null
+                );
+
+                expect(h5pEditor.getLibraryData('Foo', 1, 2)).rejects.toThrow(
+                    'Library Foo-1.2 was not found.'
+                );
+            },
+            { keep: false, unsafeCleanup: true }
+        );
     });
 });

--- a/test/H5PEditor.saving.test.ts
+++ b/test/H5PEditor.saving.test.ts
@@ -574,4 +574,27 @@ describe('H5PEditor', () => {
             { keep: false, unsafeCleanup: true }
         );
     });
+
+    it('returns a helpful error if libraryName is invalid', async () => {
+        await withDir(
+            async ({ path: tempDirPath }) => {
+                const { h5pEditor } = createH5PEditor(tempDirPath);
+                const user = new User();
+
+                // save the content
+                await expect(
+                    h5pEditor.saveH5P(
+                        undefined,
+                        mockupParametersWithoutImage,
+                        mockupMetadata,
+                        'abc',
+                        user
+                    )
+                ).rejects.toThrowError(
+                    'mainLibraryName is invalid: \'abc is not a valid H5P library name ("ubername"). You must follow this pattern: H5P.Example 1.0\''
+                );
+            },
+            { keep: false, unsafeCleanup: true }
+        );
+    });
 });

--- a/test/H5PEditor.test.ts
+++ b/test/H5PEditor.test.ts
@@ -1,0 +1,77 @@
+import axios from 'axios';
+import axiosMockAdapter from 'axios-mock-adapter';
+
+import EditorConfig from '../examples/implementation/EditorConfig';
+import H5PEditor from '../src/H5PEditor';
+import TranslationService from '../src/TranslationService';
+
+import InMemoryStorage from '../examples/implementation/InMemoryStorage';
+import User from '../examples/implementation/User';
+
+describe('H5PEditor: general', () => {
+    const axiosMock = new axiosMockAdapter(axios);
+
+    it("updates ContentTypeCache if it hasn't been downloaded before", async () => {
+        const config = new EditorConfig(new InMemoryStorage());
+        const h5pEditor = new H5PEditor(
+            new InMemoryStorage(),
+            config,
+            null,
+            null,
+            new TranslationService({
+                'hub-install-invalid-content-type':
+                    'hub-install-invalid-content-type'
+            }),
+            (library, name) => '',
+            null
+        );
+
+        axiosMock
+            .onPost(config.hubRegistrationEndpoint)
+            .reply(200, require('./data/content-type-cache/registration.json'));
+        axiosMock
+            .onPost(config.hubContentTypesEndpoint)
+            .reply(
+                200,
+                require('./data/content-type-cache/1-content-type.json')
+            );
+
+        await expect(
+            h5pEditor.installLibrary('XYZ', new User())
+        ).rejects.toThrow('hub-install-invalid-content-type');
+    });
+
+    it("updates ContentTypeCache if it hasn't been downloaded before and tries installing", async () => {
+        const config = new EditorConfig(new InMemoryStorage());
+        const h5pEditor = new H5PEditor(
+            new InMemoryStorage(),
+            config,
+            null,
+            null,
+            new TranslationService({
+                'hub-install-invalid-content-type':
+                    'hub-install-invalid-content-type'
+            }),
+            (library, name) => '',
+            null
+        );
+
+        axiosMock
+            .onPost(config.hubRegistrationEndpoint)
+            .reply(200, require('./data/content-type-cache/registration.json'));
+        axiosMock
+            .onPost(config.hubContentTypesEndpoint)
+            .reply(
+                200,
+                require('./data/content-type-cache/1-content-type.json')
+            );
+        axiosMock
+            .onGet(`${config.hubContentTypesEndpoint}H5P.Example1`)
+            .reply(500);
+
+        // we check against the error message as we we've told axios to reply with 500 to requests to the Hub endpoint.
+        await expect(
+            h5pEditor.installLibrary('H5P.Example1', new User())
+        ).rejects.toThrow('Request failed with status code 500');
+    });
+});

--- a/test/LibraryName.test.ts
+++ b/test/LibraryName.test.ts
@@ -57,4 +57,29 @@ describe('Library model', () => {
             });
         }).toThrow();
     });
+
+    it("throws an error if an ubername can't be parsed", async () => {
+        expect(() => {
+            LibraryName.fromUberName('H5P.Test 0.1');
+        }).toThrow(
+            'H5P.Test 0.1 is not a valid H5P library name ("ubername"). You must follow this pattern: H5P.Example-1.0'
+        );
+
+        expect(() => {
+            LibraryName.fromUberName('H5P.Test-0.1', {
+                useWhitespace: true
+            });
+        }).toThrow(
+            'H5P.Test-0.1 is not a valid H5P library name ("ubername"). You must follow this pattern: H5P.Example 1.0'
+        );
+
+        expect(() => {
+            LibraryName.fromUberName('XYZ', {
+                useHyphen: true,
+                useWhitespace: true
+            });
+        }).toThrow(
+            'XYZ is not a valid H5P library name ("ubername"). You must follow this pattern: H5P.Example-1.0 or H5P.Example 1.0'
+        );
+    });
 });


### PR DESCRIPTION
Resolves #233, #234 and #235.

This is how #235 is fixed: When ContentTypeCache.get() is called it now automatically tries to contact the H5P Hub and downloads the content files if this hasn't been done before. If it can't reach the Hub, it simply returns an empty array.