### PR TITLE
fix(package uploads): filenames inside uploaded packages work in S3

### DIFF
--- a/src/TemporaryFileManager.ts
+++ b/src/TemporaryFileManager.ts
@@ -127,7 +127,9 @@ export default class TemporaryFileManager {
         let exists = false;
         const dirname = path.dirname(filename);
         do {
-            filenameAttempt = `${dirname ? `${dirname}/` : ''}${path.basename(
+            filenameAttempt = `${
+                dirname && dirname !== '.' ? `${dirname}/` : ''
+            }${path.basename(
                 filename,
                 path.extname(filename)
             )}-${shortid()}${path.extname(filename)}`;


### PR DESCRIPTION
There was a bug that prevented package uploads in certain situations if you used the S3 backend. This is fixed now.