### PR TITLE
fix(localization): fallback for language codes with countries

### DIFF
--- a/src/LibraryManager.ts
+++ b/src/LibraryManager.ts
@@ -108,12 +108,21 @@ export default class LibraryManager {
                 `language/${language}.json`
             );
             return streamToString(stream);
-        } catch (ignored) {
+        } catch {
             log.debug(
                 `language '${language}' not found for ${LibraryName.toUberName(
                     library
                 )}`
             );
+            const languageCodeMatch = /^([a-zA-Z]+)\-([a-zA-Z]+)$/.exec(
+                language
+            );
+            if (languageCodeMatch && languageCodeMatch.length === 3) {
+                log.debug(
+                    `Language code ${language} seems to contain country code. Trying without it.`
+                );
+                return this.getLanguage(library, languageCodeMatch[1]);
+            }
             return null;
         }
     }

--- a/test/LibraryManager.test.ts
+++ b/test/LibraryManager.test.ts
@@ -284,6 +284,44 @@ describe('basic file library manager functionality', () => {
             { keep: false, unsafeCleanup: true }
         );
     });
+
+    it('returns null file for language en', async () => {
+        const libManager = new LibraryManager(
+            new FileLibraryStorage(`${path.resolve('')}/test/data/libraries`)
+        );
+
+        const language = await libManager.getLanguage(
+            { machineName: 'H5P.Example1', majorVersion: 1, minorVersion: 1 },
+            'en'
+        );
+        expect(language).toBeNull();
+    });
+
+    it('returns the de language file for de-DE', async () => {
+        const libManager = new LibraryManager(
+            new FileLibraryStorage(`${path.resolve('')}/test/data/libraries`)
+        );
+
+        const language = await libManager.getLanguage(
+            { machineName: 'H5P.Example1', majorVersion: 1, minorVersion: 1 },
+            'de-DE'
+        );
+        expect(JSON.parse(language)).toMatchObject({
+            semantics: [
+                {
+                    label: 'Grußbotschaft',
+                    default: 'Hallo, Welt!',
+                    description:
+                        'Die Grußbotschaft, die dem Nutzer gezeigt wird.'
+                },
+                {
+                    label: 'Kartenbild',
+                    description:
+                        'Bild, das optional auf der Karte gezeigt wird. Ohne ein solches wird nur Text auf der Karte gezeigt.'
+                }
+            ]
+        });
+    });
 });
 describe('listLanguages()', () => {
     it('returns an empty array if the language folder does not exist', async () => {


### PR DESCRIPTION
Fixes a bug in which language codes auto-detected from the browser settings like en-US or de-DE caused problems when displaying the editor, as only files without the country codes exists.

Closes #602. Closes #732.