### PR TITLE
fix(example): improved package validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
         "download:core": "sh scripts/install.sh",
         "clear": "rm -rf test/data/hub-content && rm -rf h5p/temporary-storage && rm test/data/content-type-cache/real-content-types.json",
         "download:content-type-cache": "ts-node scripts/update-real-content-type-cache.ts",
-        "ci": "npm run build && npm run lint && npm run format:check && npm run test",
+        "ci": "npm run build && npm run lint && npm run format:check && npm run test && npm run test:integration && npm run test:e2e",
         "lint": "./node_modules/.bin/tslint --project tsconfig.json --config tslint.json",
         "test": "jest --testTimeout=120000 --logHeapUsage --maxWorkers=2",
         "test:watch": "jest --watch",

--- a/src/schemas/h5p-schema.json
+++ b/src/schemas/h5p-schema.json
@@ -81,7 +81,10 @@
         },
         "licenseExtras": {
             "type": "string",
-            "pattern": "^.{1,5000}$"
+            "regexp": {
+                "pattern": "^.{1,5000}$",
+                "flags": "s"
+            }
         },
         "yearsFrom": {
             "type": "string",
@@ -108,7 +111,10 @@
                     "log": {
                         "description": "The free text what was changed in the content",
                         "type": "string",
-                        "pattern": "^.{1,5000}$"
+                        "regexp": {
+                            "pattern": "^.{1,5000}$",
+                            "flags": "s"
+                        }
                     }
                 },
                 "required": ["date", "author", "log"]
@@ -116,7 +122,10 @@
         },
         "authorComments": {
             "type": "string",
-            "pattern": "^.{1,5000}$"
+            "regexp": {
+                "pattern": "^.{1,5000}$",
+                "flags": "s"
+            }
         },
         "w": {
             "type": "string",


### PR DESCRIPTION
Some content packages in the wild didn't pass validation because their h5p.json file contained properties with multi-line strings. These strings didn't match the regex in the JSON schema. The new regex now lets them pass.

One example package, which didn't work before, was the Interactive Video package at https://h5p.org/interactive-video.