### PR TITLE
refactor(Express adapter): refactored the adapter to be more configurable

### DIFF
--- a/src/adapters/express.ts
+++ b/src/adapters/express.ts
@@ -23,20 +23,24 @@ export default function (
     const router = express.Router();
     const h5pController = new ExpressH5PController(h5pEditor);
 
+    const undefinedOrTrue = (option: boolean): boolean =>
+        option === undefined || option;
+
     /**
      * Calls the function passed to it and catches errors it throws. These arrows are then
      * passed to the next(...) function for proper error handling.
+     * You can disable error catching by setting options.handleErrors to false
      * @param fn The function to call
      */
     const catchAndPassOnErrors = (fn) => (...args) => {
-        if (options.handleErrors) {
+        if (undefinedOrTrue(options.handleErrors)) {
             return fn(...args).catch(args[2]);
         }
         return fn(...args);
     };
 
     // get library file
-    if (options.routeGetLibraryFile) {
+    if (undefinedOrTrue(options.routeGetLibraryFile)) {
         router.get(
             `${h5pEditor.config.librariesUrl}/:uberName/:file(*)`,
             catchAndPassOnErrors(h5pController.getLibraryFile)
@@ -44,7 +48,7 @@ export default function (
     }
 
     // get content file
-    if (options.routeGetContentFile) {
+    if (undefinedOrTrue(options.routeGetContentFile)) {
         router.get(
             `${h5pEditor.config.contentFilesUrl}/:id/:file(*)`,
             catchAndPassOnErrors(h5pController.getContentFile)
@@ -52,7 +56,7 @@ export default function (
     }
 
     // get temporary content file
-    if (options.routeGetTemporaryContentFile) {
+    if (undefinedOrTrue(options.routeGetTemporaryContentFile)) {
         router.get(
             `${h5pEditor.config.temporaryFilesUrl}/:file(*)`,
             catchAndPassOnErrors(h5pController.getTemporaryContentFile)
@@ -60,7 +64,7 @@ export default function (
     }
 
     // get parameters (= content.json) of content
-    if (options.routeGetParameters) {
+    if (undefinedOrTrue(options.routeGetParameters)) {
         router.get(
             `${h5pEditor.config.paramsUrl}/:contentId`,
             catchAndPassOnErrors(h5pController.getContentParameters)
@@ -68,7 +72,7 @@ export default function (
     }
 
     // get various things through the Ajax endpoint
-    if (options.routeGetAjax) {
+    if (undefinedOrTrue(options.routeGetAjax)) {
         router.get(
             h5pEditor.config.ajaxUrl,
             catchAndPassOnErrors(h5pController.getAjax)
@@ -79,7 +83,7 @@ export default function (
     // Don't be confused by the fact that many of the requests dealt with here are not
     // really POST requests, but look more like GET requests. This is simply how the H5P
     // client works and we can't change it.
-    if (options.routePostAjax) {
+    if (undefinedOrTrue(options.routePostAjax)) {
         router.post(
             h5pEditor.config.ajaxUrl,
             catchAndPassOnErrors(h5pController.postAjax)
@@ -87,12 +91,12 @@ export default function (
     }
 
     // serve core files (= JavaScript + CSS from h5p-php-library)
-    if (options.routeCoreFiles) {
+    if (undefinedOrTrue(options.routeCoreFiles)) {
         router.use(h5pEditor.config.coreUrl, express.static(h5pCorePath));
     }
 
     // serve editor core files (= JavaScript + CSS from h5p-editor-php-library)
-    if (options.routeEditorCoreFiles) {
+    if (undefinedOrTrue(options.routeEditorCoreFiles)) {
         router.use(
             h5pEditor.config.editorLibraryUrl,
             express.static(h5pEditorLibraryPath)
@@ -100,14 +104,14 @@ export default function (
     }
 
     // serve download links
-    if (options.routeGetDownload) {
+    if (undefinedOrTrue(options.routeGetDownload)) {
         router.get(
             `${h5pEditor.config.downloadUrl}/:contentId`,
             catchAndPassOnErrors(h5pController.getDownload)
         );
     }
 
-    if (options.handleErrors) {
+    if (undefinedOrTrue(options.handleErrors)) {
         router.use(expressErrorHandler);
     }
 

--- a/src/adapters/express.ts
+++ b/src/adapters/express.ts
@@ -1,337 +1,115 @@
 import express from 'express';
-import path from 'path';
 
-import * as H5P from '../';
-import AjaxSuccessResponse from '../helpers/AjaxSuccessResponse';
+import { H5PEditor } from '../';
 import expressErrorHandler from './expressErrorHandler';
+import ExpressH5PController from './expressController';
+import ExpressRouterOptions from './expressRouterOptions';
 
 /**
  * This router implements all Ajax calls necessary for the H5P (editor) client to work.
  * Use it like this: server.use('/h5p', H5P.adapters.express(h5pEditor, path.resolve('h5p/core'), path.resolve('h5p/editor')));
+ * If you only want certain routes, you can specify this in the options parameter.
  * @param h5pEditor the editor object
  * @param h5pCorePath the path on the local disk at which the core files (of the player) can be found
  * @param h5pEditorLibraryPath the path on the local disk at which the core files of the editor can be found
+ * @param options sets which routes you want and how to handle errors
  */
 export default function (
-    h5pEditor: H5P.H5PEditor,
+    h5pEditor: H5PEditor,
     h5pCorePath: string,
-    h5pEditorLibraryPath: string
+    h5pEditorLibraryPath: string,
+    options: ExpressRouterOptions = new ExpressRouterOptions()
 ): express.Router {
     const router = express.Router();
+    const h5pController = new ExpressH5PController(h5pEditor);
 
     /**
      * Calls the function passed to it and catches errors it throws. These arrows are then
      * passed to the next(...) function for proper error handling.
      * @param fn The function to call
      */
-    const catchAndPassOnErrors = (fn) => (...args) =>
-        fn(...args).catch(args[2]);
+    const catchAndPassOnErrors = (fn) => (...args) => {
+        if (options.handleErrors) {
+            return fn(...args).catch(args[2]);
+        }
+        return fn(...args);
+    };
 
     // get library file
-    router.get(
-        `${h5pEditor.config.librariesUrl}/:uberName/:file(*)`,
-        catchAndPassOnErrors(async (req, res) => {
-            const stream = await h5pEditor.getLibraryFileStream(
-                H5P.LibraryName.fromUberName(req.params.uberName),
-                req.params.file
-            );
-            stream.on('end', () => {
-                res.end();
-            });
-            stream.pipe(res.type(path.basename(req.params.file)));
-        })
-    );
+    if (options.routeGetLibraryFile) {
+        router.get(
+            `${h5pEditor.config.librariesUrl}/:uberName/:file(*)`,
+            catchAndPassOnErrors(h5pController.getLibraryFile)
+        );
+    }
 
     // get content file
-    router.get(
-        `${h5pEditor.config.contentFilesUrl}/:id/:file(*)`,
-        catchAndPassOnErrors(async (req, res) => {
-            const stream = await h5pEditor.getContentFileStream(
-                req.params.id,
-                req.params.file,
-                req.user
-            );
-            stream.on('end', () => {
-                res.end();
-            });
-            stream.pipe(res.type(path.basename(req.params.file)));
-        })
-    );
+    if (options.routeGetContentFile) {
+        router.get(
+            `${h5pEditor.config.contentFilesUrl}/:id/:file(*)`,
+            catchAndPassOnErrors(h5pController.getContentFile)
+        );
+    }
 
     // get temporary content file
-    router.get(
-        `${h5pEditor.config.temporaryFilesUrl}/:file(*)`,
-        catchAndPassOnErrors(async (req, res, next) => {
-            const stream = await h5pEditor.getContentFileStream(
-                undefined,
-                req.params.file,
-                req.user
-            );
-            stream.on('end', () => {
-                res.end();
-            });
-            stream.pipe(res.type(path.basename(req.params.file)));
-        })
-    );
+    if (options.routeGetTemporaryContentFile) {
+        router.get(
+            `${h5pEditor.config.temporaryFilesUrl}/:file(*)`,
+            catchAndPassOnErrors(h5pController.getTemporaryContentFile)
+        );
+    }
 
     // get parameters (= content.json) of content
-    router.get(
-        `${h5pEditor.config.paramsUrl}/:contentId`,
-        catchAndPassOnErrors(async (req, res) => {
-            const content = await h5pEditor.getContent(
-                req.params.contentId,
-                req.user
-            );
-            res.status(200).json(content);
-        })
-    );
+    if (options.routeGetParameters) {
+        router.get(
+            `${h5pEditor.config.paramsUrl}/:contentId`,
+            catchAndPassOnErrors(h5pController.getContentParameters)
+        );
+    }
 
     // get various things through the Ajax endpoint
-    router.get(
-        h5pEditor.config.ajaxUrl,
-        catchAndPassOnErrors(async (req, res) => {
-            const { action } = req.query;
-            const {
-                majorVersion,
-                minorVersion,
-                machineName,
-                language
-            } = req.query;
-
-            switch (action) {
-                case 'content-type-cache':
-                    const contentTypeCache = await h5pEditor.getContentTypeCache(
-                        req.user
-                    );
-                    res.status(200).json(contentTypeCache);
-                    break;
-
-                case 'libraries':
-                    const library = await h5pEditor.getLibraryData(
-                        machineName,
-                        majorVersion,
-                        minorVersion,
-                        language
-                    );
-                    res.status(200).json(library);
-
-                    break;
-
-                default:
-                    res.status(400).end();
-                    break;
-            }
-        })
-    );
+    if (options.routeGetAjax) {
+        router.get(
+            h5pEditor.config.ajaxUrl,
+            catchAndPassOnErrors(h5pController.getAjax)
+        );
+    }
 
     // post various things through the Ajax endpoint
     // Don't be confused by the fact that many of the requests dealt with here are not
     // really POST requests, but look more like GET requests. This is simply how the H5P
     // client works and we can't change it.
-    router.post(
-        h5pEditor.config.ajaxUrl,
-        catchAndPassOnErrors(async (req, res) => {
-            const { action } = req.query;
-
-            let updatedLibCount: number;
-            let installedLibCount: number;
-
-            const getLibraryResultText = (
-                installed: number,
-                updated: number
-            ): string =>
-                `${
-                    installed
-                        ? req.t('installed-libraries', { count: installed })
-                        : ''
-                } ${
-                    updated
-                        ? req.t('updated-libraries', { count: updated })
-                        : ''
-                }`.trim();
-
-            switch (action) {
-                case 'libraries':
-                    const libraryOverview = await h5pEditor.getLibraryOverview(
-                        req.body.libraries
-                    );
-                    res.status(200).json(libraryOverview);
-                    break;
-                case 'translations':
-                    const translationsResponse = await h5pEditor.listLibraryLanguageFiles(
-                        req.body.libraries,
-                        req.query.language
-                    );
-                    res.status(200).json(
-                        new AjaxSuccessResponse(translationsResponse)
-                    );
-                    break;
-                case 'files':
-                    if (!req.body.field) {
-                        throw new H5P.H5pError(
-                            'malformed-request',
-                            { error: "'field' property is missing in request" },
-                            400
-                        );
-                    }
-                    let field: any;
-                    try {
-                        field = JSON.parse(req.body.field);
-                    } catch (e) {
-                        throw new H5P.H5pError(
-                            'malformed-request',
-                            {
-                                error:
-                                    "'field' property is malformed (must be in JSON)"
-                            },
-                            400
-                        );
-                    }
-                    const uploadFileResponse = await h5pEditor.saveContentFile(
-                        req.body.contentId === '0'
-                            ? req.query.contentId
-                            : req.body.contentId,
-                        field,
-                        req.files.file,
-                        req.user
-                    );
-                    res.status(200).json(uploadFileResponse);
-                    break;
-                case 'filter':
-                    if (!req.body.libraryParameters) {
-                        throw new H5P.H5pError(
-                            'malformed-request',
-                            { error: 'libraryParameters missing' },
-                            400
-                        );
-                    }
-                    const {
-                        library: unfilteredLibrary,
-                        params: unfilteredParams,
-                        metadata: unfilteredMetadata
-                    } = JSON.parse(req.body.libraryParameters);
-
-                    if (
-                        !unfilteredLibrary ||
-                        !unfilteredParams ||
-                        !unfilteredMetadata
-                    ) {
-                        throw new H5P.H5pError(
-                            'malformed-request',
-                            { error: 'Property missing in libraryParameters' },
-                            400
-                        );
-                    }
-
-                    // TODO: properly filter params, this is just a hack to get uploading working
-
-                    res.status(200).json(
-                        new AjaxSuccessResponse({
-                            library: unfilteredLibrary,
-                            metadata: unfilteredMetadata,
-                            params: unfilteredParams
-                        })
-                    );
-                    break;
-                case 'library-install':
-                    if (!req.query || !req.query.id || !req.user) {
-                        throw new H5P.H5pError(
-                            'malformed-request',
-                            { error: 'Request Parameters incorrect.' },
-                            400
-                        );
-                    }
-                    const installedLibs = await h5pEditor.installLibraryFromHub(
-                        req.query.id,
-                        req.user
-                    );
-                    updatedLibCount = installedLibs.filter(
-                        (l) => l.type === 'patch'
-                    ).length;
-                    installedLibCount = installedLibs.filter(
-                        (l) => l.type === 'new'
-                    ).length;
-
-                    const contentTypeCache = await h5pEditor.getContentTypeCache(
-                        req.user
-                    );
-                    res.status(200).json(
-                        new AjaxSuccessResponse(
-                            contentTypeCache,
-                            installedLibCount + updatedLibCount > 0
-                                ? getLibraryResultText(
-                                      installedLibCount,
-                                      updatedLibCount
-                                  )
-                                : undefined
-                        )
-                    );
-                    break;
-                case 'library-upload':
-                    const {
-                        installedLibraries,
-                        metadata,
-                        parameters
-                    } = await h5pEditor.uploadPackage(
-                        req.files.h5p.data,
-                        req.user
-                    );
-                    updatedLibCount = installedLibraries.filter(
-                        (l) => l.type === 'patch'
-                    ).length;
-                    installedLibCount = installedLibraries.filter(
-                        (l) => l.type === 'new'
-                    ).length;
-
-                    const contentTypes = await h5pEditor.getContentTypeCache(
-                        req.user
-                    );
-                    res.status(200).json(
-                        new AjaxSuccessResponse(
-                            {
-                                content: parameters,
-                                contentTypes,
-                                h5p: metadata
-                            },
-                            installedLibCount + updatedLibCount > 0
-                                ? getLibraryResultText(
-                                      installedLibCount,
-                                      updatedLibCount
-                                  )
-                                : undefined
-                        )
-                    );
-                    break;
-                default:
-                    res.status(500).end('NOT IMPLEMENTED');
-                    break;
-            }
-        })
-    );
+    if (options.routePostAjax) {
+        router.post(
+            h5pEditor.config.ajaxUrl,
+            catchAndPassOnErrors(h5pController.postAjax)
+        );
+    }
 
     // serve core files (= JavaScript + CSS from h5p-php-library)
-    router.use(h5pEditor.config.coreUrl, express.static(h5pCorePath));
+    if (options.routeCoreFiles) {
+        router.use(h5pEditor.config.coreUrl, express.static(h5pCorePath));
+    }
 
     // serve editor core files (= JavaScript + CSS from h5p-editor-php-library)
-    router.use(
-        h5pEditor.config.editorLibraryUrl,
-        express.static(h5pEditorLibraryPath)
-    );
+    if (options.routeEditorCoreFiles) {
+        router.use(
+            h5pEditor.config.editorLibraryUrl,
+            express.static(h5pEditorLibraryPath)
+        );
+    }
 
     // serve download links
-    router.get(
-        `${h5pEditor.config.downloadUrl}/:contentId`,
-        catchAndPassOnErrors(async (req, res) => {
-            // set filename for the package with .h5p extension
-            res.setHeader(
-                'Content-disposition',
-                `attachment; filename=${req.params.contentId}.h5p`
-            );
-            await h5pEditor.exportContent(req.params.contentId, res, req.user);
-        })
-    );
+    if (options.routeGetDownload) {
+        router.get(
+            `${h5pEditor.config.downloadUrl}/:contentId`,
+            catchAndPassOnErrors(h5pController.getDownload)
+        );
+    }
 
-    router.use(expressErrorHandler);
+    if (options.handleErrors) {
+        router.use(expressErrorHandler);
+    }
 
     return router;
 }

--- a/src/adapters/expressController.ts
+++ b/src/adapters/expressController.ts
@@ -1,0 +1,303 @@
+import * as express from 'express';
+import * as path from 'path';
+
+import { H5PEditor, LibraryName, H5pError } from './..';
+import AjaxSuccessResponse from '../helpers/AjaxSuccessResponse';
+
+/**
+ * The methods in this class can be used to answer AJAX requests that are received by Express routers.
+ * You can use all methods independently at your convenience.
+ * Note that even though the names getAjax and postAjax imply that only these methods deal with AJAX
+ * requests, ALL methods except getDownload deal with AJAX requests. This confusion is caused by the
+ * HTTP interface the H5P client uses and we can't change it.
+ */
+export default class ExpressH5PController {
+    constructor(protected h5pEditor: H5PEditor) {}
+
+    /**
+     * Get various things through the Ajax endpoint.
+     */
+    public getAjax = async (
+        req: express.Request,
+        res: express.Result
+    ): Promise<void> => {
+        const { action } = req.query;
+        const { majorVersion, minorVersion, machineName, language } = req.query;
+
+        switch (action) {
+            case 'content-type-cache':
+                const contentTypeCache = await this.h5pEditor.getContentTypeCache(
+                    req.user
+                );
+                res.status(200).json(contentTypeCache);
+                break;
+
+            case 'libraries':
+                const library = await this.h5pEditor.getLibraryData(
+                    machineName,
+                    majorVersion,
+                    minorVersion,
+                    language
+                );
+                res.status(200).json(library);
+
+                break;
+
+            default:
+                res.status(400).end();
+                break;
+        }
+    };
+
+    public getContentFile = async (
+        req: express.Request,
+        res: express.Result
+    ): Promise<void> => {
+        const stream = await this.h5pEditor.getContentFileStream(
+            req.params.id,
+            req.params.file,
+            req.user
+        );
+        stream.on('end', () => {
+            res.end();
+        });
+        stream.pipe(res.type(path.basename(req.params.file)));
+    };
+
+    public getContentParameters = async (
+        req: express.Request,
+        res: express.Result
+    ): Promise<void> => {
+        const content = await this.h5pEditor.getContent(
+            req.params.contentId,
+            req.user
+        );
+        res.status(200).json(content);
+    };
+
+    public getDownload = async (
+        req: express.Request,
+        res: express.Result
+    ): Promise<void> => {
+        // set filename for the package with .h5p extension
+        res.setHeader(
+            'Content-disposition',
+            `attachment; filename=${req.params.contentId}.h5p`
+        );
+        await this.h5pEditor.exportContent(req.params.contentId, res, req.user);
+    };
+
+    public getLibraryFile = async (
+        req: express.Request,
+        res: express.Result
+    ): Promise<void> => {
+        const stream = await this.h5pEditor.getLibraryFileStream(
+            LibraryName.fromUberName(req.params.uberName),
+            req.params.file
+        );
+        stream.on('end', () => {
+            res.end();
+        });
+        stream.pipe(res.type(path.basename(req.params.file)));
+    };
+
+    public getTemporaryContentFile = async (
+        req: express.Request,
+        res: express.Result
+    ): Promise<void> => {
+        const stream = await this.h5pEditor.getContentFileStream(
+            undefined,
+            req.params.file,
+            req.user
+        );
+        stream.on('end', () => {
+            res.end();
+        });
+        stream.pipe(res.type(path.basename(req.params.file)));
+    };
+
+    /**
+     * Post various things through the Ajax endpoint
+     * Don't be confused by the fact that many of the requests dealt with here are not
+     * really POST requests, but look more like GET requests. This is simply how the H5P
+     * client works and we can't change it.
+     */
+    public postAjax = async (
+        req: express.Request,
+        res: express.Result
+    ): Promise<void> => {
+        const { action } = req.query;
+
+        let updatedLibCount: number;
+        let installedLibCount: number;
+
+        const getLibraryResultText = (
+            installed: number,
+            updated: number
+        ): string =>
+            `${
+                installed
+                    ? req.t('installed-libraries', { count: installed })
+                    : ''
+            } ${
+                updated ? req.t('updated-libraries', { count: updated }) : ''
+            }`.trim();
+
+        switch (action) {
+            case 'libraries':
+                const libraryOverview = await this.h5pEditor.getLibraryOverview(
+                    req.body.libraries
+                );
+                res.status(200).json(libraryOverview);
+                break;
+            case 'translations':
+                const translationsResponse = await this.h5pEditor.listLibraryLanguageFiles(
+                    req.body.libraries,
+                    req.query.language
+                );
+                res.status(200).json(
+                    new AjaxSuccessResponse(translationsResponse)
+                );
+                break;
+            case 'files':
+                if (!req.body.field) {
+                    throw new H5pError(
+                        'malformed-request',
+                        { error: "'field' property is missing in request" },
+                        400
+                    );
+                }
+                let field: any;
+                try {
+                    field = JSON.parse(req.body.field);
+                } catch (e) {
+                    throw new H5pError(
+                        'malformed-request',
+                        {
+                            error:
+                                "'field' property is malformed (must be in JSON)"
+                        },
+                        400
+                    );
+                }
+                const uploadFileResponse = await this.h5pEditor.saveContentFile(
+                    req.body.contentId === '0'
+                        ? req.query.contentId
+                        : req.body.contentId,
+                    field,
+                    req.files.file,
+                    req.user
+                );
+                res.status(200).json(uploadFileResponse);
+                break;
+            case 'filter':
+                if (!req.body.libraryParameters) {
+                    throw new H5pError(
+                        'malformed-request',
+                        { error: 'libraryParameters missing' },
+                        400
+                    );
+                }
+                const {
+                    library: unfilteredLibrary,
+                    params: unfilteredParams,
+                    metadata: unfilteredMetadata
+                } = JSON.parse(req.body.libraryParameters);
+
+                if (
+                    !unfilteredLibrary ||
+                    !unfilteredParams ||
+                    !unfilteredMetadata
+                ) {
+                    throw new H5pError(
+                        'malformed-request',
+                        { error: 'Property missing in libraryParameters' },
+                        400
+                    );
+                }
+
+                // TODO: properly filter params, this is just a hack to get uploading working
+
+                res.status(200).json(
+                    new AjaxSuccessResponse({
+                        library: unfilteredLibrary,
+                        metadata: unfilteredMetadata,
+                        params: unfilteredParams
+                    })
+                );
+                break;
+            case 'library-install':
+                if (!req.query || !req.query.id || !req.user) {
+                    throw new H5pError(
+                        'malformed-request',
+                        { error: 'Request Parameters incorrect.' },
+                        400
+                    );
+                }
+                const installedLibs = await this.h5pEditor.installLibraryFromHub(
+                    req.query.id,
+                    req.user
+                );
+                updatedLibCount = installedLibs.filter(
+                    (l) => l.type === 'patch'
+                ).length;
+                installedLibCount = installedLibs.filter(
+                    (l) => l.type === 'new'
+                ).length;
+
+                const contentTypeCache = await this.h5pEditor.getContentTypeCache(
+                    req.user
+                );
+                res.status(200).json(
+                    new AjaxSuccessResponse(
+                        contentTypeCache,
+                        installedLibCount + updatedLibCount > 0
+                            ? getLibraryResultText(
+                                  installedLibCount,
+                                  updatedLibCount
+                              )
+                            : undefined
+                    )
+                );
+                break;
+            case 'library-upload':
+                const {
+                    installedLibraries,
+                    metadata,
+                    parameters
+                } = await this.h5pEditor.uploadPackage(
+                    req.files.h5p.data,
+                    req.user
+                );
+                updatedLibCount = installedLibraries.filter(
+                    (l) => l.type === 'patch'
+                ).length;
+                installedLibCount = installedLibraries.filter(
+                    (l) => l.type === 'new'
+                ).length;
+
+                const contentTypes = await this.h5pEditor.getContentTypeCache(
+                    req.user
+                );
+                res.status(200).json(
+                    new AjaxSuccessResponse(
+                        {
+                            content: parameters,
+                            contentTypes,
+                            h5p: metadata
+                        },
+                        installedLibCount + updatedLibCount > 0
+                            ? getLibraryResultText(
+                                  installedLibCount,
+                                  updatedLibCount
+                              )
+                            : undefined
+                    )
+                );
+                break;
+            default:
+                res.status(500).end('NOT IMPLEMENTED');
+                break;
+        }
+    };
+}

--- a/src/adapters/expressRouterOptions.ts
+++ b/src/adapters/expressRouterOptions.ts
@@ -1,0 +1,15 @@
+/**
+ * Allows you to choose which routes you want in the Express Router
+ */
+export default class ExpressRouterOptions {
+    public handleErrors?: boolean = true;
+    public routeCoreFiles?: boolean = true;
+    public routeEditorCoreFiles?: boolean = true;
+    public routeGetAjax?: boolean = true;
+    public routeGetContentFile?: boolean = true;
+    public routeGetDownload?: boolean = true;
+    public routeGetLibraryFile?: boolean = true;
+    public routeGetParameters?: boolean = true;
+    public routeGetTemporaryContentFile?: boolean = true;
+    public routePostAjax?: boolean = true;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,9 +37,11 @@ import {
 // Adapters
 import express from './adapters/express';
 import expressErrorHandler from './adapters/expressErrorHandler';
+import expressController from './adapters/expressController';
 
 const adapters = {
     express,
+    expressController,
     expressErrorHandler
 };
 

--- a/test/adapters/express.configurations.test.ts
+++ b/test/adapters/express.configurations.test.ts
@@ -1,0 +1,114 @@
+import axios from 'axios';
+import axiosMockAdapter from 'axios-mock-adapter';
+import bodyParser from 'body-parser';
+import express from 'express';
+import fileUpload from 'express-fileupload';
+import path from 'path';
+import supertest from 'supertest';
+import { dir } from 'tmp-promise';
+
+import User from '../../examples/User';
+import * as H5P from '../../src';
+
+const axiosMock = new axiosMockAdapter(axios);
+
+describe('Configuration of the Express Ajax endpoint adapter', () => {
+    const user: H5P.IUser = new User();
+    let app: express;
+    let cleanup: () => Promise<void>;
+    let h5pEditor: H5P.H5PEditor;
+    let tempDir: string;
+
+    beforeEach(async () => {
+        app = express();
+        const tDir = await dir({ unsafeCleanup: true });
+
+        app.use(bodyParser.json());
+        app.use(
+            bodyParser.urlencoded({
+                extended: true
+            })
+        );
+        app.use(
+            fileUpload({
+                limits: { fileSize: 50 * 1024 * 1024 }
+            })
+        );
+        tempDir = tDir.path;
+        cleanup = tDir.cleanup;
+        h5pEditor = H5P.fs(
+            new H5P.H5PConfig(new H5P.fsImplementations.InMemoryStorage(), {
+                baseUrl: ''
+            }),
+            path.resolve(path.join(tempDir, 'libraries')), // the path on the local disc where libraries should be stored
+            path.resolve(path.join(tempDir, 'temporary-storage')), // the path on the local disc where temporary files (uploads) should be stored
+            path.resolve(path.join(tempDir, 'content')) // the path on the local disc where content is stored
+        );
+        axiosMock
+            .onPost(h5pEditor.config.hubRegistrationEndpoint)
+            .reply(
+                200,
+                require('../data/content-type-cache/registration.json')
+            );
+        axiosMock
+            .onPost(h5pEditor.config.hubContentTypesEndpoint)
+            .reply(
+                200,
+                require('../data/content-type-cache/real-content-types.json')
+            );
+        app.use((req, res, next) => {
+            req.user = user;
+            req.language = 'en';
+            req.languages = 'en';
+            req.t = (id, replacements) => id;
+            next();
+        });
+    });
+
+    afterEach(async () => {
+        app = null;
+        await cleanup();
+        tempDir = '';
+    });
+
+    it('should throw generic Express errors when then error handler is turned off in the configuration', async () => {
+        app.use(
+            H5P.adapters.express(
+                h5pEditor,
+                path.resolve(path.join(tempDir, 'core')), // the path on the local disc where the files of the JavaScript client of the player are stored
+                path.resolve(path.join(tempDir, 'editor')), // the path on the local disc where the files of the JavaScript client of the editor are stored
+                { handleErrors: true }
+            )
+        );
+        const res = await supertest(app).get('/libraries/H5P.Test-1.0/test.js');
+        expect(res.error).toBeDefined();
+        expect((res.error as any).message).toEqual(
+            'cannot GET /libraries/H5P.Test-1.0/test.js (404)'
+        );
+    });
+
+    it('should not handle routes that are disabled in the configuration', async () => {
+        app.use(
+            H5P.adapters.express(
+                h5pEditor,
+                path.resolve(path.join(tempDir, 'core')), // the path on the local disc where the files of the JavaScript client of the player are stored
+                path.resolve(path.join(tempDir, 'editor')), // the path on the local disc where the files of the JavaScript client of the editor are stored
+                { routeGetLibraryFile: false }
+            )
+        );
+
+        const installResult = await h5pEditor.packageImporter.installLibrariesFromPackage(
+            path.resolve('test/data/validator/valid2.h5p')
+        );
+        expect(installResult.length).toEqual(1);
+        expect(installResult[0].newVersion.machineName).toEqual(
+            'H5P.GreetingCard'
+        );
+        expect(installResult[0].newVersion.majorVersion).toEqual(1);
+        expect(installResult[0].newVersion.minorVersion).toEqual(0);
+        const res = await supertest(app).get(
+            '/libraries/H5P.GreetingCard-1.0/greetingcard.js'
+        );
+        expect(res.status).toBe(404);
+    });
+});


### PR DESCRIPTION
To allow more code reuse in implementations, I've refactored the Express adapter: Now you can opt-out of certain routes and of the default error handling.

@JPSchellenberg The new release version of this should either be 2.0.1 or 2.1.0, but there must be a new release, so I can use it in Lumi. Does refactor lead to a new release? If not, we should merge it as a fix.