### PR TITLE
fix(translation): adapter now tolerant of missing translation function

### DIFF
--- a/src/adapters/expressController.ts
+++ b/src/adapters/expressController.ts
@@ -137,10 +137,16 @@ export default class ExpressH5PController {
         ): string =>
             `${
                 installed
-                    ? req.t('installed-libraries', { count: installed })
+                    ? req.t
+                        ? req.t('installed-libraries', { count: installed })
+                        : `Installed ${installed} libraries.`
                     : ''
             } ${
-                updated ? req.t('updated-libraries', { count: updated }) : ''
+                updated
+                    ? req.t
+                        ? req.t('updated-libraries', { count: updated })
+                        : `Updated ${updated} libraries.`
+                    : ''
             }`.trim();
 
         switch (action) {


### PR DESCRIPTION
The change is necessary to avoid a bug in lumi (prevents installing content types from the hub).