### PR TITLE
fix(player): the user defined integration now overwrites the default one

### DIFF
--- a/src/H5PPlayer.ts
+++ b/src/H5PPlayer.ts
@@ -99,7 +99,6 @@ export default class H5PPlayer {
         // see https://h5p.org/creating-your-own-h5p-plugin
         log.info(`generating integration for ${contentId}`);
         return {
-            ...this.integration,
             contents: {
                 [`cid-${contentId}`]: {
                     ...this.content,
@@ -121,7 +120,8 @@ export default class H5PPlayer {
             },
             postUserStatistics: false,
             saveFreq: false,
-            url: this.baseUrl
+            url: this.baseUrl,
+            ...this.integration
         };
     }
 

--- a/test/H5PPlayer.integration.test.ts
+++ b/test/H5PPlayer.integration.test.ts
@@ -2,10 +2,6 @@ import H5PPlayer from '../src/H5PPlayer';
 
 describe('H5PPlayer.generateIntegration()', () => {
     it('should use the passed integration', () => {
-        const contentId = 'foo';
-        const contentObject = {};
-        const h5pObject = {};
-
         const integration = new H5PPlayer(
             undefined,
             undefined,

--- a/test/H5PPlayer.integration.test.ts
+++ b/test/H5PPlayer.integration.test.ts
@@ -1,0 +1,18 @@
+import H5PPlayer from '../src/H5PPlayer';
+
+describe('H5PPlayer.generateIntegration()', () => {
+    it('should use the passed integration', () => {
+        const contentId = 'foo';
+        const contentObject = {};
+        const h5pObject = {};
+
+        const integration = new H5PPlayer(
+            undefined,
+            undefined,
+            { postUserStatistics: true } as any,
+            undefined
+        ).generateIntegration('test', {}, {} as any);
+
+        expect(integration.postUserStatistics).toBeTruthy();
+    });
+});


### PR DESCRIPTION
Hey,

I noticed, that the player integration settings from the user are overwritten by the default settings.
I fixed it, so that the user integration object now overwrites the default one.