### PR TITLE
docs: Added GitHub Action to generate coverage report and send it to Coveralls

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,27 @@
+on: ["push", "pull_request"]
+
+name: Coveralls coverage generator
+
+jobs:
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+
+    - uses: actions/checkout@v1
+
+    - name: Use Node.js 10.x
+      uses: actions/setup-node@v1
+      with:
+        node-version: 10.x
+
+    - name: npm install, npm run test:coverage
+      run: |
+        npm install
+        npm run test:coverage
+
+    - name: Coveralls
+      uses: coverallsapp/github-action@master
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # H5P-Nodejs-library
 
 [![CircleCI](https://circleci.com/gh/Lumieducation/H5P-Nodejs-library/tree/master.svg?style=svg)](https://circleci.com/gh/Lumieducation/H5P-Nodejs-library/tree/master)
+[![Coverage Status](https://coveralls.io/repos/github/Lumieducation/H5P-Nodejs-library/badge.svg?branch=doc/coverage-generator)](https://coveralls.io/github/Lumieducation/H5P-Nodejs-library?branch=doc/coverage-generator)
 
 This project is a re-implementation of the [H5P-Editor-PHP-library](https://github.com/h5p/h5p-editor-php-library) and [H5P-PHP-library](https://github.com/h5p/h5p-php-library) for Nodejs. It is written in TypeScript but can be used in JavaScript just as well.
 

--- a/jest.coverage.config.js
+++ b/jest.coverage.config.js
@@ -1,0 +1,9 @@
+const base = require('./jest.config');
+
+module.exports = {
+    ...base,
+
+    // The glob patterns Jest uses to detect test files
+    testMatch: ['**/test/**/*.test.ts'],
+    testPathIgnorePatterns: ['/node_modules/', '/test/data', '/test/e2e']
+};

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
         "test:watch": "jest --watch",
         "test:e2e": "npm run test:e2e:player",
         "test:e2e:player": "./node_modules/.bin/ts-node test/e2e/H5PPlayer.DisplayContent.test.ts",
-        "test:coverage": "npx jest --collect-coverage --testTimeout=120000",
+        "test:coverage": "npx jest --config jest.coverage.config.js --collect-coverage --testTimeout=120000",
         "test:integration": "npx jest --config jest.integration.config.js --maxWorkers=2 --logHeapUsage",
         "format:check": "npx prettier --check \"{src,test,examples}/**/*.ts\"",
         "format": "npx prettier --write \"{src,test,examples}/**/*.ts\"",


### PR DESCRIPTION
I've added an GitHub action that automatically runs when we push to the repo or create a PR. It generates a coverage report and sends it to Coveralls (free for OpenSource). That way we get test coverage badges and reports (I've tested this on my fork and it works fine):
The badge we would get:
![image](https://user-images.githubusercontent.com/15268740/70044983-a0467700-15c3-11ea-932b-ec2bd61c8721.png)

A CI pipeline report on coverage changes due to PRs/pushes:
![image](https://user-images.githubusercontent.com/15268740/70044997-a5a3c180-15c3-11ea-8879-0c9718eb2f47.png)

The details report on coveralls.io (here you can browse through the source and look at the uncovered lines):
![image](https://user-images.githubusercontent.com/15268740/70045006-a89eb200-15c3-11ea-814b-c95029970340.png)

P.S. I think we should consider switching to GitHub Action alltogether: it has up to 7 GB of RAM (we have had memory issues...) and we can test on Linux, Windows and Mac!