### PR TITLE
Fix/player custom scripts

### DIFF
--- a/src/H5PPlayer.ts
+++ b/src/H5PPlayer.ts
@@ -85,7 +85,7 @@ export default class H5PPlayer {
         const model: IPlayerModel = {
             contentId,
             customScripts: this.globalCustomScripts
-                .map((script) => `<script src="${script}"/>`)
+                .map((script) => `<script src="${script}"></script>`)
                 .join(),
             downloadPath: this.getDownloadPath(contentId),
             integration: this.generateIntegration(

--- a/src/adapters/expressController.ts
+++ b/src/adapters/expressController.ts
@@ -137,10 +137,16 @@ export default class ExpressH5PController {
         ): string =>
             `${
                 installed
-                    ? req.t('installed-libraries', { count: installed })
+                    ? req.t
+                        ? req.t('installed-libraries', { count: installed })
+                        : `Installed ${installed} libraries.`
                     : ''
             } ${
-                updated ? req.t('updated-libraries', { count: updated }) : ''
+                updated
+                    ? req.t
+                        ? req.t('updated-libraries', { count: updated })
+                        : `Updated ${updated} libraries.`
+                    : ''
             }`.trim();
 
         switch (action) {

--- a/test/H5PPlayer.renderHtmlPage.test.ts
+++ b/test/H5PPlayer.renderHtmlPage.test.ts
@@ -192,7 +192,7 @@ describe('Rendering the HTML page', () => {
             .render(contentId, contentObject, h5pObject as any)
             .then((model) => {
                 expect((model as any).customScripts).toBe(
-                    '<script src="/test"/>'
+                    '<script src="/test"></script>'
                 );
             });
     });
@@ -337,7 +337,7 @@ describe('Rendering the HTML page', () => {
                       "saveFreq": false,
                       "url": "/h5p"
                     };
-                        </script><script src="/test" />
+                        </script><script src="/test"></script>
                     </head>
                     <body>
                         <div class="h5p-content" data-content-id="foo"></div>


### PR DESCRIPTION
The script tag for custom scripts in the player was not generated in a standard conform way. I've fixed this.