### PR TITLE
fix(package upload): missing temporary files

### DIFF
--- a/examples/config.json
+++ b/examples/config.json
@@ -6,5 +6,10 @@
     "hubRegistrationEndpoint": "https://api.h5p.org/v1/sites",
     "hubContentTypesEndpoint": "https://api.h5p.org/v1/content-types/",
     "contentTypeCacheRefreshInterval": 86400000,
-    "enableLrsContentTypes": true
+    "enableLrsContentTypes": true,
+    "editorAddons": {
+        "H5P.CoursePresentation": ["H5P.MathDisplay"],
+        "H5P.InteractiveVideo": ["H5P.MathDisplay"],
+        "H5P.DragQuestion": ["H5P.MathDisplay"]
+    }
 }

--- a/src/ContentStorer.ts
+++ b/src/ContentStorer.ts
@@ -293,6 +293,10 @@ export default class ContentStorer {
                         );
                     }
                 }
+            } catch (error) {
+                log.error(
+                    `There was an error while copying file ${fileToCopy} to content ${contentId}: ${error.message}. Ignoring and continuing.`
+                );
             } finally {
                 if (readStream?.close) {
                     readStream.close();


### PR DESCRIPTION
This PR fixes an edge case bug in which the h5p.org editor creates H5P packages that are invalid: Sometimes packages include references to temporary files on the h5p.org server that aren't included in the package. This might be caused by some copy & paste error in the original H5P implementation. 

We now detect these cases and remove the the dead paths from the parameters to avoid trouble later.