### PR TITLE
refactor(integration): improved typing of integration object

### DIFF
--- a/src/ContentManager.ts
+++ b/src/ContentManager.ts
@@ -26,12 +26,10 @@ export default class ContentManager {
     /**
      * @param contentStorage The storage object
      */
-    constructor(contentStorage: IContentStorage) {
+    constructor(private contentStorage: IContentStorage) {
         log.info('initialize');
         this.contentStorage = contentStorage;
     }
-
-    private contentStorage: IContentStorage;
 
     /**
      * Adds a content file to an existing content object. The content object has to be created with createContent(...) first.

--- a/src/DependencyGetter.ts
+++ b/src/DependencyGetter.ts
@@ -1,6 +1,5 @@
-import LibraryManager from './LibraryManager';
 import LibraryName from './LibraryName';
-import { ILibraryName } from './types';
+import { ILibraryName, ILibraryStorage } from './types';
 
 import Logger from './helpers/Logger';
 const log = new Logger('DependencyGetter');
@@ -9,7 +8,7 @@ const log = new Logger('DependencyGetter');
  * Uses LibraryManager to get metadata for libraries.
  */
 export default class DependencyGetter {
-    constructor(private libraryManager: LibraryManager) {
+    constructor(private libraryStorage: ILibraryStorage) {
         log.info(`initialize`);
     }
 
@@ -76,7 +75,7 @@ export default class DependencyGetter {
         }
         libraries.add(LibraryName.toUberName(library));
 
-        const metadata = await this.libraryManager.getLibrary(library);
+        const metadata = await this.libraryStorage.getLibrary(library);
         if (preloaded && metadata.preloadedDependencies) {
             await this.addDependenciesToSet(
                 metadata.preloadedDependencies,

--- a/src/H5PEditor.ts
+++ b/src/H5PEditor.ts
@@ -96,8 +96,8 @@ export default class H5PEditor {
             this.contentStorer
         );
         this.packageExporter = new PackageExporter(
-            this.libraryManager,
-            this.contentManager
+            this.libraryStorage,
+            this.contentStorage
         );
     }
 

--- a/src/H5PPlayer.ts
+++ b/src/H5PPlayer.ts
@@ -179,7 +179,7 @@ export default class H5PPlayer {
                         frame: false,
                         icon: false
                     },
-                    fullScreen: false,
+                    fullScreen: '0',
                     jsonContent: JSON.stringify(parameters),
                     library: ContentMetadata.toUbername(metadata)
                 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -165,7 +165,7 @@ export interface IIntegration {
      */
     contents?: {
         [key: string]: {
-            contentUserData: {
+            contentUserData?: {
                 /**
                  * The state as a serialized JSON object.
                  */
@@ -183,19 +183,19 @@ export interface IIntegration {
              * The full embed code (<iframe>...</iframe> with absolute URLs).
              * Example: <iframe src=\"https://example.org/h5p/embed/XXX\" width=\":w\" height=\":h\" frameborder=\"0\" allowfullscreen=\"allowfullscreen\"></iframe>"
              */
-            embedCode: string;
+            embedCode?: string;
             /**
              * The download URL (absolute URL).
              */
-            exportUrl: string;
+            exportUrl?: string;
             fullScreen: '0' | '1';
             jsonContent: string;
             /**
              * The ubername with whitespace as separator.
              */
             library: string;
-            mainId: string;
-            metadata: {
+            mainId?: string;
+            metadata?: {
                 defaultLanguage: string;
                 license: string;
                 title: string;
@@ -205,11 +205,11 @@ export interface IIntegration {
              * to make the iframe size to the available width. Use absolute URLs.
              * Example: <script src=\"https://example.org/h5p/library/js/h5p-resizer.js\" charset=\"UTF-8\"></script>
              */
-            resizeCode: string;
+            resizeCode?: string;
             /**
              * The absolute URL to the current content.
              */
-            url: string;
+            url?: string;
         };
     };
     /**
@@ -220,6 +220,16 @@ export interface IIntegration {
      * Can be null.
      */
     crossoriginCacheBuster?: any;
+    /**
+     * We pass certain configuration values to the client with the editor
+     * integration object. Note that the way to pass these values to the client
+     * is NOT standardized and in the PHP implementation it is not the same in
+     * the Drupal, Moodle and WordPress clients. For our NodeJS version
+     * we've decided to put the values into the integration object. The page
+     * created by the editor renderer has to extract these values and put
+     * them into the corresponding properties of the H5PEditor object!
+     * See /src/renderers/default.ts how this can be done!
+     */
     editor?: IEditorIntegration;
     hubIsEnabled: boolean;
     l10n: {
@@ -257,8 +267,12 @@ export interface IIntegration {
 }
 
 /**
- * The editor integration object is used to pass information to the H5P JavaScript
- * editor client about settings and constants of the server.
+ * The editor integration object is used to pass information to the page that
+ * is created by the renderer. Note that this object is NOT standard H5P
+ * behavior but specific to our NodeJS implementation.
+ * The editor view created by the renderer has to copy these values into the
+ * H5PEditor object! This is the responsibility of the implementation and NOT
+ * done by the H5P client automatically!
  */
 export interface IEditorIntegration {
     ajaxPath: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -237,7 +237,7 @@ export interface IIntegration {
      * The cache buster appended to JavaScript and CSS files.
      * Example: ?q8idru
      */
-    pluginCacheBuster: string;
+    pluginCacheBuster?: string;
     postUserStatistics: boolean;
     reportingIsEnabled?: boolean;
     /**
@@ -267,12 +267,26 @@ export interface IEditorIntegration {
         css: string[];
         js: string[];
     };
+    basePath?: string;
+    baseUrl?: string;
+    contentId?: string;
+    contentLanguage?: string;
+    contentRelUrl?: string;
+    copyrightSemantics?: any;
+    editorRelUrl?: string;
+    fileIcon?: {
+        height: number;
+        path: string;
+        width: number;
+    };
     /**
      * The path where **temporary** files can be retrieved from.
      */
     filesPath: string;
     libraryUrl: string;
+    metadataSemantics?: any;
     nodeVersionId: ContentId;
+    relativeUrl?: string;
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -144,19 +144,111 @@ export interface IContentMetadata {
  */
 export interface IIntegration {
     ajax: {
+        /**
+         * The Ajax endpoint called when the user state has changed
+         * Example: /h5p-ajax/content-user-data/:contentId/:dataType/:subContentId?token=XYZ
+         */
         contentUserData: string;
+        /**
+         * An Ajax endpoint called when the user has finished the content.
+         * Example: /h5p-ajax/set-finished.json?token=XYZ
+         */
         setFinished: string;
     };
     ajaxPath: string;
-    contents?: any;
+    /**
+     * The base URL, e.g. https://example.org
+     */
+    baseUrl?: string;
+    /**
+     * The key must be of the form "cid-XXX", where XXX is the id of the content
+     */
+    contents?: {
+        [key: string]: {
+            contentUserData: {
+                /**
+                 * The state as a serialized JSON object.
+                 */
+                state: string;
+            }[];
+            displayOptions: {
+                copy: boolean;
+                copyright: boolean;
+                embed: boolean;
+                export: boolean;
+                frame: boolean;
+                icon: boolean;
+            };
+            /**
+             * The full embed code (<iframe>...</iframe> with absolute URLs).
+             * Example: <iframe src=\"https://example.org/h5p/embed/XXX\" width=\":w\" height=\":h\" frameborder=\"0\" allowfullscreen=\"allowfullscreen\"></iframe>"
+             */
+            embedCode: string;
+            /**
+             * The download URL (absolute URL).
+             */
+            exportUrl: string;
+            fullScreen: '0' | '1';
+            jsonContent: string;
+            /**
+             * The ubername with whitespace as separator.
+             */
+            library: string;
+            mainId: string;
+            metadata: {
+                defaultLanguage: string;
+                license: string;
+                title: string;
+            };
+            /**
+             * A script html tag which can be included alongside the embed code
+             * to make the iframe size to the available width. Use absolute URLs.
+             * Example: <script src=\"https://example.org/h5p/library/js/h5p-resizer.js\" charset=\"UTF-8\"></script>
+             */
+            resizeCode: string;
+            /**
+             * The absolute URL to the current content.
+             */
+            url: string;
+        };
+    };
+    /**
+     * Can be null.
+     */
+    crossorigin?: any;
+    /**
+     * Can be null.
+     */
+    crossoriginCacheBuster?: any;
     editor?: IEditorIntegration;
     hubIsEnabled: boolean;
-    l10n: object;
+    l10n: {
+        H5P: any;
+    };
+    /**
+     * Can be null.
+     */
+    libraryConfig?: any;
+    /**
+     * The URL at which the core files are stored.
+     */
+    libraryUrl?: string;
+    /**
+     * The cache buster appended to JavaScript and CSS files.
+     * Example: ?q8idru
+     */
+    pluginCacheBuster: string;
     postUserStatistics: boolean;
+    reportingIsEnabled?: boolean;
     /**
      * Set to false to disable saving user state.
      */
     saveFreq: number | boolean;
+    /**
+     * The URL at which files can be accessed. Combined with the baseUrl by the
+     * client.
+     * Example. /h5p
+     */
     url: string;
     user: {
         mail: string;

--- a/test/DependencyGetter.test.ts
+++ b/test/DependencyGetter.test.ts
@@ -7,11 +7,11 @@ import LibraryName from '../src/LibraryName';
 
 describe('basic file library manager functionality', () => {
     it('determines dependencies of libraries', async () => {
-        const libManager = new LibraryManager(
-            new FileLibraryStorage(path.resolve('test/data/library-dependency'))
+        const storage = new FileLibraryStorage(
+            path.resolve('test/data/library-dependency')
         );
 
-        const dependencyGetter = new DependencyGetter(libManager);
+        const dependencyGetter = new DependencyGetter(storage);
 
         expect(
             (

--- a/test/H5PPlayer.renderHtmlPage.test.ts
+++ b/test/H5PPlayer.renderHtmlPage.test.ts
@@ -43,7 +43,7 @@ describe('Rendering the HTML page', () => {
                         "frame": false,
                         "icon": false
                       },
-                      "fullScreen": false,
+                      "fullScreen": "0",
                       "jsonContent": "{\\"my\\":\\"content\\"}"
                     }
                   },
@@ -258,7 +258,7 @@ describe('Rendering the HTML page', () => {
                             "frame": false,
                             "icon": false
                           },
-                          "fullScreen": false,
+                          "fullScreen": "0",
                           "jsonContent": "{\\"my\\":\\"content\\"}"
                         }
                       },

--- a/test/PackageExporter.test.ts
+++ b/test/PackageExporter.test.ts
@@ -26,12 +26,10 @@ export async function importAndExportPackage(
             const user = new User();
             user.canUpdateAndInstallLibraries = true;
 
-            const contentManager = new ContentManager(
-                new FileContentStorage(contentDir)
-            );
-            const libraryManager = new LibraryManager(
-                new FileLibraryStorage(libraryDir)
-            );
+            const contentStorage = new FileContentStorage(contentDir);
+            const contentManager = new ContentManager(contentStorage);
+            const libraryStorage = new FileLibraryStorage(libraryDir);
+            const libraryManager = new LibraryManager(libraryStorage);
             const config = new H5PConfig(null);
 
             const packageImporter = new PackageImporter(
@@ -41,8 +39,8 @@ export async function importAndExportPackage(
             );
 
             const packageExporter = new PackageExporter(
-                libraryManager,
-                contentManager
+                libraryStorage,
+                contentStorage
             );
             const contentId = (
                 await packageImporter.addPackageLibrariesAndContent(

--- a/test/implementation/db/MongoS3ContentStorage.test.ts
+++ b/test/implementation/db/MongoS3ContentStorage.test.ts
@@ -249,6 +249,8 @@ describe('MongoS3ContentStorage', () => {
         expect(retrievedFiles.sort()).toMatchObject(files.sort());
     }, 120000);
 
+    // This test is sometimes a bit fragile (s.t. it works, s.t. it doesn't).
+    // We need to look into this.
     it('deletes added files from S3', async () => {
         const contentId = await storage.addContent(
             stubMetadata,

--- a/test/implementation/db/S3TemporaryFileStorage.test.ts
+++ b/test/implementation/db/S3TemporaryFileStorage.test.ts
@@ -112,6 +112,8 @@ describe('MongoS3ContentStorage', () => {
         expect(onFinish1).toHaveBeenCalled();
     });
 
+    // TODO: This test is a bit fragile (sometimes it fails, sometimes it doesn't)
+    // We need to look into this.
     it('deletes added files from S3', async () => {
         const filename = 'testfile1.jpg';
         expect(


### PR DESCRIPTION
The typing of the integration object is more complete now. 

I've also removed the dependency of PackageManager on ContentManager. Now it uses IContentStorage directly. This will be needed for more flexibility when exporting to HTML.