### PR TITLE
feat(exports): Interfaces are now exported with type definitions

### DIFF
--- a/examples/implementation/DirectoryTemporaryFileStorage.ts
+++ b/examples/implementation/DirectoryTemporaryFileStorage.ts
@@ -3,8 +3,12 @@ import fsExtra from 'fs-extra';
 import path from 'path';
 import promisepipe from 'promisepipe';
 
-import H5pError from '../../src/helpers/H5pError';
-import { ITemporaryFile, ITemporaryFileStorage, IUser } from '../../src/types';
+import {
+    H5pError,
+    ITemporaryFile,
+    ITemporaryFileStorage,
+    IUser
+} from '../../src';
 
 /**
  * Stores temporary files in directories on the disk.
@@ -53,18 +57,20 @@ export default class DirectoryTemporaryFileStorage
 
     public async listFiles(user?: IUser): Promise<ITemporaryFile[]> {
         const users = user ? [user.id] : await fsExtra.readdir(this.directory);
-        return (await Promise.all(
-            users.map(async u => {
-                const filesOfUser = await fsExtra.readdir(
-                    path.join(this.directory, u)
-                );
-                return Promise.all(
-                    filesOfUser
-                        .filter(f => !f.endsWith('.metadata'))
-                        .map(f => this.getTemporaryFileInfo(f, u))
-                );
-            })
-        )).reduce((prev, curr) => prev.concat(curr), []);
+        return (
+            await Promise.all(
+                users.map(async u => {
+                    const filesOfUser = await fsExtra.readdir(
+                        path.join(this.directory, u)
+                    );
+                    return Promise.all(
+                        filesOfUser
+                            .filter(f => !f.endsWith('.metadata'))
+                            .map(f => this.getTemporaryFileInfo(f, u))
+                    );
+                })
+            )
+        ).reduce((prev, curr) => prev.concat(curr), []);
     }
 
     public async saveFile(

--- a/examples/implementation/EditorConfig.ts
+++ b/examples/implementation/EditorConfig.ts
@@ -1,4 +1,4 @@
-import { IEditorConfig, IKeyValueStorage } from '../../src/types';
+import { IEditorConfig, IKeyValueStorage } from '../../src';
 
 /**
  * Stores configuration options and literals that are used throughout the system.
@@ -53,7 +53,7 @@ export default class EditorConfig implements IEditorConfig {
 
     /**
      * This is where the client will look for image, video etc. files added to content.
-     * WARNING: Do not change the 'content' part of the URL, as the editor client assumes that it can find 
+     * WARNING: Do not change the 'content' part of the URL, as the editor client assumes that it can find
      * content under this path!
      */
     public filesPath: string = '/h5p/content';

--- a/examples/implementation/FileContentStorage.ts
+++ b/examples/implementation/FileContentStorage.ts
@@ -11,7 +11,7 @@ import {
     IContentStorage,
     IUser,
     Permission
-} from '../../src/types';
+} from '../../src';
 
 /**
  * Persists content to the disk.

--- a/examples/implementation/FileLibraryStorage.ts
+++ b/examples/implementation/FileLibraryStorage.ts
@@ -5,9 +5,14 @@ import path from 'path';
 import promisepipe from 'promisepipe';
 import { Stream } from 'stream';
 
-import InstalledLibrary from '../../src/InstalledLibrary';
-import LibraryName from '../../src/LibraryName';
-import { IInstalledLibrary, ILibraryMetadata, ILibraryName, ILibraryStorage } from '../../src/types';
+import {
+    IInstalledLibrary,
+    ILibraryMetadata,
+    ILibraryName,
+    ILibraryStorage,
+    InstalledLibrary,
+    LibraryName
+} from '../../src';
 
 /**
  * Stores libraries in a directory.
@@ -38,7 +43,9 @@ export default class FileLibraryStorage implements ILibraryStorage {
     ): Promise<boolean> {
         if (!(await this.getId(library))) {
             throw new Error(
-                `Can't add file ${filename} to library ${LibraryName.toUberName(library)} because the library metadata has not been installed.`
+                `Can't add file ${filename} to library ${LibraryName.toUberName(
+                    library
+                )} because the library metadata has not been installed.`
             );
         }
         const fullPath = this.getFullPath(library, filename);
@@ -57,13 +64,15 @@ export default class FileLibraryStorage implements ILibraryStorage {
     public async clearLibraryFiles(library: ILibraryName): Promise<void> {
         if (!(await this.getId(library))) {
             throw new Error(
-                `Can't clear library ${LibraryName.toUberName(library)} because the library has not been installed.`
+                `Can't clear library ${LibraryName.toUberName(
+                    library
+                )} because the library has not been installed.`
             );
         }
         const fullLibraryPath = this.getDirectoryPath(library);
-        const directoryEntries = (await fsExtra.readdir(
-            fullLibraryPath
-        )).filter(entry => entry !== 'library.json');
+        const directoryEntries = (
+            await fsExtra.readdir(fullLibraryPath)
+        ).filter(entry => entry !== 'library.json');
         await Promise.all(
             directoryEntries.map(entry =>
                 fsExtra.remove(this.getFullPath(library, entry))
@@ -93,7 +102,11 @@ export default class FileLibraryStorage implements ILibraryStorage {
      */
     public getFileStream(library: ILibraryName, filename: string): ReadStream {
         return fsExtra.createReadStream(
-            path.join(this.librariesDirectory, LibraryName.toUberName(library), filename)
+            path.join(
+                this.librariesDirectory,
+                LibraryName.toUberName(library),
+                filename
+            )
         );
     }
 
@@ -115,7 +128,9 @@ export default class FileLibraryStorage implements ILibraryStorage {
      * @param  {...string[]} machineNames (optional) only return libraries that have these machine names
      * @returns {Promise<ILibraryName[]>} the libraries installed
      */
-    public async getInstalled(...machineNames: string[]): Promise<ILibraryName[]> {
+    public async getInstalled(
+        ...machineNames: string[]
+    ): Promise<ILibraryName[]> {
         const nameRegex = /([^\s]+)-(\d+)\.(\d+)/;
         const libraryDirectories = await fsExtra.readdir(
             this.librariesDirectory
@@ -169,7 +184,9 @@ export default class FileLibraryStorage implements ILibraryStorage {
         const libPath = this.getDirectoryPath(library);
         if (await fsExtra.pathExists(libPath)) {
             throw new Error(
-                `Library ${LibraryName.toUberName(library)} has already been installed.`
+                `Library ${LibraryName.toUberName(
+                    library
+                )} has already been installed.`
             );
         }
         try {
@@ -208,7 +225,9 @@ export default class FileLibraryStorage implements ILibraryStorage {
         const libPath = this.getDirectoryPath(library);
         if (!(await fsExtra.pathExists(libPath))) {
             throw new Error(
-                `Library ${LibraryName.toUberName(library)} is not installed on the system.`
+                `Library ${LibraryName.toUberName(
+                    library
+                )} is not installed on the system.`
             );
         }
         await fsExtra.remove(libPath);
@@ -228,7 +247,9 @@ export default class FileLibraryStorage implements ILibraryStorage {
         const libPath = this.getDirectoryPath(libraryMetadata);
         if (!(await fsExtra.pathExists(libPath))) {
             throw new Error(
-                `Library ${LibraryName.toUberName(libraryMetadata)} can't be updated as it hasn't been installed yet.`
+                `Library ${LibraryName.toUberName(
+                    libraryMetadata
+                )} can't be updated as it hasn't been installed yet.`
             );
         }
         await fsExtra.writeJSON(
@@ -246,7 +267,10 @@ export default class FileLibraryStorage implements ILibraryStorage {
      * @returns {string} the absolute path to the directory
      */
     private getDirectoryPath(library: ILibraryName): string {
-        return path.join(this.librariesDirectory, LibraryName.toUberName(library));
+        return path.join(
+            this.librariesDirectory,
+            LibraryName.toUberName(library)
+        );
     }
 
     /**

--- a/examples/implementation/InMemoryStorage.ts
+++ b/examples/implementation/InMemoryStorage.ts
@@ -1,4 +1,4 @@
-import { IKeyValueStorage } from '../../src/types';
+import { IKeyValueStorage } from '../../src';
 
 /**
  * Stores objects in memory. It can store any key-value pairs.

--- a/examples/implementation/User.ts
+++ b/examples/implementation/User.ts
@@ -1,4 +1,4 @@
-import { IUser } from '../../src/types';
+import { IUser } from '../../src';
 
 /**
  * Example user object

--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
         "test:e2e:player": "./node_modules/.bin/ts-node test/e2e/H5PPlayer.DisplayContent.test.ts",
         "test:coverage": "npx jest --collect-coverage --testTimeout=120000",
         "test:integration": "npx jest --config jest.integration.config.js --maxWorkers=2 --logHeapUsage",
-        "format:check": "npx prettier --check \"{src,test}/**/*.ts\"",
-        "format": "npx prettier --write \"{src,test}/**/*.ts\"",
+        "format:check": "npx prettier --check \"{src,test,examples}/**/*.ts\"",
+        "format": "npx prettier --write \"{src,test,examples}/**/*.ts\"",
         "semantic-release": "semantic-release"
     },
     "release": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,17 +1,60 @@
+// Classes
 import H5PEditor from './H5PEditor';
 import H5PPlayer from './H5PPlayer';
+import H5pError from './helpers/H5pError';
+import InstalledLibrary from './InstalledLibrary';
 import LibraryName from './LibraryName';
 import PackageExporter from './PackageExporter';
 import TranslationService from './TranslationService';
 
+// Interfaces
+import {
+    ContentId,
+    IContentMetadata,
+    IContentStorage,
+    IEditorConfig,
+    IInstalledLibrary,
+    IKeyValueStorage,
+    ILibraryFileUrlResolver,
+    ILibraryMetadata,
+    ILibraryName,
+    ILibraryStorage,
+    ITemporaryFile,
+    ITemporaryFileStorage,
+    ITranslationService,
+    IUser,
+    Permission
+} from './types';
+
+// Assets
+
 import englishStrings from './translations/en.json';
 
-export default {
+export {
+    // classes
+    H5PEditor,
+    H5pError,
+    H5PPlayer,
+    InstalledLibrary,
     LibraryName,
     PackageExporter,
     TranslationService,
-    englishStrings,
-    // tslint:disable-next-line: object-literal-sort-keys
-    Editor: H5PEditor,
-    Player: H5PPlayer
+    // interfaces
+    ContentId,
+    IContentMetadata,
+    IContentStorage,
+    IEditorConfig,
+    IInstalledLibrary,
+    IKeyValueStorage,
+    ILibraryFileUrlResolver,
+    ILibraryMetadata,
+    ILibraryName,
+    ILibraryStorage,
+    ITemporaryFile,
+    ITemporaryFileStorage,
+    ITranslationService,
+    IUser,
+    Permission,
+    // assets
+    englishStrings
 };

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -2,6 +2,7 @@
     "extends": "./tsconfig.base.json",
     "include": ["src/**/*.ts", "examples/**/*.ts"],
     "compilerOptions": {
+        "declaration": true,
         "outDir": "./build"
     }
 }


### PR DESCRIPTION
There now is an index.d.ts file in build/src, which is an entry point into the type definitions needed to write an implementation. I had to remove the default export for this to work, so you must now import the library like this: (breaking change)

```
import * as h5pLib from 'h5p-nodejs-library'
```

The Express example now also doesn't import the source TypeScript files directly anymore, but imports from index.ts. 

Currently, the package also exports a few (utility) classes, which is ok in some cases (H5pError, LibraryName, InstalledLibrary). In others we should try to remove the exports in the future (PackageExporter (should be instantiated internally, see #282), TranslationService (should be implemented by the example)). I don't want this PR to become too big, so I think we can do this later.

Note that there is an "error" in the index.d.ts file, if you install the package:
![image](https://user-images.githubusercontent.com/15268740/69492363-51e9f780-0ea2-11ea-9447-7bd21b98af0c.png)
The reason for this is that you need these TS compiler flags for TS to accept JSON files in imports:

```
"resolveJsonModule": true,
"esModuleInterop": true,
```

The error means that the ``englishStrings`` property doesn't have typings, but the values can be read fine, as the actual import is done in the JS file.