### PR TITLE
fix(h5p core): added h5peditor-fullscreenbar.js to assets

### DIFF
--- a/src/editorAssetList.json
+++ b/src/editorAssetList.json
@@ -17,6 +17,7 @@
             "scripts/h5p-hub-client.js",                        
             "scripts/h5peditor-semantic-structure.js",
             "scripts/h5peditor-library-selector.js",
+            "scripts/h5peditor-fullscreen-bar.js",
             "scripts/h5peditor-form.js",
             "scripts/h5peditor-text.js",
             "scripts/h5peditor-html.js",


### PR DESCRIPTION
A JavaScript file was missing from the asset list that was generated for the integration object and the renderer. I've added the file to the list.