### PR TITLE
feat(h5p-server)!: CSRF tokens in UrlGenerator

### DIFF
--- a/docs/advanced/localization.md
+++ b/docs/advanced/localization.md
@@ -35,8 +35,8 @@ shows where this must be done:
 
 | Place | What to do |
 | :--- | :--- |
-| 1. core language strings | Call `H5PEditor.render(contentId, language)` with the language code you need. |
-| 2. notify H5P editor client | Call `H5PEditor.render(contentId, language)` with the language code you need. |
+| 1. core language strings | Call `H5PEditor.render(contentId, language, ...)` with the language code you need. |
+| 2. notify H5P editor client | Call `H5PEditor.render(contentId, language, ...)` with the language code you need. |
 | 3. properties of IIntegration | Pass a valid `translationCallback` of type `ITranslationFunction` to the constructor of `H5PEditor` |
 | 4. error messages emitted by @lumieducation/h5p-server | Catch errors of types `H5PError` and `AggregateH5PError` and localize the message property yourself. |
 

--- a/docs/packages/h5p-react.md
+++ b/docs/packages/h5p-react.md
@@ -138,7 +138,7 @@ using a renderer that simply returns the player model if you call
 
 ```ts
 h5pPlayerOnServer.setRenderer(model => model);
-const playerModel = await h5pPlayerOnServer.render(contentId);
+const playerModel = await h5pPlayerOnServer.render(contentId, user);
 // send playerModel to client and return it in loadContentCallback
 ```
 

--- a/docs/packages/h5p-webcomponents.md
+++ b/docs/packages/h5p-webcomponents.md
@@ -163,7 +163,7 @@ renderer that simply returns the player model if you call
 
 ```ts
 h5pPlayerOnServer.setRenderer(model => model);
-const playerModel = await h5pPlayerOnServer.render(contentId);
+const playerModel = await h5pPlayerOnServer.render(contentId, user);
 // send playerModel to client and return it in loadContentCallback
 ```
 

--- a/docs/usage/integrating.md
+++ b/docs/usage/integrating.md
@@ -52,7 +52,7 @@ HTML user interface around the actual editor and the editor itself) for a
 specific content ID, you call
 
 ```javascript
-const html = await h5pEditor.render(contentId);
+const html = await h5pEditor.render(contentId, user);
 // send the html to the browser, which will display it
 ```
 

--- a/packages/h5p-examples/src/User.ts
+++ b/packages/h5p-examples/src/User.ts
@@ -11,11 +11,13 @@ export default class User implements IUser {
         this.canUpdateAndInstallLibraries = true;
         this.canCreateRestricted = true;
         this.type = 'local';
+        this.email = 'test@example.com';
     }
 
     public canCreateRestricted: boolean;
     public canInstallRecommended: boolean;
     public canUpdateAndInstallLibraries: boolean;
+    public email: string;
     public id: string;
     public name: string;
     public type: 'local';

--- a/packages/h5p-examples/src/createH5PEditor.ts
+++ b/packages/h5p-examples/src/createH5PEditor.ts
@@ -2,7 +2,7 @@ import { Cache, caching } from 'cache-manager';
 import redisStore from 'cache-manager-redis-store';
 
 import * as H5P from '@lumieducation/h5p-server';
-import dbImplementations from '@lumieducation/h5p-mongos3';
+import * as dbImplementations from '@lumieducation/h5p-mongos3';
 
 /**
  * Create a H5PEditor object.

--- a/packages/h5p-examples/src/expressRoutes.ts
+++ b/packages/h5p-examples/src/expressRoutes.ts
@@ -20,26 +20,36 @@ export default function (
 ): express.Router {
     const router = express.Router();
 
-    router.get(`${h5pEditor.config.playUrl}/:contentId`, async (req, res) => {
-        try {
-            const h5pPage = await h5pPlayer.render(req.params.contentId);
-            res.send(h5pPage);
-            res.status(200).end();
-        } catch (error) {
-            res.status(500).end(error.message);
+    router.get(
+        `${h5pEditor.config.playUrl}/:contentId`,
+        async (req: IRequestWithUser, res) => {
+            try {
+                const h5pPage = await h5pPlayer.render(
+                    req.params.contentId,
+                    req.user
+                );
+                res.send(h5pPage);
+                res.status(200).end();
+            } catch (error) {
+                res.status(500).end(error.message);
+            }
         }
-    });
+    );
 
-    router.get('/edit/:contentId', async (req: IRequestWithLanguage, res) => {
-        const page = await h5pEditor.render(
-            req.params.contentId,
-            languageOverride === 'auto'
-                ? req.language ?? 'en'
-                : languageOverride
-        );
-        res.send(page);
-        res.status(200).end();
-    });
+    router.get(
+        '/edit/:contentId',
+        async (req: IRequestWithLanguage & IRequestWithUser, res) => {
+            const page = await h5pEditor.render(
+                req.params.contentId,
+                languageOverride === 'auto'
+                    ? req.language ?? 'en'
+                    : languageOverride,
+                req.user
+            );
+            res.send(page);
+            res.status(200).end();
+        }
+    );
 
     router.post('/edit/:contentId', async (req: IRequestWithUser, res) => {
         const contentId = await h5pEditor.saveOrUpdateContent(
@@ -54,16 +64,20 @@ export default function (
         res.status(200).end();
     });
 
-    router.get('/new', async (req: IRequestWithLanguage, res) => {
-        const page = await h5pEditor.render(
-            undefined,
-            languageOverride === 'auto'
-                ? req.language ?? 'en'
-                : languageOverride
-        );
-        res.send(page);
-        res.status(200).end();
-    });
+    router.get(
+        '/new',
+        async (req: IRequestWithLanguage & IRequestWithUser, res) => {
+            const page = await h5pEditor.render(
+                undefined,
+                languageOverride === 'auto'
+                    ? req.language ?? 'en'
+                    : languageOverride,
+                req.user
+            );
+            res.send(page);
+            res.status(200).end();
+        }
+    );
 
     router.post('/new', async (req: IRequestWithUser, res) => {
         if (

--- a/packages/h5p-express/test/User.ts
+++ b/packages/h5p-express/test/User.ts
@@ -17,8 +17,8 @@ export default class User implements IUser {
     public canCreateRestricted: boolean;
     public canInstallRecommended: boolean;
     public canUpdateAndInstallLibraries: boolean;
+    public email: string;
     public id: string;
     public name: string;
     public type: 'local';
-    public email: string;
 }

--- a/packages/h5p-express/test/User.ts
+++ b/packages/h5p-express/test/User.ts
@@ -11,6 +11,7 @@ export default class User implements IUser {
         this.canUpdateAndInstallLibraries = true;
         this.canCreateRestricted = true;
         this.type = 'local';
+        this.email = 'test@example.com';
     }
 
     public canCreateRestricted: boolean;
@@ -19,4 +20,5 @@ export default class User implements IUser {
     public id: string;
     public name: string;
     public type: 'local';
+    public email: string;
 }

--- a/packages/h5p-html-exporter/src/HtmlExporter.ts
+++ b/packages/h5p-html-exporter/src/HtmlExporter.ts
@@ -169,7 +169,7 @@ export default class HtmlExporter {
                 }
             )
         );
-        return this.player.render(contentId, undefined, undefined, user);
+        return this.player.render(contentId, user);
     }
 
     /**
@@ -193,8 +193,7 @@ export default class HtmlExporter {
                 libraries: 'inline'
             })
         );
-        return (await this.player.render(contentId, undefined, undefined, user))
-            .html;
+        return (await this.player.render(contentId, user)).html;
     }
 
     /**

--- a/packages/h5p-html-exporter/test/User.ts
+++ b/packages/h5p-html-exporter/test/User.ts
@@ -11,11 +11,13 @@ export default class User implements IUser {
         this.canUpdateAndInstallLibraries = true;
         this.canCreateRestricted = true;
         this.type = 'local';
+        this.email = 'test@example.com';
     }
 
     public canCreateRestricted: boolean;
     public canInstallRecommended: boolean;
     public canUpdateAndInstallLibraries: boolean;
+    public email: string;
     public id: string;
     public name: string;
     public type: 'local';

--- a/packages/h5p-mongos3/test/User.ts
+++ b/packages/h5p-mongos3/test/User.ts
@@ -11,11 +11,13 @@ export default class User implements IUser {
         this.canUpdateAndInstallLibraries = true;
         this.canCreateRestricted = true;
         this.type = 'local';
+        this.email = 'test@example.com';
     }
 
     public canCreateRestricted: boolean;
     public canInstallRecommended: boolean;
     public canUpdateAndInstallLibraries: boolean;
+    public email: string;
     public id: string;
     public name: string;
     public type: 'local';

--- a/packages/h5p-server/src/UrlGenerator.ts
+++ b/packages/h5p-server/src/UrlGenerator.ts
@@ -2,7 +2,8 @@ import {
     ContentId,
     IFullLibraryName,
     IH5PConfig,
-    IUrlGenerator
+    IUrlGenerator,
+    IUser
 } from './types';
 
 /**
@@ -33,22 +34,34 @@ import {
 export default class UrlGenerator implements IUrlGenerator {
     constructor(private config: IH5PConfig) {}
 
+    public ajaxEndpoint = (user: IUser): string => {
+        return `${this.config.baseUrl}${this.config.ajaxUrl}?action=`;
+    };
+
+    public baseUrl = (): string => {
+        return this.config.baseUrl;
+    };
+    
+    public contentUserData = (user: IUser): string => {
+        return `${this.config.baseUrl}/contentUserData`;
+    };
+
     /**
      * Also adds a cache buster based on IH5PConfig.h5pVersion.
      * @param file
      */
     public coreFile = (file: string) => {
-        return `${this.getBaseUrl()}${this.config.coreUrl}/${file}?version=${
+        return `${this.baseUrl()}${this.config.coreUrl}/${file}?version=${
             this.config.h5pVersion
         }`;
     };
 
     public coreFiles = () => {
-        return `${this.getBaseUrl()}${this.config.coreUrl}/js`;
+        return `${this.baseUrl()}${this.config.coreUrl}/js`;
     };
 
     public downloadPackage = (contentId: ContentId) => {
-        return `${this.getBaseUrl()}${this.config.downloadUrl}/${contentId}`;
+        return `${this.baseUrl()}${this.config.downloadUrl}/${contentId}`;
     };
 
     /**
@@ -56,20 +69,20 @@ export default class UrlGenerator implements IUrlGenerator {
      * @param file
      */
     public editorLibraryFile = (file: string): string => {
-        return `${this.getBaseUrl()}${
+        return `${this.baseUrl()}${
             this.config.editorLibraryUrl
         }/${file}?version=${this.config.h5pVersion}`;
     };
 
     public editorLibraryFiles = (): string => {
-        return `${this.getBaseUrl()}${this.config.editorLibraryUrl}/`;
+        return `${this.baseUrl()}${this.config.editorLibraryUrl}/`;
     };
 
     public libraryFile = (library: IFullLibraryName, file: string) => {
         if (file.startsWith('http://') || file.startsWith('https://')) {
             return file;
         }
-        return `${this.getBaseUrl()}${this.config.librariesUrl}/${
+        return `${this.baseUrl()}${this.config.librariesUrl}/${
             library.machineName
         }-${library.majorVersion}.${library.minorVersion}/${file}?version=${
             library.majorVersion
@@ -77,18 +90,17 @@ export default class UrlGenerator implements IUrlGenerator {
     };
 
     public parameters = () => {
-        return `${this.getBaseUrl()}${this.config.paramsUrl}`;
+        return `${this.baseUrl()}${this.config.paramsUrl}`;
     };
 
     public play = () => {
-        return `${this.getBaseUrl()}${this.config.playUrl}`;
+        return `${this.baseUrl()}${this.config.playUrl}`;
+    };
+    public setFinished = (user: IUser): string => {
+        return `${this.config.baseUrl}/setFinished`;
     };
 
     public temporaryFiles = (): string => {
-        return this.getBaseUrl() + this.config.temporaryFilesUrl;
-    };
-
-    protected getBaseUrl = (): string => {
-        return this.config.baseUrl;
+        return this.baseUrl() + this.config.temporaryFilesUrl;
     };
 }

--- a/packages/h5p-server/src/implementation/H5PConfig.ts
+++ b/packages/h5p-server/src/implementation/H5PConfig.ts
@@ -19,12 +19,12 @@ export default class H5PConfig implements IH5PConfig {
             }
         }
     }
-
     public ajaxUrl: string = '/ajax';
     public baseUrl: string = '/h5p';
     public contentFilesUrl: string = '/content';
     public contentFilesUrlPlayerOverride: string;
     public contentTypeCacheRefreshInterval: number = 1 * 1000 * 60 * 60 * 24;
+    public contentUserDataUrl: string = '/contentUserData';
     public contentWhitelist: string =
         'json png jpg jpeg gif bmp tif tiff svg eot ttf woff woff2 otf webm mp4 ogg mp3 m4a wav txt pdf rtf doc docx xls xlsx ppt pptx odt ods odp xml csv diff patch swf md textile vtt webvtt';
     public coreApiVersion: { major: number; minor: number } = {
@@ -85,6 +85,7 @@ export default class H5PConfig implements IH5PConfig {
     };
     public playUrl: string = '/play';
     public sendUsageStatistics: boolean = false;
+    public setFinishedUrl: string = '/setFinished';
     public siteType: 'local' | 'network' | 'internet' = 'local';
     public temporaryFileLifetime: number = 120 * 60 * 1000; // 120 minutes
     public temporaryFilesUrl: string = '/temp-files';

--- a/packages/h5p-server/src/types.ts
+++ b/packages/h5p-server/src/types.ts
@@ -1320,6 +1320,11 @@ export interface IH5PConfig {
      */
     contentTypeCacheRefreshInterval: number;
     /**
+     * URL prefix for content user data (e.g. the user state where a user left
+     * off displaying H5P content)
+     */
+    contentUserDataUrl: string;
+    /**
      * A list of file extensions allowed for content files.
      * Contains file extensions (without .) separated by whitespaces.
      */
@@ -1478,6 +1483,11 @@ export interface IH5PConfig {
      * User-configurable.
      */
     sendUsageStatistics: boolean;
+    /**
+     * URL prefix for the finished URL (the URL to which requests are sent when
+     * the user has finished content)
+     */
+    setFinishedUrl: string;
     /**
      * Indicates on what kind of network the site is running. Can be "local", "network" or "internet".
      * TODO: This value should not be user-configurable, but has to be determined by the system on startup.

--- a/packages/h5p-server/src/types.ts
+++ b/packages/h5p-server/src/types.ts
@@ -507,6 +507,10 @@ export interface IUser {
      */
     canUpdateAndInstallLibraries: boolean;
     /**
+     * E-Mail address.
+     */
+    email: string;
+    /**
      * An internal id used to check if user objects are identical.
      */
     id: string;
@@ -1685,6 +1689,9 @@ export interface IEditorModel {
 }
 
 export interface IUrlGenerator {
+    ajaxEndpoint(user: IUser): string;
+    baseUrl(): string;
+    contentUserData(user: IUser): string;
     coreFile(file: string): string;
     coreFiles(): string;
     downloadPackage(contentId: ContentId): string;
@@ -1693,6 +1700,7 @@ export interface IUrlGenerator {
     libraryFile(library: IFullLibraryName, file: string): string;
     parameters(): string;
     play(): string;
+    setFinished(user: IUser): string;
     temporaryFiles(): string;
 }
 

--- a/packages/h5p-server/test/H5PEditor.getLibraryOverview.test.ts
+++ b/packages/h5p-server/test/H5PEditor.getLibraryOverview.test.ts
@@ -1,5 +1,3 @@
-import path from 'path';
-
 import H5PEditor from '../src/H5PEditor';
 import H5PConfig from '../src/implementation/H5PConfig';
 import FileLibraryStorage from '../src/implementation/fs/FileLibraryStorage';

--- a/packages/h5p-server/test/H5PPlayer.loadDependencies.test.ts
+++ b/packages/h5p-server/test/H5PPlayer.loadDependencies.test.ts
@@ -1,6 +1,7 @@
 import H5PPlayer from '../src/H5PPlayer';
 import H5PConfig from '../src/implementation/H5PConfig';
 import { ILibraryName } from '../src/types';
+import User from './User';
 
 describe('Loading dependencies', () => {
     it('resolves main dependencies', () => {
@@ -58,7 +59,10 @@ describe('Loading dependencies', () => {
             undefined
         )
             .setRenderer((model) => model)
-            .render(contentId, contentObject, h5pObject as any)
+            .render(contentId, new User(), {
+                parametersOverride: contentObject,
+                metadataOverride: h5pObject as any
+            })
             .then((model) => {
                 expect((model as any).styles.slice(3)).toEqual([
                     '/h5p/libraries/Foo-4.2/foo1.css?version=4.2.0',
@@ -139,7 +143,10 @@ describe('Loading dependencies', () => {
             undefined
         )
             .setRenderer((model) => model)
-            .render(contentId, contentObject, h5pObject as any)
+            .render(contentId, new User(), {
+                parametersOverride: contentObject,
+                metadataOverride: h5pObject as any
+            })
             .then((model) => {
                 expect((model as any).styles.slice(3)).toEqual([
                     '/h5p/libraries/Foo-4.2/foo1.css?version=4.2.0',
@@ -231,7 +238,10 @@ describe('Loading dependencies', () => {
             undefined
         )
             .setRenderer((model) => model)
-            .render(contentId, contentObject, h5pObject as any)
+            .render(contentId, new User(), {
+                parametersOverride: contentObject,
+                metadataOverride: h5pObject as any
+            })
             .then((model) => {
                 expect((model as any).styles.slice(3)).toEqual([
                     '/h5p/libraries/Baz-3.3/baz.css?version=3.3.0',
@@ -316,7 +326,10 @@ describe('Loading dependencies', () => {
             undefined
         )
             .setRenderer((model) => model)
-            .render(contentId, contentObject, h5pObject as any)
+            .render(contentId, new User(), {
+                parametersOverride: contentObject,
+                metadataOverride: h5pObject as any
+            })
             .then((model) => {
                 expect((model as any).styles.slice(3)).toEqual([
                     '/h5p/libraries/Baz-3.3/baz.css?version=3.3.0',
@@ -405,7 +418,10 @@ describe('Loading dependencies', () => {
             undefined
         )
             .setRenderer((model) => model)
-            .render(contentId, contentObject, h5pObject as any)
+            .render(contentId, new User(), {
+                parametersOverride: contentObject,
+                metadataOverride: h5pObject as any
+            })
             .then((model) => {
                 expect((model as any).styles.slice(3)).toEqual([
                     '/h5p/libraries/Baz-3.3/baz.css?version=3.3.0',
@@ -500,11 +516,10 @@ describe('Loading dependencies', () => {
         );
 
         h5p.setRenderer((m) => m);
-        const model: any = await h5p.render(
-            contentId,
-            contentObject,
-            h5pObject as any
-        );
+        const model: any = await h5p.render(contentId, new User(), {
+            parametersOverride: contentObject,
+            metadataOverride: h5pObject as any
+        });
         expect(model.scripts).toEqual([
             `/baseUrl/coreUrl/js/jquery.js?version=${config.h5pVersion}`,
             `/baseUrl/coreUrl/js/h5p.js?version=${config.h5pVersion}`,

--- a/packages/h5p-server/test/H5PPlayer.render.test.ts
+++ b/packages/h5p-server/test/H5PPlayer.render.test.ts
@@ -1,6 +1,8 @@
+import UrlGenerator from '../src/UrlGenerator';
 import H5PPlayer from '../src/H5PPlayer';
 import H5PConfig from '../src/implementation/H5PConfig';
 import User from './User';
+import { IPlayerModel } from '../src/types';
 
 describe('H5P.render()', () => {
     it('should work with a callback', () => {
@@ -18,5 +20,78 @@ describe('H5P.render()', () => {
                 expect(model).toBeDefined();
                 expect((model as any).contentId).toBe('foo');
             });
+    });
+
+    it('should generate AJAX URLs with CSRF token if option is set', () => {
+        const contentId = 'foo';
+        const contentObject = {};
+        const metadata: any = {};
+
+        const config = new H5PConfig(undefined);
+
+        new H5PPlayer(
+            undefined,
+            undefined,
+            config,
+            undefined,
+            new UrlGenerator(config, {
+                protectAjax: true,
+                protectContentUserData: true,
+                protectSetFinished: true,
+                queryParamGenerator: (user) => {
+                    return { name: '_csrf', value: 'token' };
+                }
+            })
+        )
+            .setRenderer((model) => model)
+            .render(contentId, new User(), {
+                parametersOverride: contentObject,
+                metadataOverride: metadata as any
+            })
+            .then((model) => {
+                expect((model as IPlayerModel).integration.ajaxPath).toBe(
+                    '/h5p/ajax?_csrf=token&action='
+                );
+            });
+    });
+
+    it('should not generate AJAX URLs with CSRF token if option is not set', () => {
+        const contentId = 'foo';
+        const contentObject = {};
+        const metadata: any = {};
+
+        const config = new H5PConfig(undefined);
+
+        new H5PPlayer(undefined, undefined, config)
+            .setRenderer((model) => model)
+            .render(contentId, new User(), {
+                parametersOverride: contentObject,
+                metadataOverride: metadata as any
+            })
+            .then((model) => {
+                expect((model as IPlayerModel).integration.ajaxPath).toBe(
+                    '/h5p/ajax?action='
+                );
+            });
+    });
+
+    it('adds user information to integration', async () => {
+        const contentId = 'foo';
+        const contentObject = {};
+        const metadata: any = {};
+
+        const config = new H5PConfig(undefined);
+        const user = new User();
+
+        const player = new H5PPlayer(undefined, undefined, config);
+        player.setRenderer((model) => model);
+        const playerModel: IPlayerModel = await player.render(contentId, user, {
+            parametersOverride: contentObject,
+            metadataOverride: metadata as any
+        });
+
+        expect(playerModel.integration.user.id).toEqual(user.id);
+        expect(playerModel.integration.user.mail).toEqual(user.email);
+        expect(playerModel.integration.user.name).toEqual(user.name);
     });
 });

--- a/packages/h5p-server/test/H5PPlayer.render.test.ts
+++ b/packages/h5p-server/test/H5PPlayer.render.test.ts
@@ -1,5 +1,6 @@
 import H5PPlayer from '../src/H5PPlayer';
 import H5PConfig from '../src/implementation/H5PConfig';
+import User from './User';
 
 describe('H5P.render()', () => {
     it('should work with a callback', () => {
@@ -9,7 +10,10 @@ describe('H5P.render()', () => {
 
         new H5PPlayer(undefined, undefined, new H5PConfig(undefined))
             .setRenderer((model) => model)
-            .render(contentId, contentObject, metadata)
+            .render(contentId, new User(), {
+                parametersOverride: contentObject,
+                metadataOverride: metadata as any
+            })
             .then((model) => {
                 expect(model).toBeDefined();
                 expect((model as any).contentId).toBe('foo');

--- a/packages/h5p-server/test/H5PPlayer.renderHtmlPage.test.ts
+++ b/packages/h5p-server/test/H5PPlayer.renderHtmlPage.test.ts
@@ -1,6 +1,7 @@
 import H5PPlayer from '../src/H5PPlayer';
 import H5PConfig from '../src/implementation/H5PConfig';
 import { ILibraryName, ILibraryMetadata } from '../src/types';
+import User from './User';
 
 describe('Rendering the HTML page', () => {
     it('uses default renderer and integration values', () => {
@@ -11,7 +12,10 @@ describe('Rendering the HTML page', () => {
         const h5pObject = {};
         const config = new H5PConfig(undefined);
         return new H5PPlayer(undefined, undefined, config)
-            .render(contentId, contentObject, h5pObject as any)
+            .render(contentId, new User(), {
+                parametersOverride: contentObject,
+                metadataOverride: h5pObject as any
+            })
             .then((html) => {
                 expect(html.replace(/ /g, '')).toBe(
                     `<!doctype html>
@@ -34,6 +38,10 @@ describe('Rendering the HTML page', () => {
                 
                     <script>
                         window.H5PIntegration = {
+                  "ajax":{
+                     "contentUserData":"/h5p/contentUserData",
+                     "setFinished":"/h5p/setFinished"
+                  },
                   "contents": {
                     "cid-foo": {
                       "displayOptions": {
@@ -162,7 +170,12 @@ describe('Rendering the HTML page', () => {
                   "saveFreq": false,
                   "url": "/h5p",
                   "hubIsEnabled": true,
-                  "fullscreenDisabled": 0
+                  "fullscreenDisabled": 0,
+                  "user":{
+                    "name":"FirstnameSurname",
+                    "mail":"test@example.com",
+                    "id":"1"
+                  }
                 };
                     </script>
                 </head>
@@ -206,7 +219,10 @@ describe('Rendering the HTML page', () => {
             new H5PConfig(undefined)
         )
             .setRenderer((model) => model)
-            .render(contentId, contentObject, h5pObject as any)
+            .render(contentId, new User(), {
+                parametersOverride: contentObject,
+                metadataOverride: h5pObject as any
+            })
             .then((model) => {
                 expect(
                     (model as any).integration.contents['cid-foo'].library
@@ -241,11 +257,10 @@ describe('Rendering the HTML page', () => {
             }
         );
         player.setRenderer((mod) => mod);
-        const model = await player.render(
-            contentId,
-            contentObject,
-            h5pObject as any
-        );
+        const model = await player.render(contentId, new User(), {
+            parametersOverride: contentObject,
+            metadataOverride: h5pObject as any
+        });
 
         expect((model as any).scripts.includes('/test.js')).toEqual(true);
         expect((model as any).styles.includes('/test.css')).toEqual(true);
@@ -260,7 +275,10 @@ describe('Rendering the HTML page', () => {
             integration: 'test'
         } as any)
             .setRenderer((model) => model)
-            .render(contentId, contentObject, h5pObject as any)
+            .render(contentId, new User(), {
+                parametersOverride: contentObject,
+                metadataOverride: h5pObject as any
+            })
             .then((model) => {
                 expect((model as any).integration.integration).toBe('test');
             });
@@ -289,7 +307,10 @@ describe('Rendering the HTML page', () => {
                 }
             }
         )
-            .render(contentId, contentObject, h5pObject as any)
+            .render(contentId, new User(), {
+                parametersOverride: contentObject,
+                metadataOverride: h5pObject as any
+            })
             .then((html) => {
                 expect(html.replace(/ /g, '')).toBe(
                     `<!doctype html>
@@ -314,6 +335,10 @@ describe('Rendering the HTML page', () => {
                     
                         <script>
                             window.H5PIntegration = {
+                      "ajax":{
+                         "contentUserData":"/h5p/contentUserData",
+                         "setFinished":"/h5p/setFinished"
+                       },
                       "contents": {
                         "cid-foo": {
                           "displayOptions": {
@@ -446,7 +471,12 @@ describe('Rendering the HTML page', () => {
                       "saveFreq": false,
                       "url": "/h5p",
                       "hubIsEnabled": true,
-                      "fullscreenDisabled": 0
+                      "fullscreenDisabled": 0,
+                      "user":{
+                        "name":"FirstnameSurname",
+                        "mail":"test@example.com",
+                        "id":"1"
+                      }
                     };
                         </script>
                     </head>
@@ -525,11 +555,10 @@ describe('Rendering the HTML page', () => {
             }
         );
         player.setRenderer((mod) => mod);
-        const model = await player.render(
-            contentId,
-            contentObject,
-            h5pObject as any
-        );
+        const model = await player.render(contentId, new User(), {
+            parametersOverride: contentObject,
+            metadataOverride: h5pObject as any
+        });
 
         expect(
             (model as any).scripts.includes(
@@ -623,11 +652,10 @@ describe('Rendering the HTML page', () => {
             }
         );
         player.setRenderer((mod) => mod);
-        const model = await player.render(
-            contentId,
-            contentObject,
-            h5pObject as any
-        );
+        const model = await player.render(contentId, new User(), {
+            parametersOverride: contentObject,
+            metadataOverride: h5pObject as any
+        });
 
         expect(
             (model as any).scripts.includes(

--- a/packages/h5p-server/test/User.ts
+++ b/packages/h5p-server/test/User.ts
@@ -11,11 +11,13 @@ export default class User implements IUser {
         this.canUpdateAndInstallLibraries = true;
         this.canCreateRestricted = true;
         this.type = 'local';
+        this.email = 'test@example.com';
     }
 
     public canCreateRestricted: boolean;
     public canInstallRecommended: boolean;
     public canUpdateAndInstallLibraries: boolean;
+    public email: string;
     public id: string;
     public name: string;
     public type: 'local';


### PR DESCRIPTION
The UrlGenerator can now generate CSRF tokens for the current user.
The editor and player correctly set user objects in the integration (needed for xAPI to work).

BREAKING CHANGES:
The signature of H5PPlayer.render(...) was changed. You now need to pass in a user object and the optional parameters were moved to a dedicated options object.