### PR TITLE
fix(interactive video): seeking in videos works

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,7 +83,7 @@ jobs:
     db-tests:
         docker:
             - image: circleci/node:10
-            - image: circleci/mongo:latest-ram
+            - image: circleci/mongo:latest
               environment:
                   MONGO_INITDB_ROOT_USERNAME: root
                   MONGO_INITDB_ROOT_PASSWORD: h5pnodejs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,6 +80,24 @@ jobs:
                   at: .
             - run: npm run test:e2e
 
+    db-tests:
+        docker:
+            - image: circleci/node:10
+            - image: circleci/mongo:latest-ram
+              environment:
+                  MONGO_INITDB_ROOT_USERNAME: root
+                  MONGO_INITDB_ROOT_PASSWORD: h5pnodejs
+            - image: minio/minio
+              environment:
+                  MINIO_ACCESS_KEY: minioaccesskey
+                  MINIO_SECRET_KEY: miniosecret
+              command: server /data
+        steps:
+            - checkout
+            - attach_workspace:
+                  at: .
+            - run: npm run test:db
+
     release:
         docker:
             - image: 'circleci/node:10'
@@ -112,6 +130,9 @@ workflows:
             - integration-tests:
                   requires:
                       - install-build
+            - db-tests:
+                  requires:
+                      - install-build
             - release:
                   requires:
                       - install-build
@@ -120,3 +141,4 @@ workflows:
                       - unit-tests
                       - e2e-tests
                       - integration-tests
+                      - db-tests

--- a/assets/translations/server/en.json
+++ b/assets/translations/server/en.json
@@ -52,5 +52,7 @@
     "updated-libraries_plural": "Updated {{count}} old libraries.",
     "updated-libraries": "Updated {{count}} old library.",
     "upload-package-failed-tmp": "Could not save uploaded package to temporary file.",
-    "upload-validation-error": "The file you've uploaded is invalid."
+    "upload-validation-error": "The file you've uploaded is invalid.",
+    "unsatisfiable-range": "The requested range of the file is not within the size of the actual file.",
+    "multipart-ranges-unsupported": "Multipart range requests are not supported on this server."
 }

--- a/src/ContentManager.ts
+++ b/src/ContentManager.ts
@@ -182,16 +182,26 @@ export default class ContentManager {
      * @param contentId the id of the content object that the file is attached to
      * @param filename the filename of the file to get
      * @param user the user who wants to retrieve the content file
+     * @param rangeStart (optional) the position in bytes at which the stream should start
+     * @param rangeEnd (optional) the position in bytes at which the stream should end
      * @returns
      */
     public async getContentFileStream(
         contentId: ContentId,
         filename: string,
-        user: IUser
+        user: IUser,
+        rangeStart?: number,
+        rangeEnd?: number
     ): Promise<Readable> {
         log.debug(`loading ${filename} for ${contentId}`);
 
-        return this.contentStorage.getFileStream(contentId, filename, user);
+        return this.contentStorage.getFileStream(
+            contentId,
+            filename,
+            user,
+            rangeStart,
+            rangeEnd
+        );
     }
 
     /**

--- a/src/H5PEditor.ts
+++ b/src/H5PEditor.ts
@@ -213,12 +213,16 @@ export default class H5PEditor {
      * @param contentId the content id (undefined if retrieved for unsaved content)
      * @param filename the file to get (without 'content/' prefix!)
      * @param user the user who wants to retrieve the file
+     * @param rangeStart (optional) the position in bytes at which the stream should start
+     * @param rangeEnd (optional) the position in bytes at which the stream should end
      * @returns a stream of the content file
      */
     public async getContentFileStream(
         contentId: ContentId,
         filename: string,
-        user: IUser
+        user: IUser,
+        rangeStart?: number,
+        rangeEnd?: number
     ): Promise<Readable> {
         // We have to try the regular content repository first and then fall back to the temporary storage.
         // This is necessary as the H5P client ignores the '#tmp' suffix we've added to temporary files.
@@ -228,7 +232,9 @@ export default class H5PEditor {
                 const returnStream = await this.contentManager.getContentFileStream(
                     contentId,
                     filename,
-                    user
+                    user,
+                    rangeStart,
+                    rangeEnd
                 );
                 return returnStream;
             } catch (error) {
@@ -237,7 +243,12 @@ export default class H5PEditor {
                 );
             }
         }
-        return this.temporaryFileManager.getFileStream(filename, user);
+        return this.temporaryFileManager.getFileStream(
+            filename,
+            user,
+            rangeStart,
+            rangeEnd
+        );
     }
 
     /**

--- a/src/TemporaryFileManager.ts
+++ b/src/TemporaryFileManager.ts
@@ -99,14 +99,18 @@ export default class TemporaryFileManager {
      * Make sure to close this stream. Otherwise the temporary files can't be deleted properly!
      * @param filename the file to get
      * @param user the user who requests the file
+     * @param rangeStart (optional) the position in bytes at which the stream should start
+     * @param rangeEnd (optional) the position in bytes at which the stream should end
      * @returns a stream to read from
      */
     public async getFileStream(
         filename: string,
-        user: IUser
+        user: IUser,
+        rangeStart?: number,
+        rangeEnd?: number
     ): Promise<Readable> {
         log.info(`Getting temporary file ${filename}`);
-        return this.storage.getFileStream(filename, user);
+        return this.storage.getFileStream(filename, user, rangeStart, rangeEnd);
     }
 
     /**

--- a/src/implementation/db/MongoS3ContentStorage.ts
+++ b/src/implementation/db/MongoS3ContentStorage.ts
@@ -437,12 +437,43 @@ export default class MongoS3ContentStorage implements IContentStorage {
      * @param user the user who wants to retrieve the content file
      * @returns
      */
-    getFileStats(
+    public async getFileStats(
         contentId: string,
-        file: string,
+        filename: string,
         user: IUser
     ): Promise<IFileStats> {
-        return null;
+        validateFilename(filename);
+
+        if (
+            !(await this.getUserPermissions(contentId, user)).includes(
+                Permission.View
+            )
+        ) {
+            log.error(
+                `User tried to get stats of file from a content object without proper permissions.`
+            );
+            throw new H5pError(
+                'mongo-s3-content-storage:missing-view-permission',
+                {},
+                403
+            );
+        }
+
+        try {
+            const head = await this.s3
+                .headObject({
+                    Bucket: this.options.s3Bucket,
+                    Key: MongoS3ContentStorage.getS3Key(contentId, filename)
+                })
+                .promise();
+            return { size: head.ContentLength, birthtime: head.LastModified };
+        } catch (error) {
+            throw new H5pError(
+                'content-file-missing',
+                { filename, contentId },
+                404
+            );
+        }
     }
 
     /**

--- a/src/implementation/db/MongoS3ContentStorage.ts
+++ b/src/implementation/db/MongoS3ContentStorage.ts
@@ -459,7 +459,9 @@ export default class MongoS3ContentStorage implements IContentStorage {
     public async getFileStream(
         contentId: ContentId,
         filename: string,
-        user: IUser
+        user: IUser,
+        rangeStart?: number,
+        rangeEnd?: number
     ): Promise<Readable> {
         log.debug(
             `Getting stream for file "${filename}" in content ${contentId}.`
@@ -493,7 +495,11 @@ export default class MongoS3ContentStorage implements IContentStorage {
         return this.s3
             .getObject({
                 Bucket: this.options.s3Bucket,
-                Key: MongoS3ContentStorage.getS3Key(contentId, filename)
+                Key: MongoS3ContentStorage.getS3Key(contentId, filename),
+                Range:
+                    rangeStart && rangeEnd
+                        ? `bytes=${rangeStart}-${rangeEnd}`
+                        : undefined
             })
             .createReadStream();
     }

--- a/src/implementation/db/S3TemporaryFileStorage.ts
+++ b/src/implementation/db/S3TemporaryFileStorage.ts
@@ -5,7 +5,8 @@ import {
     IUser,
     ITemporaryFile,
     Permission,
-    IH5PConfig
+    IH5PConfig,
+    IFileStats
 } from '../../types';
 import { ReadStream } from 'fs';
 import { validateFilename, sanitizeFilename } from './S3Utils';
@@ -170,6 +171,20 @@ export default class S3TemporaryFileStorage implements ITemporaryFileStorage {
     }
 
     /**
+     * Returns a information about a temporary file.
+     * Throws an exception if the file does not exist.
+     * @param filename the relative path inside the library
+     * @param user the user who wants to access the file
+     * @returns the file stats
+     */
+    public async getFileStats(
+        filename: string,
+        user: IUser
+    ): Promise<IFileStats> {
+        return undefined;
+    }
+
+    /**
      * Returns a readable for a file.
      *
      * Note: Make sure to handle the 'error' event of the Readable! This method
@@ -178,10 +193,14 @@ export default class S3TemporaryFileStorage implements ITemporaryFileStorage {
      * to the response if the file doesn't exist!
      * @param filename
      * @param user
+     * @param rangeStart (optional) the position in bytes at which the stream should start
+     * @param rangeEnd (optional) the position in bytes at which the stream should end
      */
     public async getFileStream(
         filename: string,
-        user: IUser
+        user: IUser,
+        rangeStart?: number,
+        rangeEnd?: number
     ): Promise<Readable> {
         log.debug(`Getting stream for temporary file "${filename}".`);
         validateFilename(filename);
@@ -209,7 +228,11 @@ export default class S3TemporaryFileStorage implements ITemporaryFileStorage {
         return this.s3
             .getObject({
                 Bucket: this.options?.s3Bucket,
-                Key: filename
+                Key: filename,
+                Range:
+                    rangeStart && rangeEnd
+                        ? `bytes=${rangeStart}-${rangeEnd}`
+                        : undefined
             })
             .createReadStream();
     }

--- a/src/implementation/fs/FileContentStorage.ts
+++ b/src/implementation/fs/FileContentStorage.ts
@@ -290,12 +290,16 @@ export default class FileContentStorage implements IContentStorage {
      * @param id the id of the content object that the file is attached to
      * @param filename the filename of the file to get
      * @param user the user who wants to retrieve the content file
+     * @param rangeStart (optional) the position in bytes at which the stream should start
+     * @param rangeEnd (optional) the position in bytes at which the stream should end
      * @returns
      */
     public async getFileStream(
         id: ContentId,
         filename: string,
-        user: IUser
+        user: IUser,
+        rangeStart?: number,
+        rangeEnd?: number
     ): Promise<ReadStream> {
         if (!(await this.fileExists(id, filename))) {
             throw new H5pError(
@@ -305,7 +309,11 @@ export default class FileContentStorage implements IContentStorage {
             );
         }
         return fsExtra.createReadStream(
-            path.join(this.getContentPath(), id.toString(), filename)
+            path.join(this.getContentPath(), id.toString(), filename),
+            {
+                start: rangeStart,
+                end: rangeEnd
+            }
         );
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,7 +36,8 @@ import {
     IRequestWithLanguage,
     IRequestWithTranslator,
     Permission,
-    ILibraryAdministrationOverviewItem
+    ILibraryAdministrationOverviewItem,
+    IFileStats
 } from './types';
 
 // Adapters
@@ -92,6 +93,7 @@ export {
     IRequestWithLanguage,
     IRequestWithTranslator,
     Permission,
+    IFileStats,
     // implementations
     H5PConfig,
     fs,

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,6 +46,7 @@ import { errorHandler } from './adapters/expressErrorHandler';
 import expressController from './adapters/H5PAjaxRouter/H5PAjaxExpressController';
 import LibraryAdministrationExpressRouter from './adapters/LibraryAdministrationRouter/LibraryAdministrationExpressRouter';
 import ContentTypeCacheExpressRouter from './adapters/ContentTypeCacheRouter/ContentTypeCacheExpressRouter';
+import LibraryAdministration from './LibraryAdministration';
 
 const adapters = {
     express,
@@ -71,6 +72,7 @@ export {
     InstalledLibrary,
     LibraryName,
     PackageExporter,
+    LibraryAdministration,
     // interfaces
     ContentId,
     ContentParameters,

--- a/src/types.ts
+++ b/src/types.ts
@@ -601,12 +601,16 @@ export interface IContentStorage {
      * @param id the id of the content object that the file is attached to
      * @param filename the filename of the file to get; can be a path including subdirectories (e.g. 'images/xyz.png')
      * @param user the user who wants to retrieve the content file
+     * @param rangeStart (optional) the position in bytes at which the stream should start
+     * @param rangeEnd (optional) the position in bytes at which the stream should end
      * @returns the stream (that can be used to send the file to the user)
      */
     getFileStream(
         contentId: ContentId,
         file: string,
-        user: IUser
+        user: IUser,
+        rangeStart?: number,
+        rangeEnd?: number
     ): Promise<Readable>;
 
     /**
@@ -1483,13 +1487,29 @@ export interface ITemporaryFileStorage {
     fileExists(filename: string, user: IUser): Promise<boolean>;
 
     /**
+     * Returns a information about a temporary file.
+     * Throws an exception if the file does not exist.
+     * @param filename the relative path inside the library
+     * @param user the user who wants to access the file
+     * @returns the file stats
+     */
+    getFileStats(filename: string, user: IUser): Promise<IFileStats>;
+
+    /**
      * Returns the contents of a file.
      * Must check for access permissions and throw an H5PError if a file is not accessible.
      * @param filename the filename; can be a path including subdirectories (e.g. 'images/xyz.png')
      * @param user the user who accesses the file
+     * @param rangeStart (optional) the position in bytes at which the stream should start
+     * @param rangeEnd (optional) the position in bytes at which the stream should end
      * @returns the stream containing the file's content
      */
-    getFileStream(filename: string, user: IUser): Promise<Readable>;
+    getFileStream(
+        filename: string,
+        user: IUser,
+        rangeStart?: number,
+        rangeEnd?: number
+    ): Promise<Readable>;
 
     /**
      * Returns a list of files in temporary storage for the specified user.

--- a/test/e2e/H5PPlayer.DisplayContent.test.ts
+++ b/test/e2e/H5PPlayer.DisplayContent.test.ts
@@ -65,6 +65,6 @@ describe('e2e test: play content', () => {
                 waitUntil: ['load', 'networkidle0']
             });
             expect(errorHandler).not.toHaveBeenCalled();
-        }, 10000);
+        });
     }
 });

--- a/test/implementation/db/MongoS3ContentStorage.test.ts
+++ b/test/implementation/db/MongoS3ContentStorage.test.ts
@@ -64,7 +64,9 @@ describe('MongoS3ContentStorage', () => {
             auth: {
                 user: 'root',
                 password: 'h5pnodejs'
-            }
+            },
+            ignoreUndefined: true,
+            useUnifiedTopology: true
         });
         mongo = mongoClient.db('h5pintegrationtest');
     });
@@ -195,7 +197,7 @@ describe('MongoS3ContentStorage', () => {
         expect(list).toMatchObject([contentId1, contentId2, contentId3]);
     });
 
-    it('adds files and returns stream to them', async () => {
+    it('adds files, returns its size and a stream to them', async () => {
         const contentId = await storage.addContent(
             stubMetadata,
             stubParameters,
@@ -214,6 +216,14 @@ describe('MongoS3ContentStorage', () => {
         await expect(storage.fileExists(contentId, filename)).resolves.toEqual(
             true
         );
+
+        const fsStats = await fsExtra.stat(stubJsonPath);
+        const s3Stats = await storage.getFileStats(
+            contentId,
+            filename,
+            stubUser
+        );
+        expect(s3Stats.size).toEqual(fsStats.size);
 
         const returnedStream = await storage.getFileStream(
             contentId,

--- a/test/implementation/db/MongoS3ContentStorage.test.ts
+++ b/test/implementation/db/MongoS3ContentStorage.test.ts
@@ -56,11 +56,11 @@ describe('MongoS3ContentStorage', () => {
         s3 = initS3({
             accessKeyId: 'minioaccesskey',
             secretAccessKey: 'miniosecret',
-            endpoint: 'http://127.0.0.1:9000',
+            endpoint: 'http://localhost:9000',
             s3ForcePathStyle: true,
             signatureVersion: 'v4'
         });
-        mongoClient = await mongodb.connect('mongodb://127.0.0.1:27017', {
+        mongoClient = await mongodb.connect('mongodb://localhost:27017', {
             auth: {
                 user: 'root',
                 password: 'h5pnodejs'
@@ -278,6 +278,9 @@ describe('MongoS3ContentStorage', () => {
             fsExtra.createReadStream(stubImagePath),
             stubUser
         );
+        // It looks like it can take some time until a file is reachable in
+        // minio, so we wait a bit.
+        await new Promise((resolve) => setTimeout(resolve, 200));
         expect(
             s3
                 .headObject({

--- a/test/implementation/db/S3TemporaryFileStorage.test.ts
+++ b/test/implementation/db/S3TemporaryFileStorage.test.ts
@@ -88,7 +88,7 @@ describe('MongoS3ContentStorage', () => {
         expect(lifecycleConfiguration.Rules[0].Expiration.Days).toEqual(4);
     });
 
-    it('adds files and returns stream to them', async () => {
+    it('adds files and returns stats and stream to them', async () => {
         const filename = 'testfile1.jpg';
         await expect(storage.fileExists(filename, stubUser)).resolves.toEqual(
             false
@@ -102,6 +102,10 @@ describe('MongoS3ContentStorage', () => {
         await expect(storage.fileExists(filename, stubUser)).resolves.toEqual(
             true
         );
+
+        const fsStats = await fsExtra.stat(stubImagePath);
+        const s3Stats = await storage.getFileStats(filename, stubUser);
+        expect(s3Stats.size).toEqual(fsStats.size);
 
         const returnedStream = await storage.getFileStream(filename, stubUser);
 

--- a/test/implementation/db/S3TemporaryFileStorage.test.ts
+++ b/test/implementation/db/S3TemporaryFileStorage.test.ts
@@ -32,7 +32,7 @@ describe('MongoS3ContentStorage', () => {
         s3 = initS3({
             accessKeyId: 'minioaccesskey',
             secretAccessKey: 'miniosecret',
-            endpoint: 'http://127.0.0.1:9000',
+            endpoint: 'http://localhost:9000',
             s3ForcePathStyle: true,
             signatureVersion: 'v4'
         });


### PR DESCRIPTION
Seeking in interactive videos didn't work as the editor requested ranges in the
HTTP headers, which wasn't supported. This fix adds support for ranges.

BREAKING CHANGE: the IContentStorage and ITemporaryFileStorage interfaces were
extended to support ranges when getting file streams.

Closes #604 