### PR TITLE
feat(storage): direct access to content S3 storage in player

### DIFF
--- a/docs/mongo-s3-content-storage.md
+++ b/docs/mongo-s3-content-storage.md
@@ -114,9 +114,40 @@ getPermissions = (
 ) => Promise<Permission[]>;
 ```
 
-The function receives the contentId of the object that is being accessed and the user who is trying to access it. It must return a list of permissions the user
+The function receives the contentId of the object that is being accessed and the
+user who is trying to access it. It must return a list of permissions the user
 has on this object. Your implementation of this function will probably be an
 adapter that hooks into your rights and permission system.
+
+## Increasing scalability by getting content files directly from S3
+
+In the default setup all resources used by H5P content in the **player** (images,
+video, ...) will be requested from the H5P server. The H5P server in turn will
+request the resources from S3 and relay the results. This means that in a high
+load scenario, there will be a lot of load on the H5P server to serve these
+static files. You can improve scalability by setting up the player to load
+content resources directly from the S3 bucket. For this you must grant read
+access on the bucket to anonymous users. If you have content that must not
+be accessible to the public (for e.g. copyright reasons), this is probably not
+an option.
+
+This currently only works for the player, not for the editor. Because of this
+you must still serve the 'get content file' route to make sure the editor can
+work with resources correctly.
+
+Steps:
+
+1. Grant read-only permission to anonymous users for your bucket with bucket
+   policies. See the [AWS documentation for details](https://docs.aws.amazon.com/AmazonS3/latest/dev/example-bucket-policies.html#example-bucket-policies-use-case-2).
+2. Set the configuration option `contentFilesUrlPlayerOverride` to point to your
+   S3 bucket. The URL must also include the contentID of the object. For this,
+   you must add the placeholder `{{contentId}}` to the configuration value. Examples:
+
+```ts
+contentFilesUrlPlayerOverride = 'https://bucket.s3server.com/{{contentId}}';
+// or
+contentFilesUrlPlayerOverride = 'https://s3server.com/bucket/{{contentId}}';
+```
 
 ## Developing and testing
 

--- a/src/H5PEditor.ts
+++ b/src/H5PEditor.ts
@@ -30,7 +30,7 @@ import {
     IContentMetadata,
     IContentStorage,
     IH5PConfig,
-    IEditorIntegration,
+    ILumiEditorIntegration,
     IIntegration,
     IKeyValueStorage,
     ILibraryDetailedDataForClient,
@@ -607,7 +607,7 @@ export default class H5PEditor {
 
     private generateEditorIntegration(
         contentId: ContentId
-    ): IEditorIntegration {
+    ): ILumiEditorIntegration {
         log.info(`generating integration for ${contentId}`);
         return {
             ...defaultEditorIntegration,

--- a/src/H5PPlayer.ts
+++ b/src/H5PPlayer.ts
@@ -181,7 +181,11 @@ export default class H5PPlayer {
                     },
                     fullScreen: '0',
                     jsonContent: JSON.stringify(parameters),
-                    library: ContentMetadata.toUbername(metadata)
+                    library: ContentMetadata.toUbername(metadata),
+                    contentUrl: this.config.contentFilesUrlPlayerOverride?.replace(
+                        '{{contentId}}',
+                        contentId
+                    )
                 }
             },
             l10n: {

--- a/src/implementation/H5PConfig.ts
+++ b/src/implementation/H5PConfig.ts
@@ -23,6 +23,7 @@ export default class H5PConfig implements IH5PConfig {
     public ajaxUrl: string = '/ajax';
     public baseUrl: string = '/h5p';
     public contentFilesUrl: string = '/content';
+    public contentFilesUrlPlayerOverride: string;
     public contentTypeCacheRefreshInterval: number = 1 * 1000 * 60 * 60 * 24;
     public contentWhitelist: string =
         'json png jpg jpeg gif bmp tif tiff svg eot ttf woff woff2 otf webm mp4 ogg mp3 m4a wav txt pdf rtf doc docx xls xlsx ppt pptx odt ods odp xml csv diff patch swf md textile vtt webvtt';

--- a/src/types.ts
+++ b/src/types.ts
@@ -263,7 +263,7 @@ export interface IIntegration {
      * them into the corresponding properties of the H5PEditor object!
      * See /src/renderers/default.ts how this can be done!
      */
-    editor?: IEditorIntegration;
+    editor?: ILumiEditorIntegration;
     fullscreenDisabled?: 0 | 1;
     hubIsEnabled: boolean;
     /**
@@ -339,6 +339,17 @@ export interface IIntegration {
  * H5PEditor object! This is the responsibility of the implementation and NOT
  * done by the H5P client automatically!
  */
+export interface ILumiEditorIntegration extends IEditorIntegration {
+    baseUrl?: string;
+    contentId?: string;
+    contentRelUrl?: string;
+    editorRelUrl?: string;
+    relativeUrl?: string;
+}
+
+/**
+ * This is the H5P standard editor integration interface.
+ */
 export interface IEditorIntegration {
     ajaxPath: string;
     apiVersion: { majorVersion: number; minorVersion: number };
@@ -347,25 +358,21 @@ export interface IEditorIntegration {
         js: string[];
     };
     basePath?: string;
-    baseUrl?: string;
-    contentId?: string;
-    contentLanguage?: string;
-    contentRelUrl?: string;
     copyrightSemantics?: any;
-    editorRelUrl?: string;
     fileIcon?: {
         height: number;
         path: string;
         width: number;
     };
     /**
-     * The path where **temporary** files can be retrieved from.
+     * The path at which **temporary** files can be retrieved from.
      */
     filesPath: string;
+    language?: string;
     libraryUrl: string;
     metadataSemantics?: any;
     nodeVersionId: ContentId;
-    relativeUrl?: string;
+    wysiwygButtons?: string[];
 }
 
 /**
@@ -1074,9 +1081,25 @@ export interface IH5PConfig {
      */
     baseUrl: string;
     /**
-     * base path for content files (e.g. images)
+     * Base path for content files (e.g. images). Used in the player and in
+     * the editor.
      */
     contentFilesUrl: string;
+
+    /**
+     * Base path for content files (e.g. images) IN THE PLAYER. It MUST direct
+     * to a URL at which the content files for THE CONTENT BEING DISPLAYED must
+     * be accessible. This means it must include the contentId of the object!
+     * You can insert the contentId using the placeholder {{contentId}}.
+     *
+     * Example:
+     * http://127.0.0.1:9000/s3bucket/${contentId}`
+     *
+     * You can use this URL to load content files from a different server, e.g.
+     * S3 storage. Note that this only work for the player and not the editor.
+     */
+    contentFilesUrlPlayerOverride: string;
+
     /**
      * Time after which the content type cache is considered to be outdated in milliseconds.
      * User-configurable.

--- a/src/types.ts
+++ b/src/types.ts
@@ -148,11 +148,17 @@ export interface IIntegration {
         /**
          * The Ajax endpoint called when the user state has changed
          * Example: /h5p-ajax/content-user-data/:contentId/:dataType/:subContentId?token=XYZ
+         * You can use these placeholders:
+         * :contentId
+         * :dataType
+         * :subContentId
+         * The H5P client will replace them with the actual values.
          */
         contentUserData: string;
         /**
          * An Ajax endpoint called when the user has finished the content.
          * Example: /h5p-ajax/set-finished.json?token=XYZ
+         * Only called when postUserStatistics is set to true.
          */
         setFinished: string;
     };
@@ -166,6 +172,15 @@ export interface IIntegration {
      */
     contents?: {
         [key: string]: {
+            /**
+             * Can be used to override the URL used for getting content files.
+             * It must be a URL to which the actual filenames can be appended.
+             * Do not end it with a slash!
+             * If it is a relative URL it will be appended to the hostname that
+             * is in use (this is done in the H5P client).
+             * If it is an absolute URL it will be used directly.
+             */
+            contentUrl?: string;
             contentUserData?: {
                 /**
                  * The state as a serialized JSON object.
@@ -202,6 +217,10 @@ export interface IIntegration {
                 title: string;
             };
             /**
+             * The parameters.
+             */
+            params?: any;
+            /**
              * A script html tag which can be included alongside the embed code
              * to make the iframe size to the available width. Use absolute URLs.
              * Example: <script src=\"https://example.org/h5p/library/js/h5p-resizer.js\" charset=\"UTF-8\"></script>
@@ -212,6 +231,19 @@ export interface IIntegration {
              */
             url?: string;
         };
+    };
+    /**
+     * The files in this list are references when creating iframes.
+     */
+    core?: {
+        /**
+         * A list of JavaScript files that make up the H5P core
+         */
+        scripts?: string[];
+        /**
+         * A list of CSS styles that make up the H5P core.
+         */
+        styles?: string[];
     };
     /**
      * Can be null.
@@ -232,14 +264,27 @@ export interface IIntegration {
      * See /src/renderers/default.ts how this can be done!
      */
     editor?: IEditorIntegration;
+    fullscreenDisabled?: 0 | 1;
     hubIsEnabled: boolean;
+    /**
+     * The localization strings. The namespace can for example be 'H5P'.
+     */
     l10n: {
-        H5P: any;
+        [namespace: string]: any;
     };
     /**
-     * Can be null.
+     * Can be null. Usage is unknown. the server might be able to customize
+     * library behavior by setting the library config for certain machine names,
+     * as the H5P client allows it to be called by executing
+     * H5P.getLibraryConfig(machineName). This means that libraries can retrieve
+     * configuration values from the server that way. The core never calls the
+     * method and none of the content types on the H5P hub do so...
+     * The Moodle implementation simply passed through a configuration value
+     * in this case.
      */
-    libraryConfig?: any;
+    libraryConfig?: {
+        [machineName: string]: any;
+    };
     /**
      * The URL at which the core files are stored.
      */
@@ -249,6 +294,10 @@ export interface IIntegration {
      * Example: ?q8idru
      */
     pluginCacheBuster?: string;
+    /**
+     * If set the URL specified in ajax.setFinished is called when the user is
+     * finished with a content object.
+     */
     postUserStatistics: boolean;
     reportingIsEnabled?: boolean;
     /**
@@ -256,12 +305,27 @@ export interface IIntegration {
      */
     saveFreq: number | boolean;
     /**
+     * Used when generating xAPI statements.
+     */
+    siteUrl?: string;
+    /**
      * The URL at which files can be accessed. Combined with the baseUrl by the
      * client.
      * Example. /h5p
      */
     url: string;
+    /**
+     * Used to override the auto-generated library URL (libraries means "content
+     * types" here). If this is unset, the H5P client will assume '/libraries'.
+     * Note that the URL is NOT appended to the url or baseUrl property!
+     */
+    urlLibraries?: string;
     user: {
+        /**
+         * Usage unknown.
+         */
+        canToggleViewOthersH5PContents?: 0 | 1;
+        id?: any;
         mail: string;
         name: string;
     };


### PR DESCRIPTION
The player can now be configured to use S3 storage directly in the player to display content files (images, videos,...) This is not possible in the editor, as there are issues with copy & paste if the files are not in the same base url.