### PR TITLE
fix(library management): removed id and libraryId properties of installed libraries (resolves #203)

### DIFF
--- a/src/ContentTypeInformationRepository.ts
+++ b/src/ContentTypeInformationRepository.ts
@@ -187,7 +187,6 @@ export default class ContentTypeInformationRepository {
                               'icon.svg'
                           )
                         : undefined,
-                    id: localLib.id,
                     installed: true,
                     isUpToDate: true,
                     localMajorVersion: localLib.majorVersion,
@@ -245,7 +244,6 @@ export default class ContentTypeInformationRepository {
                     hubLib.canInstall = this.canInstallLibrary(hubLib, user);
                     hubLib.isUpToDate = true;
                 } else {
-                    hubLib.id = localLib.id;
                     hubLib.installed = true;
                     hubLib.restricted =
                         this.libraryIsRestricted(localLib) &&

--- a/src/InstalledLibrary.ts
+++ b/src/InstalledLibrary.ts
@@ -20,7 +20,6 @@ export default class InstalledLibrary implements IInstalledLibrary {
         this.majorVersion = majorVersion;
         this.minorVersion = minorVersion;
         this.patchVersion = patchVersion;
-        this.id = undefined;
         this.title = undefined;
         this.runnable = undefined;
         this.restricted = restricted;
@@ -35,8 +34,6 @@ export default class InstalledLibrary implements IInstalledLibrary {
     public embedTypes?: ('iframe' | 'div')[];
     public fullscreen?: 0 | 1;
     public h?: number;
-    public id: number;
-    public libraryId: number;
     public license?: string;
     public metadataSettings?: { disable: 0 | 1; disableExtraTitleField: 0 | 1 };
     public preloadedCss?: IPath[];

--- a/src/LibraryManager.ts
+++ b/src/LibraryManager.ts
@@ -62,17 +62,6 @@ export default class LibraryManager {
     }
 
     /**
-     * Get id to an existing installed library.
-     * If version number is not specified, the newest version will be returned.
-     * @param {ILibraryName} library Note that patch version is ignored.
-     * @returns {Promise<number>} The id of the specified library or undefined (if not installed).
-     */
-    public async getId(library: ILibraryName): Promise<number> {
-        log.debug(`getting id for library ${LibraryName.toUberName(library)}`);
-        return this.libraryStorage.getId(library);
-    }
-
-    /**
      * Get a list of the currently installed libraries.
      * @param {String[]?} machineNames (if supplied) only return results for the machines names in the list
      * @returns {Promise<any>} An object which has properties with the existing library machine names. The properties'
@@ -89,7 +78,6 @@ export default class LibraryManager {
                     const installedLib = InstalledLibrary.fromName(libName);
                     const info = await this.loadLibrary(libName);
                     installedLib.patchVersion = info.patchVersion;
-                    installedLib.id = info.libraryId;
                     installedLib.runnable = info.runnable;
                     installedLib.title = info.title;
                     return installedLib;
@@ -157,7 +145,7 @@ export default class LibraryManager {
         const newLibraryMetadata: ILibraryMetadata = await fsExtra.readJSON(
             `${directory}/library.json`
         );
-        if (await this.getId(newLibraryMetadata)) {
+        if (await this.libraryExists(newLibraryMetadata)) {
             // Check if library is already installed.
             if (await this.isPatchedLibrary(newLibraryMetadata)) {
                 // Update the library if it is only a patch of an existing library
@@ -209,17 +197,7 @@ export default class LibraryManager {
      * @returns true if the library has been installed
      */
     public async libraryExists(library: LibraryName): Promise<boolean> {
-        const installed = await this.getInstalled([library.machineName]);
-        if (!installed || !installed[library.machineName]) {
-            return false;
-        }
-        return (
-            installed[library.machineName].find(
-                l =>
-                    l.majorVersion === library.majorVersion &&
-                    l.minorVersion === l.minorVersion
-            ) !== undefined
-        );
+        return this.libraryStorage.libraryExists(library);
     }
 
     /**
@@ -349,7 +327,7 @@ export default class LibraryManager {
                 library,
                 'library.json'
             );
-            libraryMetadata.libraryId = await this.getId(library);
+            libraryMetadata.libraryId = await this.libraryExists(library);
             return libraryMetadata;
         } catch (ignored) {
             log.warn(
@@ -379,7 +357,7 @@ export default class LibraryManager {
      * @returns {Promise<boolean>} true if the library is ok. Throws errors if not.
      */
     private async checkConsistency(library: ILibraryName): Promise<boolean> {
-        if (!(await this.libraryStorage.getId(library))) {
+        if (!(await this.libraryExists(library))) {
             log.error(
                 `Error in library ${LibraryName.toUberName(
                     library

--- a/src/types.ts
+++ b/src/types.ts
@@ -418,13 +418,6 @@ export interface ILibraryStorage {
     getFileStream(library: ILibraryName, file: string): ReadStream;
 
     /**
-     * Returns the id of an installed library.
-     * @param library The library to get the id for
-     * @returns the id or undefined if the library is not installed
-     */
-    getId(library: ILibraryName): Promise<number>;
-
-    /**
      * Returns all installed libraries or the installed libraries that have the machine names in the arguments.
      * @param machineNames (optional) only return libraries that have these machine names
      * @returns the libraries installed
@@ -450,6 +443,13 @@ export interface ILibraryStorage {
         libraryData: ILibraryMetadata,
         restricted: boolean
     ): Promise<IInstalledLibrary>;
+
+    /**
+     * Checks if the library has been installed.
+     * @param name the library name
+     * @returns true if the library has been installed
+     */
+    libraryExists(name: ILibraryName): Promise<boolean>;
 
     /**
      * Gets a list of all library files that exist for this library.
@@ -626,17 +626,6 @@ export interface ISemanticsEntry {
  * Objects of this interface represent installed libraries that have an id.
  */
 export interface IInstalledLibrary extends ILibraryMetadata {
-    /**
-     * The id used internally to identify the library. Must be unique and assigned when the
-     * library is installed. Libraries whose machine name is identical but that have different
-     * major or minor version must also have different ids, while libraries that only differ in
-     * patch versions can have the same id (as they can't co-exist).
-     */
-    id: number;
-    /**
-     * Unknown. Check if obsolete and to be removed.
-     */
-    libraryId: number;
     /**
      * If set to true, the library can only be used be users who have this special
      * privilege.


### PR DESCRIPTION
`IInstalledLibrary` had the properties `id` and `libraryId` until now. I've removed those and the client still works fine. I'm quite certain that they are only artifacts of the relational database schema used by the PHP implementation to store the libraries. The ids are fully redundant as normally the system uses the "ubername" to uniquely identify installed libraries. (All endpoints I've implemented so far always used the ubername and never an numeric `id`). Even Joubel uses the name "id" for the machine name in the editor client, so I assume that the "library ids" in the PHP editor server are only internal and don't have to imitated. We can still re-introduce later them if needed after all.