### PR TITLE
fix(library storage): Made ILibraryStorage.getFileStream async

### DIFF
--- a/src/LibraryManager.ts
+++ b/src/LibraryManager.ts
@@ -54,7 +54,10 @@ export default class LibraryManager {
      * @param {string} filename the relative path inside the library
      * @returns {ReadStream} a readable stream of the file's contents
      */
-    public getFileStream(library: ILibraryName, file: string): ReadStream {
+    public async getFileStream(
+        library: ILibraryName,
+        file: string
+    ): Promise<ReadStream> {
         log.debug(
             `getting file ${file} from library ${LibraryName.toUberName(
                 library

--- a/src/PackageExporter.ts
+++ b/src/PackageExporter.ts
@@ -125,7 +125,10 @@ export default class PackageExporter {
                 const files = await this.libraryManager.listFiles(dependency);
                 for (const file of files) {
                     outputZipFile.addReadStream(
-                        await this.libraryManager.getFileStream(dependency, file),
+                        await this.libraryManager.getFileStream(
+                            dependency,
+                            file
+                        ),
                         `${LibraryName.toUberName(dependency)}/${file}`
                     );
                 }

--- a/src/PackageExporter.ts
+++ b/src/PackageExporter.ts
@@ -125,7 +125,7 @@ export default class PackageExporter {
                 const files = await this.libraryManager.listFiles(dependency);
                 for (const file of files) {
                     outputZipFile.addReadStream(
-                        this.libraryManager.getFileStream(dependency, file),
+                        await this.libraryManager.getFileStream(dependency, file),
                         `${LibraryName.toUberName(dependency)}/${file}`
                     );
                 }

--- a/src/adapters/express.ts
+++ b/src/adapters/express.ts
@@ -20,7 +20,7 @@ export default function(
     router.get(
         `${h5pEditor.config.librariesUrl}/:uberName/:file(*)`,
         async (req, res) => {
-            const stream = h5pEditor.libraryManager.getFileStream(
+            const stream = await h5pEditor.libraryManager.getFileStream(
                 H5P.LibraryName.fromUberName(req.params.uberName),
                 req.params.file
             );

--- a/src/implementation/fs/FileLibraryStorage.ts
+++ b/src/implementation/fs/FileLibraryStorage.ts
@@ -115,7 +115,7 @@ export default class FileLibraryStorage implements ILibraryStorage {
         library: ILibraryName,
         filename: string
     ): Promise<ReadStream> {
-        if (!await this.fileExists(library, filename)) {
+        if (!(await this.fileExists(library, filename))) {
             throw new Error('File does not exist.'); // TODO: add nicer H5P error
         }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -427,12 +427,11 @@ export interface ILibraryStorage {
     /**
      * Returns a readable stream of a library file's contents.
      * Throws an exception if the file does not exist.
-     * NOTE: THIS METHOD IS NOT ASYNC!
      * @param library library
      * @param filename the relative path inside the library
      * @returns a readable stream of the file's contents
      */
-    getFileStream(library: ILibraryName, file: string): ReadStream;
+    getFileStream(library: ILibraryName, file: string): Promise<ReadStream>;
 
     /**
      * Returns all installed libraries or the installed libraries that have the machine names in the arguments.


### PR DESCRIPTION
Now all methods in the interface are async. This is needed for proper error checking. Otherwise the storage throws file system errors.

Also introduced a ignore pattern in FileLibraryStorage needed for https://github.com/sr258/h5p-dev-server