### PR TITLE
refactor(library installer): The library installer now returns a list of installed library.

### DIFF
--- a/src/H5PEditor.ts
+++ b/src/H5PEditor.ts
@@ -31,6 +31,7 @@ import {
     IIntegration,
     IKeyValueStorage,
     ILibraryDetailedDataForClient,
+    ILibraryInstallResult,
     ILibraryName,
     ILibraryOverviewForClient,
     ILibraryStorage,
@@ -101,13 +102,13 @@ export default class H5PEditor {
 
     public contentManager: ContentManager;
     public contentTypeCache: ContentTypeCache;
+    public contentTypeRepository: ContentTypeInformationRepository;
     public libraryManager: LibraryManager;
     public packageImporter: PackageImporter;
     public temporaryFileManager: TemporaryFileManager;
     public translationService: ITranslationService;
 
     private contentStorer: ContentStorer;
-    private contentTypeRepository: ContentTypeInformationRepository;
     private packageExporter: PackageExporter;
     private renderer: any;
     private translation: any;
@@ -324,10 +325,13 @@ export default class H5PEditor {
 
     /**
      * Installs a content type from the H5P Hub.
-     * @param {string} id The name of the content type to install (e.g. H5P.Test-1.0)
-     * @returns {Promise<true>} true if successful. Will throw errors if something goes wrong.
+     * @param id The name of the content type to install (e.g. H5P.Test-1.0)
+     * @returns a list of installed libraries if succcesful. Will throw errors if something goes wrong.
      */
-    public async installLibrary(id: string, user: IUser): Promise<boolean> {
+    public async installLibrary(
+        id: string,
+        user: IUser
+    ): Promise<ILibraryInstallResult[]> {
         return this.contentTypeRepository.install(id, user);
     }
 
@@ -463,12 +467,17 @@ export default class H5PEditor {
     public async uploadPackage(
         data: Buffer,
         user: IUser
-    ): Promise<{ metadata: IContentMetadata; parameters: any }> {
+    ): Promise<{
+        installedLibraries: ILibraryInstallResult[];
+        metadata: IContentMetadata;
+        parameters: any;
+    }> {
         log.info(`uploading package`);
         const dataStream: any = new stream.PassThrough();
         dataStream.end(data);
 
         let returnValues: {
+            installedLibraries: ILibraryInstallResult[];
             metadata: IContentMetadata;
             parameters: any;
         };

--- a/src/types.ts
+++ b/src/types.ts
@@ -51,6 +51,16 @@ export interface ILibraryName {
     minorVersion: number;
 }
 
+export interface IFullLibraryName extends ILibraryName {
+    patchVersion: number;
+}
+
+export interface ILibraryInstallResult {
+    newVersion?: IFullLibraryName;
+    oldVersion?: IFullLibraryName;
+    type: 'new' | 'patch' | 'none';
+}
+
 /**
  * This is an author inside content metadata.
  */
@@ -655,7 +665,7 @@ export interface IInstalledLibrary extends ILibraryMetadata {
 /**
  * This interface represents the structure of library.json files.
  */
-export interface ILibraryMetadata extends ILibraryName {
+export interface ILibraryMetadata extends IFullLibraryName {
     author?: string;
     /**
      * The core API required to run the library.
@@ -673,7 +683,6 @@ export interface ILibraryMetadata extends ILibraryName {
         disable: 0 | 1;
         disableExtraTitleField: 0 | 1;
     };
-    patchVersion: number;
     preloadedCss?: IPath[];
     preloadedDependencies?: ILibraryName[];
     preloadedJs?: IPath[];

--- a/test/ContentTypeInformationRepository.test.ts
+++ b/test/ContentTypeInformationRepository.test.ts
@@ -325,7 +325,7 @@ describe('Content type information repository (= connection to H5P Hub)', () => 
                 axiosMock.restore(); // TODO: It would be nicer if the download of the Hub File could be mocked as well, but this is not possible as axios-mock-adapter doesn't support stream yet ()
                 await expect(
                     repository.install('H5P.DragText', user)
-                ).resolves.toEqual(true);
+                ).resolves.toBeDefined();
                 const libs = await libManager.getInstalled();
                 expect(Object.keys(libs).length).toEqual(11); // TODO: must be adapted to changes in the Hub file
             },

--- a/test/LibraryManager.test.ts
+++ b/test/LibraryManager.test.ts
@@ -35,15 +35,15 @@ describe('basic file library manager functionality', () => {
         const libraryObject = await libManager.getInstalled(['H5P.Example1']);
         expect(
             await libManager.isPatchedLibrary(libraryObject['H5P.Example1'][0])
-        ).toEqual(false);
+        ).toBeUndefined();
         libraryObject['H5P.Example1'][0].patchVersion += 1;
         expect(
             await libManager.isPatchedLibrary(libraryObject['H5P.Example1'][0])
-        ).toEqual(true);
+        ).toBeDefined();
         libraryObject['H5P.Example1'][0].patchVersion -= 2;
         expect(
             await libManager.isPatchedLibrary(libraryObject['H5P.Example1'][0])
-        ).toEqual(false);
+        ).toBeUndefined();
     });
 
     it("doesn't install libraries if a library is corrupt and leaves no traces", async () => {
@@ -91,7 +91,7 @@ describe('basic file library manager functionality', () => {
                         path.resolve('test/data/patches/H5P.Example1-1.1.2'),
                         false
                     )
-                ).resolves.toEqual(true);
+                ).resolves.toHaveProperty('type', 'new');
 
                 // try installing library version 1.1.1 (should fail)
                 await expect(
@@ -99,7 +99,7 @@ describe('basic file library manager functionality', () => {
                         path.resolve('test/data/patches/H5P.Example1-1.1.1'),
                         false
                     )
-                ).resolves.toEqual(false);
+                ).resolves.toHaveProperty('type', 'none');
 
                 // check if library version 1.1.2 is still installed
                 const installedLibraries = await libManager.getInstalled([
@@ -122,7 +122,7 @@ describe('basic file library manager functionality', () => {
                         path.resolve('test/data/patches/H5P.Example1-1.1.2'),
                         false
                     )
-                ).resolves.toEqual(false);
+                ).resolves.toMatchObject({ type: 'none' });
             },
             { keep: false, unsafeCleanup: true }
         );
@@ -141,7 +141,7 @@ describe('basic file library manager functionality', () => {
                         path.resolve('test/data/patches/H5P.Example1-1.1.1'),
                         false
                     )
-                ).resolves.toEqual(true);
+                ).resolves.toHaveProperty('type', 'new');
 
                 // try installing library version 1.2.0 (should success)
                 await expect(
@@ -149,7 +149,15 @@ describe('basic file library manager functionality', () => {
                         path.resolve('test/data/patches/H5P.Example1-1.2.0'),
                         false
                     )
-                ).resolves.toEqual(true);
+                ).resolves.toMatchObject({
+                    newVersion: {
+                        machineName: 'H5P.Example1',
+                        majorVersion: 1,
+                        minorVersion: 2,
+                        patchVersion: 0
+                    },
+                    type: 'new'
+                });
 
                 // check if library version 1.1.2  and 1.2.0 are now installed
                 const installedLibraries = await libManager.getInstalled([
@@ -192,7 +200,7 @@ describe('basic file library manager functionality', () => {
                         path.resolve('test/data/patches/H5P.Example1-1.1.1'),
                         false
                     )
-                ).resolves.toEqual(true);
+                ).resolves.toMatchObject({ type: 'new' });
 
                 // try installing library version 1.1.2 (should success)
                 await expect(
@@ -200,7 +208,21 @@ describe('basic file library manager functionality', () => {
                         path.resolve('test/data/patches/H5P.Example1-1.1.2'),
                         false
                     )
-                ).resolves.toEqual(true);
+                ).resolves.toMatchObject({
+                    newVersion: {
+                        machineName: 'H5P.Example1',
+                        majorVersion: 1,
+                        minorVersion: 1,
+                        patchVersion: 2
+                    },
+                    oldVersion: {
+                        machineName: 'H5P.Example1',
+                        majorVersion: 1,
+                        minorVersion: 1,
+                        patchVersion: 1
+                    },
+                    type: 'patch'
+                });
 
                 // check if library version 1.1.2 is now installed
                 const installedLibraries = await libManager.getInstalled([
@@ -234,7 +256,9 @@ describe('basic file library manager functionality', () => {
                         path.resolve('test/data/patches/H5P.Example1-1.1.1'),
                         false
                     )
-                ).resolves.toEqual(true);
+                ).resolves.toMatchObject({
+                    type: 'new'
+                });
 
                 // try installing library version 1.1.3 (should fail)
                 await expect(

--- a/test/PackageImporter.test.ts
+++ b/test/PackageImporter.test.ts
@@ -29,9 +29,19 @@ describe('package importer', () => {
                     new TranslationService({}),
                     new EditorConfig(null)
                 );
-                await packageImporter.installLibrariesFromPackage(
+                const installedLibraryNames = await packageImporter.installLibrariesFromPackage(
                     path.resolve('test/data/validator/valid2.h5p')
                 );
+
+                expect(installedLibraryNames.length).toEqual(1);
+                expect(installedLibraryNames[0].type).toEqual('new');
+                expect(installedLibraryNames[0].oldVersion).toBeUndefined();
+                expect(installedLibraryNames[0].newVersion).toMatchObject({
+                    machineName: 'H5P.GreetingCard',
+                    majorVersion: 1,
+                    minorVersion: 0,
+                    patchVersion: 6
+                });
 
                 // Check if library was installed correctly
                 const installedLibraries = await libraryManager.getInstalled();


### PR DESCRIPTION
To ease proper status reporting through the AJAX interface I've added the capability to get a list of libraries that were installed when uploading a package or when installing from the hub.