### PR TITLE
 fix(player): missing libraries omitted when listing libraries (closes #501)

### DIFF
--- a/src/DependencyGetter.ts
+++ b/src/DependencyGetter.ts
@@ -73,9 +73,16 @@ export default class DependencyGetter {
         if (libraries.has(LibraryName.toUberName(library))) {
             return null;
         }
+        let metadata;
+        try {
+            metadata = await this.libraryStorage.getLibrary(library);
+        } catch {
+            // We silently ignore missing libraries, as this can happen with
+            // 'fake libraries' used by the H5P client (= libraries which are
+            // referenced in the parameters, but don't exist)
+            return libraries;
+        }
         libraries.add(LibraryName.toUberName(library));
-
-        const metadata = await this.libraryStorage.getLibrary(library);
         if (preloaded && metadata.preloadedDependencies) {
             await this.addDependenciesToSet(
                 metadata.preloadedDependencies,

--- a/src/H5PPlayer.ts
+++ b/src/H5PPlayer.ts
@@ -221,8 +221,14 @@ export default class H5PPlayer {
                 if (key in loaded) {
                     return;
                 }
-
-                const lib = await this.getLibrary(name, majVer, minVer);
+                let lib;
+                try {
+                    lib = await this.getLibrary(name, majVer, minVer);
+                } catch {
+                    log.info(
+                        `Could not find library ${name}-${majVer}.${minVer} in storage. Silently ignoring...`
+                    );
+                }
                 if (lib) {
                     loaded[key] = lib;
                     await this.getLibraries(

--- a/src/TemporaryFileManager.ts
+++ b/src/TemporaryFileManager.ts
@@ -127,7 +127,9 @@ export default class TemporaryFileManager {
         let exists = false;
         const dirname = path.dirname(filename);
         do {
-            filenameAttempt = `${dirname ? `${dirname}/` : ''}${path.basename(
+            filenameAttempt = `${
+                dirname && dirname !== '.' ? `${dirname}/` : ''
+            }${path.basename(
                 filename,
                 path.extname(filename)
             )}-${shortid()}${path.extname(filename)}`;


### PR DESCRIPTION
As the H5P client uses so called 'fake libraries' in the Drag & Drop activity to enable copy & paste, we must silently ignore missing libraries. This is now fixed.

Closes #501 