### PR TITLE
fix(package upload): content of uploaded packages is now not permanently stored in the system

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,3 +181,4 @@ Read more about them at the following websites:
 -   CARO - https://blogs.uni-bremen.de/caroprojekt/
 -   University of Bremen - https://www.uni-bremen.de/en.html
 -   BMBF - https://www.bmbf.de/en/index.html
+

--- a/examples/express.ts
+++ b/examples/express.ts
@@ -160,7 +160,9 @@ const start = async () => {
 
         exec(`sh scripts/download-example.sh ${examples[key].h5p}`)
             .then(async () => {
-                const contentId = await h5pEditor.packageImporter.addPackageLibrariesAndContent(
+                const {
+                    id: contentId
+                } = await h5pEditor.packageImporter.addPackageLibrariesAndContent(
                     tempFilename,
                     new User()
                 );
@@ -288,20 +290,17 @@ const start = async () => {
                 });
                 break;
             case 'library-upload':
-                const contentId = await h5pEditor.uploadPackage(
+                const { metadata, parameters } = await h5pEditor.uploadPackage(
                     req.files.h5p.data,
-                    req.query.contentId,
                     user
                 );
-                const [content, contentTypes] = await Promise.all([
-                    h5pEditor.loadH5P(contentId),
-                    h5pEditor.getContentTypeCache(user)
-                ]);
+                const contentTypes = await h5pEditor.getContentTypeCache(user);
+
                 res.status(200).json({
                     data: {
-                        content: content.params.params,
+                        content: parameters,
                         contentTypes,
-                        h5p: content.h5p
+                        h5p: metadata
                     },
                     success: true
                 });

--- a/examples/express.ts
+++ b/examples/express.ts
@@ -305,10 +305,10 @@ const start = async () => {
                     success: true
                 });
                 break;
-            case 'filter': 
+            case 'filter':
                 res.status(200).json({
                     data: JSON.parse(req.body.libraryParameters),
-                    success: true                    
+                    success: true
                 });
                 break;
             default:

--- a/examples/express.ts
+++ b/examples/express.ts
@@ -305,6 +305,12 @@ const start = async () => {
                     success: true
                 });
                 break;
+            case 'filter': 
+                res.status(200).json({
+                    data: JSON.parse(req.body.libraryParameters),
+                    success: true                    
+                });
+                break;
             default:
                 res.status(500).end('NOT IMPLEMENTED');
                 break;

--- a/src/ContentManager.ts
+++ b/src/ContentManager.ts
@@ -83,21 +83,21 @@ export default class ContentManager {
     /**
      * Adds content from a H5P package (in a temporary directory) to the installation.
      * It does not check whether the user has permissions to save content.
-     * @param {string} packageDirectory The absolute path containing the package (the directory containing h5p.json)
-     * @param {IUser} user The user who is adding the package.
-     * @param {number} contentId (optional) The content id to use for the package
-     * @returns {Promise<string>} The id of the content that was created (the one passed to the method or a new id if there was none).
+     * @param packageDirectory The absolute path containing the package (the directory containing h5p.json)
+     * @param user The user who is adding the package.
+     * @param contentId (optional) The content id to use for the package
+     * @returns The id of the content that was created (the one passed to the method or a new id if there was none).
      */
     public async copyContentFromDirectory(
         packageDirectory: string,
         user: IUser,
         contentId?: ContentId
-    ): Promise<ContentId> {
+    ): Promise<{ id: ContentId; metadata: IContentMetadata; parameters: any }> {
         log.info(`copying content from directory ${packageDirectory}`);
         const metadata: IContentMetadata = await fsExtra.readJSON(
             path.join(packageDirectory, 'h5p.json')
         );
-        const content: ContentParameters = await fsExtra.readJSON(
+        const parameters: ContentParameters = await fsExtra.readJSON(
             path.join(packageDirectory, 'content', 'content.json')
         );
         const otherContentFiles: string[] = (
@@ -109,7 +109,7 @@ export default class ContentManager {
 
         const newContentId: ContentId = await this.contentStorage.createContent(
             metadata,
-            content,
+            parameters,
             user,
             contentId
         );
@@ -134,7 +134,7 @@ export default class ContentManager {
             await this.contentStorage.deleteContent(newContentId);
             throw error;
         }
-        return newContentId;
+        return { id: newContentId, metadata, parameters };
     }
 
     /**

--- a/src/ContentStorer.ts
+++ b/src/ContentStorer.ts
@@ -1,12 +1,21 @@
+import fsExtra from 'fs-extra';
+import globPromise from 'glob-promise';
 import path from 'path';
 import shortid from 'shortid';
+import { Stream } from 'stream';
 
 import { ContentFileScanner, IFileReference } from './ContentFileScanner';
 import ContentManager from './ContentManager';
 import Logger from './helpers/Logger';
 import LibraryManager from './LibraryManager';
 import TemporaryFileManager from './TemporaryFileManager';
-import { ContentId, IContentMetadata, ILibraryName, IUser } from './types';
+import {
+    ContentId,
+    ContentParameters,
+    IContentMetadata,
+    ILibraryName,
+    IUser
+} from './types';
 
 const log = new Logger('ContentStorer');
 
@@ -24,6 +33,51 @@ export default class ContentStorer {
     }
 
     private contentFileScanner: ContentFileScanner;
+
+    /**
+     * Scans through the parameters of the content and copies all referenced files into
+     * temporary storage.
+     * @param packageDirectory
+     * @param user
+     * @returns the metadata and parameters of the content
+     */
+    public async copyFromDirectoryToTemporary(
+        packageDirectory: string,
+        user: IUser
+    ): Promise<{ metadata: IContentMetadata; parameters: any }> {
+        const metadata: IContentMetadata = await fsExtra.readJSON(
+            path.join(packageDirectory, 'h5p.json')
+        );
+        const parameters: ContentParameters = await fsExtra.readJSON(
+            path.join(packageDirectory, 'content', 'content.json')
+        );
+
+        const fileReferencesInParams = await this.contentFileScanner.scanForFiles(
+            parameters,
+            metadata.preloadedDependencies.find(
+                l => l.machineName === metadata.mainLibrary
+            )
+        );
+
+        for (const reference of fileReferencesInParams) {
+            const filepath = path.join(
+                packageDirectory,
+                'content',
+                reference.filePath
+            );
+            if (!(await fsExtra.pathExists(filepath))) {
+                continue;
+            }
+            const readStream = fsExtra.createReadStream(filepath);
+            const newFilename = await this.temporaryFileManager.saveFile(
+                reference.filePath,
+                readStream,
+                user
+            );
+            reference.context.params.path = `${newFilename}#tmp`;
+        }
+        return { metadata, parameters };
+    }
 
     /**
      * Saves content in the persistence system. Also copies over files from temporary storage

--- a/src/H5PEditor.ts
+++ b/src/H5PEditor.ts
@@ -81,12 +81,6 @@ export default class H5PEditor {
         );
         this.translationService = translationService;
         this.config = config;
-        this.packageImporter = new PackageImporter(
-            this.libraryManager,
-            this.translationService,
-            this.config,
-            this.contentManager
-        );
         this.temporaryFileManager = new TemporaryFileManager(
             temporaryStorage,
             this.config
@@ -95,6 +89,12 @@ export default class H5PEditor {
             this.contentManager,
             this.libraryManager,
             this.temporaryFileManager
+        );
+        this.packageImporter = new PackageImporter(
+            this.libraryManager,
+            this.translationService,
+            this.config,
+            this.contentStorer
         );
     }
 
@@ -417,21 +417,25 @@ export default class H5PEditor {
     }
 
     /**
-     * Adds the contents of a package to the system.
-     * @param {*} data The data (format?)
-     * @param {number} contentId (optional) the content id of the uploaded package
-     * @returns {Promise<string>} the newly created content it or the one passed to it
+     * Adds the contents of a package to the system: Installs required libraries (if
+     * the user has the permissions for this), adds files to temporary storage and
+     * returns the actual content information for the editor to process.
+     * Throws errors if something goes wrong.
+     * @param data the raw data of the h5p package as a buffer
+     * @returns the content information extracted from the package
      */
     public async uploadPackage(
         data: Buffer,
-        contentId: ContentId,
         user: IUser
-    ): Promise<ContentId> {
-        log.info(`uploading package for ${contentId}`);
+    ): Promise<{ metadata: IContentMetadata; parameters: any }> {
+        log.info(`uploading package`);
         const dataStream: any = new stream.PassThrough();
         dataStream.end(data);
 
-        let newContentId: ContentId;
+        let returnValues: {
+            metadata: IContentMetadata;
+            parameters: any;
+        };
 
         await withFile(
             async ({ path: tempPackagePath }) => {
@@ -446,16 +450,15 @@ export default class H5PEditor {
                     );
                 }
 
-                newContentId = await this.packageImporter.addPackageLibrariesAndContent(
+                returnValues = await this.packageImporter.addPackageLibrariesAndTemporaryFiles(
                     tempPackagePath,
-                    user,
-                    contentId
+                    user
                 );
             },
             { postfix: '.h5p', keep: false }
         );
 
-        return newContentId;
+        return returnValues;
     }
 
     public useRenderer(renderer: any): H5PEditor {

--- a/src/H5PEditor.ts
+++ b/src/H5PEditor.ts
@@ -94,6 +94,7 @@ export default class H5PEditor {
             this.libraryManager,
             this.translationService,
             this.config,
+            this.contentManager,
             this.contentStorer
         );
     }
@@ -153,17 +154,19 @@ export default class H5PEditor {
 
     public async getLibraryData(
         machineName: string,
-        majorVersion: number,
-        minorVersion: number,
+        majorVersion: string,
+        minorVersion: string,
         language: string = 'en'
     ): Promise<ILibraryDetailedDataForClient> {
         log.info(
             `getting data for library ${machineName}-${majorVersion}.${minorVersion}`
         );
+        const majorVersionAsNr = Number.parseInt(majorVersion, 10);
+        const minorVersionAsNr = Number.parseInt(minorVersion, 10);
         const library = new LibraryName(
             machineName,
-            majorVersion,
-            minorVersion
+            majorVersionAsNr,
+            minorVersionAsNr
         );
 
         if (!(await this.libraryManager.libraryExists(library))) {
@@ -179,7 +182,12 @@ export default class H5PEditor {
             languages,
             upgradeScriptPath
         ] = await Promise.all([
-            this.loadAssets(machineName, majorVersion, minorVersion, language),
+            this.loadAssets(
+                machineName,
+                majorVersionAsNr,
+                minorVersionAsNr,
+                language
+            ),
             this.libraryManager.loadSemantics(library),
             this.libraryManager.loadLanguage(library, language),
             this.libraryManager.listLanguages(library),
@@ -194,8 +202,8 @@ export default class H5PEditor {
             language: languageObject,
             name: machineName,
             version: {
-                major: majorVersion,
-                minor: minorVersion
+                major: majorVersionAsNr,
+                minor: minorVersionAsNr
             },
             javascript: assets.scripts,
             translations: assets.translations,

--- a/src/LibraryManager.ts
+++ b/src/LibraryManager.ts
@@ -197,15 +197,7 @@ export default class LibraryManager {
      * @returns true if the library has been installed
      */
     public async libraryExists(library: LibraryName): Promise<boolean> {
-        const installed = await this.getInstalled([library.machineName]);
-        if (!installed || !installed[library.machineName]) {
-            return false;
-        }
-        return installed[library.machineName].some(
-            l =>
-                l.majorVersion === library.majorVersion &&
-                l.minorVersion === library.minorVersion
-        );
+        return this.libraryStorage.libraryExists(library);
     }
 
     /**

--- a/src/LibraryManager.ts
+++ b/src/LibraryManager.ts
@@ -213,12 +213,10 @@ export default class LibraryManager {
         if (!installed || !installed[library.machineName]) {
             return false;
         }
-        return (
-            installed[library.machineName].find(
-                l =>
-                    l.majorVersion === library.majorVersion &&
-                    l.minorVersion === l.minorVersion
-            ) !== undefined
+        return installed[library.machineName].some(
+            l =>
+                l.majorVersion === library.majorVersion &&
+                l.minorVersion === library.minorVersion
         );
     }
 
@@ -530,7 +528,9 @@ export default class LibraryManager {
         restricted: boolean
     ): Promise<IInstalledLibrary> {
         log.info(
-            `installing library ${libraryMetadata.machineName}-${libraryMetadata.majorVersion}.${libraryMetadata.minorVersion} from ${fromDirectory}`
+            `installing library ${LibraryName.toUberName(
+                libraryMetadata
+            )} from ${fromDirectory}`
         );
         const newLibraryInfo = await this.libraryStorage.installLibrary(
             libraryMetadata,
@@ -541,9 +541,19 @@ export default class LibraryManager {
             await this.copyLibraryFiles(fromDirectory, newLibraryInfo);
             await this.checkConsistency(libraryMetadata);
         } catch (error) {
+            log.error(
+                `There was a consistency error when installing library ${LibraryName.toUberName(
+                    libraryMetadata
+                )}. Reverting installation.`
+            );
             await this.libraryStorage.removeLibrary(libraryMetadata);
             throw error;
         }
+        log.debug(
+            `library ${LibraryName.toUberName(
+                libraryMetadata
+            )} successfully installed.`
+        );
         return newLibraryInfo;
     }
 

--- a/src/LibraryName.ts
+++ b/src/LibraryName.ts
@@ -9,6 +9,22 @@ export default class LibraryName implements ILibraryName {
     ) {}
 
     /**
+     * Checks if two libraries are identical.
+     * @param library1
+     * @param library2
+     */
+    public static equal(
+        library1: ILibraryName,
+        library2: ILibraryName
+    ): boolean {
+        return (
+            library1.machineName === library2.machineName &&
+            library1.majorVersion === library2.majorVersion &&
+            library1.minorVersion === library2.minorVersion
+        );
+    }
+
+    /**
      * Creates a library object from a library name
      * @param {string} libraryName The library name in a format "H5P.Example-1.0" or "H5P.Example 1.0" (see options)
      * @param {boolean} restricted true if the library is restricted

--- a/test/ContentFileScanner.test.ts
+++ b/test/ContentFileScanner.test.ts
@@ -47,10 +47,9 @@ describe('ContentFileScanner', () => {
             new EditorConfig(null),
             contentManager
         );
-        const contentId = await packageImporter.addPackageLibrariesAndContent(
-            file,
-            user
-        );
+        const contentId = (
+            await packageImporter.addPackageLibrariesAndContent(file, user)
+        ).id;
 
         // create ContentScanner
         return {

--- a/test/ContentScanner.test.ts
+++ b/test/ContentScanner.test.ts
@@ -43,10 +43,9 @@ async function createContentScanner(
         new EditorConfig(null),
         contentManager
     );
-    const contentId = await packageImporter.addPackageLibrariesAndContent(
-        file,
-        user
-    );
+    const contentId = (
+        await packageImporter.addPackageLibrariesAndContent(file, user)
+    ).id;
 
     // create ContentScanner
     return {

--- a/test/H5PEditor.getLibraryData.test.ts
+++ b/test/H5PEditor.getLibraryData.test.ts
@@ -32,7 +32,9 @@ describe('aggregating data from library folders for the editor', () => {
 
         h5pEditor.libraryManager = libraryManager;
 
-        return expect(h5pEditor.getLibraryData('Foo', 1, 2)).resolves.toEqual({
+        return expect(
+            h5pEditor.getLibraryData('Foo', '1', '2')
+        ).resolves.toEqual({
             css: [],
             defaultLanguage: null,
             javascript: [],
@@ -82,7 +84,7 @@ describe('aggregating data from library folders for the editor', () => {
 
         h5pEditor.libraryManager = libraryManager;
 
-        return h5pEditor.getLibraryData('Foo', 1, 2).then(libraryData => {
+        return h5pEditor.getLibraryData('Foo', '1', '2').then(libraryData => {
             expect(libraryData.semantics).toEqual({
                 arbitrary: 'content',
                 machineName: 'Foo',
@@ -173,7 +175,7 @@ describe('aggregating data from library folders for the editor', () => {
 
         h5pEditor.libraryManager = libraryManager;
 
-        return h5pEditor.getLibraryData('Foo', 1, 2).then(libraryData => {
+        return h5pEditor.getLibraryData('Foo', '1', '2').then(libraryData => {
             expect(libraryData.javascript).toEqual([
                 '/h5p/libraries/PreloadedDependency-1.0/some/script.js',
                 '/h5p/libraries/EditorDependency-1.0/path/to/script.js'
@@ -273,7 +275,7 @@ describe('aggregating data from library folders for the editor', () => {
 
         h5pEditor.libraryManager = libraryManager;
 
-        return h5pEditor.getLibraryData('Foo', 1, 2).then(libraryData => {
+        return h5pEditor.getLibraryData('Foo', '1', '2').then(libraryData => {
             expect(libraryData.javascript).toEqual([
                 '/h5p/libraries/PreloadedDependency-1.0/some/script.js',
                 '/h5p/libraries/EditorDependency-1.0/path/to/script.js',
@@ -341,7 +343,7 @@ describe('aggregating data from library folders for the editor', () => {
         const language = 'en';
 
         return h5pEditor
-            .getLibraryData('Foo', 1, 2, language)
+            .getLibraryData('Foo', '1', '2', language)
             .then(libraryData => {
                 expect(libraryData.language).toEqual({
                     arbitrary: 'languageObject'
@@ -418,7 +420,7 @@ describe('aggregating data from library folders for the editor', () => {
         const majorVersion = 1;
         const minorVersion = 2;
 
-        return h5pEditor.getLibraryData('Foo', 1, 2).then(libraryData => {
+        return h5pEditor.getLibraryData('Foo', '1', '2').then(libraryData => {
             expect(libraryData.languages).toEqual([
                 'array',
                 'with',
@@ -547,7 +549,7 @@ describe('aggregating data from library folders for the editor', () => {
 
         h5pEditor.libraryManager = libraryManager;
 
-        return h5pEditor.getLibraryData('Foo', 1, 0).then(libraryData => {
+        return h5pEditor.getLibraryData('Foo', '1', '0').then(libraryData => {
             expect(libraryData.javascript).toEqual([
                 '/h5p/libraries/Jaz-1.0/script.js',
                 '/h5p/libraries/Bar-1.0/script.js',
@@ -570,9 +572,9 @@ describe('aggregating data from library folders for the editor', () => {
                     null
                 );
 
-                expect(h5pEditor.getLibraryData('Foo', 1, 2)).rejects.toThrow(
-                    'Library Foo-1.2 was not found.'
-                );
+                expect(
+                    h5pEditor.getLibraryData('Foo', '1', '2')
+                ).rejects.toThrow('Library Foo-1.2 was not found.');
             },
             { keep: false, unsafeCleanup: true }
         );

--- a/test/H5PEditor.saving.test.ts
+++ b/test/H5PEditor.saving.test.ts
@@ -4,76 +4,14 @@ import promisepipe from 'promisepipe';
 import { BufferWritableMock } from 'stream-mock';
 import { withDir } from 'tmp-promise';
 
-import H5PEditor from '../src/H5PEditor';
 import LibraryName from '../src/LibraryName';
-import TranslationService from '../src/TranslationService';
-import {
-    IContentMetadata,
-    IContentStorage,
-    IEditorConfig,
-    IKeyValueStorage,
-    ILibraryFileUrlResolver,
-    ILibraryStorage,
-    ITemporaryFileStorage,
-    ITranslationService
-} from '../src/types';
+import { IContentMetadata } from '../src/types';
 
-import DirectoryTemporaryFileStorage from '../examples/implementation/DirectoryTemporaryFileStorage';
-import EditorConfig from '../examples/implementation/EditorConfig';
-import FileContentStorage from '../examples/implementation/FileContentStorage';
-import FileLibraryStorage from '../examples/implementation/FileLibraryStorage';
-import InMemoryStorage from '../examples/implementation/InMemoryStorage';
 import User from '../examples/implementation/User';
 
+import { createH5PEditor } from './helpers/H5PEditor';
+
 describe('H5PEditor', () => {
-    function createH5PEditor(
-        tempPath: string
-    ): {
-        config: IEditorConfig;
-        contentStorage: IContentStorage;
-        h5pEditor: H5PEditor;
-        keyValueStorage: IKeyValueStorage;
-        libraryFileUrlResolver: ILibraryFileUrlResolver;
-        libraryStorage: ILibraryStorage;
-        temporaryStorage: ITemporaryFileStorage;
-        translationService: ITranslationService;
-    } {
-        const keyValueStorage = new InMemoryStorage();
-        const config = new EditorConfig(keyValueStorage);
-        const libraryStorage = new FileLibraryStorage(
-            path.join(tempPath, 'libraries')
-        );
-        const contentStorage = new FileContentStorage(
-            path.join(tempPath, 'content')
-        );
-        const translationService = new TranslationService({});
-        const libraryFileUrlResolver = () => '';
-        const temporaryStorage = new DirectoryTemporaryFileStorage(
-            path.join(tempPath, 'tmp')
-        );
-
-        const h5pEditor = new H5PEditor(
-            keyValueStorage,
-            config,
-            libraryStorage,
-            contentStorage,
-            translationService,
-            libraryFileUrlResolver,
-            temporaryStorage
-        );
-
-        return {
-            config,
-            contentStorage,
-            h5pEditor,
-            keyValueStorage,
-            libraryFileUrlResolver,
-            libraryStorage,
-            temporaryStorage,
-            translationService
-        };
-    }
-
     const mockupMetadata: IContentMetadata = {
         embedTypes: ['div'],
         language: 'und',

--- a/test/H5PEditor.uploadingPackages.test.ts
+++ b/test/H5PEditor.uploadingPackages.test.ts
@@ -1,0 +1,82 @@
+import fsExtra from 'fs-extra';
+import path from 'path';
+import { withDir } from 'tmp-promise';
+
+import User from '../examples/implementation/User';
+
+import { createH5PEditor } from './helpers/H5PEditor';
+
+describe('H5PEditor', () => {
+    it('returns metadata and parameters of package uploads', async () => {
+        await withDir(
+            async ({ path: tempDirPath }) => {
+                const { h5pEditor } = createH5PEditor(tempDirPath);
+                const user = new User();
+
+                const fileBuffer = fsExtra.readFileSync(
+                    path.resolve('test/data/validator/valid2.h5p')
+                );
+                const { metadata, parameters } = await h5pEditor.uploadPackage(
+                    fileBuffer,
+                    user
+                );
+
+                expect(metadata).toMatchObject({
+                    embedTypes: ['div'],
+                    language: 'und',
+                    license: 'U',
+                    mainLibrary: 'H5P.GreetingCard',
+                    preloadedDependencies: [
+                        {
+                            machineName: 'H5P.GreetingCard',
+                            majorVersion: '1',
+                            minorVersion: '0'
+                        }
+                    ],
+                    title: 'Greeting card'
+                });
+
+                expect(parameters).toMatchObject({
+                    greeting: 'Hello world!',
+                    image: {
+                        copyright: { license: 'U' },
+                        height: 300,
+                        // we've left out the image as the path must have been changed
+                        width: 300
+                    }
+                });
+            },
+            { keep: false, unsafeCleanup: true }
+        );
+    });
+
+    it('adds files in uploaded package to temporary storage', async () => {
+        await withDir(
+            async ({ path: tempDirPath }) => {
+                const { h5pEditor, temporaryStorage } = createH5PEditor(
+                    tempDirPath
+                );
+                const user = new User();
+
+                const fileBuffer = fsExtra.readFileSync(
+                    path.resolve('test/data/validator/valid2.h5p')
+                );
+                const { parameters } = await h5pEditor.uploadPackage(
+                    fileBuffer,
+                    user
+                );
+
+                expect(
+                    temporaryStorage.fileExists(
+                        parameters.image.path.substr(
+                            0,
+                            parameters.image.path.length - 4
+                        ),
+                        user
+                    )
+                ).resolves.toEqual(true);
+            },
+            { keep: false, unsafeCleanup: true }
+        );
+    });
+});

--- a/test/PackageExporter.test.ts
+++ b/test/PackageExporter.test.ts
@@ -50,10 +50,12 @@ export async function importAndExportPackage(
                 config,
                 contentManager
             );
-            const contentId = await packageImporter.addPackageLibrariesAndContent(
-                packagePath,
-                user
-            );
+            const contentId = (
+                await packageImporter.addPackageLibrariesAndContent(
+                    packagePath,
+                    user
+                )
+            ).id;
 
             await withFile(
                 async fileResult => {

--- a/test/PackageImporter.test.ts
+++ b/test/PackageImporter.test.ts
@@ -1,7 +1,6 @@
 import * as fsExtra from 'fs-extra';
 import * as path from 'path';
 import promisepipe from 'promisepipe';
-// tslint:disable-next-line: no-implicit-dependencies
 import { BufferWritableMock } from 'stream-mock';
 import { withDir } from 'tmp-promise';
 
@@ -75,10 +74,12 @@ describe('package importer', () => {
                     new EditorConfig(null),
                     contentManager
                 );
-                const contentId = await packageImporter.addPackageLibrariesAndContent(
-                    path.resolve('test/data/validator/valid2.h5p'),
-                    user
-                );
+                const contentId = (
+                    await packageImporter.addPackageLibrariesAndContent(
+                        path.resolve('test/data/validator/valid2.h5p'),
+                        user
+                    )
+                ).id;
 
                 // Check if library was installed
                 const installedLibraries = await libraryManager.getInstalled();

--- a/test/helpers/H5PEditor.ts
+++ b/test/helpers/H5PEditor.ts
@@ -1,0 +1,67 @@
+import path from 'path';
+
+import {
+    H5PEditor,
+    IContentStorage,
+    IEditorConfig,
+    IKeyValueStorage,
+    ILibraryFileUrlResolver,
+    ILibraryStorage,
+    ITemporaryFileStorage,
+    ITranslationService,
+    TranslationService
+} from '../../src';
+
+import DirectoryTemporaryFileStorage from '../../examples/implementation/DirectoryTemporaryFileStorage';
+import EditorConfig from '../../examples/implementation/EditorConfig';
+import FileContentStorage from '../../examples/implementation/FileContentStorage';
+import FileLibraryStorage from '../../examples/implementation/FileLibraryStorage';
+import InMemoryStorage from '../../examples/implementation/InMemoryStorage';
+
+export function createH5PEditor(
+    tempPath: string
+): {
+    config: IEditorConfig;
+    contentStorage: IContentStorage;
+    h5pEditor: H5PEditor;
+    keyValueStorage: IKeyValueStorage;
+    libraryFileUrlResolver: ILibraryFileUrlResolver;
+    libraryStorage: ILibraryStorage;
+    temporaryStorage: ITemporaryFileStorage;
+    translationService: ITranslationService;
+} {
+    const keyValueStorage = new InMemoryStorage();
+    const config = new EditorConfig(keyValueStorage);
+    const libraryStorage = new FileLibraryStorage(
+        path.join(tempPath, 'libraries')
+    );
+    const contentStorage = new FileContentStorage(
+        path.join(tempPath, 'content')
+    );
+    const translationService = new TranslationService({});
+    const libraryFileUrlResolver = () => '';
+    const temporaryStorage = new DirectoryTemporaryFileStorage(
+        path.join(tempPath, 'tmp')
+    );
+
+    const h5pEditor = new H5PEditor(
+        keyValueStorage,
+        config,
+        libraryStorage,
+        contentStorage,
+        translationService,
+        libraryFileUrlResolver,
+        temporaryStorage
+    );
+
+    return {
+        config,
+        contentStorage,
+        h5pEditor,
+        keyValueStorage,
+        libraryFileUrlResolver,
+        libraryStorage,
+        temporaryStorage,
+        translationService
+    };
+}

--- a/test/integration/ContentFileScanner.test.ts
+++ b/test/integration/ContentFileScanner.test.ts
@@ -70,10 +70,12 @@ describe('ContentFileScanner (integration test with H5P Hub examples)', () => {
         for (const file of h5pPackages.filter(f => f.endsWith('.h5p'))) {
             packageIdMap.set(
                 file,
-                await packageImporter.addPackageLibrariesAndContent(
-                    path.join(directory, file),
-                    user
-                )
+                (
+                    await packageImporter.addPackageLibrariesAndContent(
+                        path.join(directory, file),
+                        user
+                    )
+                ).id
             );
         }
 


### PR DESCRIPTION
- [X] change signatures of PackageImporter to return metadata and parameters instead of contentId
- [X] implement logic to copy content files to temporary storage