### PR TITLE
fix(h5p-server): fixed url generation for absolulte library files

### DIFF
--- a/packages/h5p-server/src/UrlGenerator.ts
+++ b/packages/h5p-server/src/UrlGenerator.ts
@@ -123,7 +123,11 @@ export default class UrlGenerator implements IUrlGenerator {
         `${this.baseUrl()}${this.config.editorLibraryUrl}/`;
 
     public libraryFile = (library: IFullLibraryName, file: string): string => {
-        if (file.startsWith('http://') || file.startsWith('https://')) {
+        if (
+            file.startsWith('http://') ||
+            file.startsWith('https://') ||
+            file.startsWith('/')
+        ) {
             return file;
         }
         return `${this.baseUrl()}${this.config.librariesUrl}/${

--- a/packages/h5p-server/test/H5PPlayer.renderHtmlPage.test.ts
+++ b/packages/h5p-server/test/H5PPlayer.renderHtmlPage.test.ts
@@ -509,6 +509,7 @@ describe('Rendering the HTML page', () => {
                                 scripts: [
                                     ...scripts,
                                     'preload3.js',
+                                    '/preload4.js',
                                     'https://example.com/script.js'
                                 ],
                                 styles: [styles[0], styles[1]]
@@ -540,6 +541,7 @@ describe('Rendering the HTML page', () => {
                 '/h5p/libraries/Foo-1.0/preload3.js?version=1.0.0'
             )
         ).toBe(true);
+        expect((model as any).scripts.includes('/preload4.js')).toBe(true);
         expect(
             (model as any).scripts.includes('https://example.com/script.js')
         ).toBe(true);


### PR DESCRIPTION
Closes #1179.