### PR TITLE
refactor(h5p-server): validator now works on extracted packages

### DIFF
--- a/packages/h5p-server/src/PackageImporter.ts
+++ b/packages/h5p-server/src/PackageImporter.ts
@@ -220,7 +220,10 @@ export default class PackageImporter {
         parameters: any;
     }> {
         log.info(`processing package ${packagePath}`);
-        const packageValidator = new PackageValidator(this.config);
+        const packageValidator = new PackageValidator(
+            this.config,
+            this.libraryManager
+        );
         // no need to check result as the validator throws an exception if there is an error
         await packageValidator.validateFileSizes(packagePath);
         // we don't use withDir here, to have better error handling (catch & finally block below)

--- a/packages/h5p-server/src/PackageImporter.ts
+++ b/packages/h5p-server/src/PackageImporter.ts
@@ -223,12 +223,7 @@ export default class PackageImporter {
         log.info(`processing package ${packagePath}`);
         const packageValidator = new PackageValidator(this.config);
         // no need to check result as the validator throws an exception if there is an error
-        await packageValidator.validatePackage(
-            packagePath,
-            copyMode === ContentCopyModes.Install ||
-                copyMode === ContentCopyModes.Temporary,
-            true
-        );
+        await packageValidator.validateFileSizes(packagePath);
         // we don't use withDir here, to have better error handling (catch & finally block below)
         const { path: tempDirPath } = await dir();
 
@@ -244,6 +239,13 @@ export default class PackageImporter {
                     copyMode === ContentCopyModes.Install ||
                     copyMode === ContentCopyModes.Temporary
             });
+
+            await packageValidator.validateExtractedPackage(
+                tempDirPath,
+                copyMode === ContentCopyModes.Install ||
+                    copyMode === ContentCopyModes.Temporary,
+                true
+            );
             const dirContent = await fsExtra.readdir(tempDirPath);
 
             // install all libraries

--- a/packages/h5p-server/src/PackageImporter.ts
+++ b/packages/h5p-server/src/PackageImporter.ts
@@ -16,7 +16,6 @@ import {
     ILibraryInstallResult,
     IUser
 } from './types';
-
 import Logger from './helpers/Logger';
 
 const log = new Logger('PackageImporter');
@@ -82,9 +81,10 @@ export default class PackageImporter {
     ): Promise<void> {
         log.info(`extracting package ${packagePath} to ${directoryPath}`);
         const zipFile = await yauzlPromise.open(packagePath);
-        await zipFile.walkEntries(async (entry: any) => {
+        await zipFile.walkEntries(async (entry: yauzlPromise.Entry) => {
             const basename = path.basename(entry.fileName);
             if (
+                !entry.fileName.endsWith('/') &&
                 !basename.startsWith('.') &&
                 !basename.startsWith('_') &&
                 ((includeContent && entry.fileName.startsWith('content/')) ||
@@ -95,7 +95,6 @@ export default class PackageImporter {
             ) {
                 const readStream = await entry.openReadStream();
                 const writePath = path.join(directoryPath, entry.fileName);
-
                 await fsExtra.mkdirp(path.dirname(writePath));
                 const writeStream = fsExtra.createWriteStream(writePath);
                 await promisepipe(readStream, writeStream);

--- a/packages/h5p-server/src/PackageValidator.ts
+++ b/packages/h5p-server/src/PackageValidator.ts
@@ -16,6 +16,7 @@ import {
 } from './helpers/ValidatorBuilder';
 import { IH5PConfig } from './types';
 import LibraryManager from './LibraryManager';
+import LibraryName from './LibraryName';
 
 const log = new Logger('PackageValidator');
 
@@ -34,7 +35,8 @@ const log = new Logger('PackageValidator');
  */
 export default class PackageValidator {
     /**
-     * @param configurationValues Object containing all required configuration parameters
+     * @param configurationValues Object containing all required configuration
+     * parameters
      */
     constructor(
         private config: IH5PConfig,
@@ -107,7 +109,8 @@ export default class PackageValidator {
     ): Promise<yauzlPromise.ZipFile> {
         try {
             log.debug(`opening zip archive ${file}`);
-            // we await the promise here because we want to catch the error and return undefined
+            // we await the promise here because we want to catch the error and
+            // return undefined
             return await yauzlPromise.open(file, { lazyEntries: false });
         } catch (ignored) {
             log.error(`zip file ${file} could not be opened: ${ignored}`);
@@ -227,11 +230,15 @@ export default class PackageValidator {
     }
 
     /**
-     * Checks if the core API version required in the metadata can be satisfied by the running instance.
-     * @param {{coreApi: { majorVersion: number, minorVersion: number }}} metadata The object containing information about the required core version
+     * Checks if the core API version required in the metadata can be satisfied
+     * by the running instance.
+     * @param metadata The object containing information about the required core
+     * version
      * @param libraryName The name of the library that is being checked.
      * @param error The error object.
-     * @returns true if the core API required in the metadata can be satisfied by the running instance. Also true if the metadata doesn't require any core API version.
+     * @returns true if the core API required in the metadata can be satisfied
+     * by the running instance. Also true if the metadata doesn't require any
+     * core API version.
      */
     private checkCoreVersion(
         metadata: { coreApi: { majorVersion: number; minorVersion: number } },
@@ -272,11 +279,13 @@ export default class PackageValidator {
     }
 
     /**
-     * Factory for the file extension rule: Checks if the file extensions of the files in the array are
-     * in the whitelists.
-     * Does NOT throw errors but appends them to the error object.
-     * @param {(arg: string) => boolean} filter The filter function must return true if the filename passed to it should be checked
-     * @param whitelist The file extensions that are allowed for files that match the filter
+     * Factory for the file extension rule: Checks if the file extensions of the
+     * files in the array are in the whitelists. Does NOT throw errors but
+     * appends them to the error object.
+     * @param filter The filter function must return true if the filename passed
+     * to it should be checked
+     * @param whitelist The file extensions that are allowed for files that
+     * match the filter
      * @returns the rule
      */
     private fileExtensionMustBeAllowed(
@@ -323,12 +332,15 @@ export default class PackageValidator {
     }
 
     /**
-     * Factory for a rule that makes sure that a certain file must exist.
-     * Does NOT throw errors but appends them to the error object.
-     * @param filename The filename that must exist among the zip entries (path, not case-sensitive)
+     * Factory for a rule that makes sure that a certain file must exist. Does
+     * NOT throw errors but appends them to the error object.
+     * @param filename The filename that must exist among the zip entries (path,
+     * not case-sensitive)
      * @param errorId The error message that is used if the file does not exist
-     * @param throwOnError (optional) If true, the rule will throw an error if the file does not exist.
-     * @param errorReplacements (optional) The replacement variables to pass to the error.
+     * @param throwOnError (optional) If true, the rule will throw an error if
+     * the file does not exist.
+     * @param errorReplacements (optional) The replacement variables to pass to
+     * the error.
      * @returns the rule
      */
     private fileMustExist(
@@ -364,8 +376,8 @@ export default class PackageValidator {
     }
 
     /**
-     * Checks file sizes (single files and all files combined)
-     * Does NOT throw errors but appends them to the error object.
+     * Checks file sizes (single files and all files combined) Does NOT throw
+     * errors but appends them to the error object.
      * @param zipEntries The entries inside the h5p file
      * @param error The error object to use
      * @returns The unchanged zip entries
@@ -409,7 +421,8 @@ export default class PackageValidator {
 
     /**
      * Factory for a rule that filters out files from the validation.
-     * @param {(string) => boolean} filter The filter. Filenames matched by this filter will be filtered out.
+     * @param filter The filter. Filenames matched by this filter will be
+     * filtered out.
      * @returns the rule
      */
     private filterOutEntries(
@@ -424,8 +437,9 @@ export default class PackageValidator {
     }
 
     /**
-     * Initializes the JSON schema validators _h5pMetaDataValidator and _libraryMetadataValidator.
-     * Can be called multiple times, as it only creates new validators when it hasn't been called before.
+     * Initializes the JSON schema validators _h5pMetaDataValidator and
+     * _libraryMetadataValidator. Can be called multiple times, as it only
+     * creates new validators when it hasn't been called before.
      */
     private async initializeJsonValidators(): Promise<void> {
         if (this.h5pMetadataValidator && this.libraryMetadataValidator) {
@@ -630,7 +644,8 @@ export default class PackageValidator {
     };
 
     /**
-     * Factory for a rule that checks if library's directory conforms to naming standards
+     * Factory for a rule that checks if library's directory conforms to naming
+     * standards
      * @param libraryName The name of the library (directory)
      * @returns the rule
      */
@@ -659,7 +674,8 @@ export default class PackageValidator {
     }
 
     /**
-     * Checks if the language files in the library have the correct naming schema and are valid JSON.
+     * Checks if the language files in the library have the correct naming
+     * schema and are valid JSON.
      * @param filenames zip entries in the package
      * @param jsonData jsonData of the library.json file.
      * @param error The error object to use
@@ -708,10 +724,11 @@ export default class PackageValidator {
     };
 
     /**
-     * Factory for a check that makes sure that the directory name of the library matches the name in
-     * the library.json metadata.
-     * Does not throw a ValidationError.
-     * @param directoryName the name of the directory in the package this library is in
+     * Factory for a check that makes sure that the directory name of the
+     * library matches the name in the library.json metadata. Does not throw a
+     * ValidationError.
+     * @param directoryName the name of the directory in the package this
+     * library is in
      * @returns the rule
      */
     private libraryMustHaveMatchingDirectoryName(
@@ -738,8 +755,8 @@ export default class PackageValidator {
             // Library's directory name must be:
             // - <machineName>
             //     - or -
-            // - <machineName>-<majorVersion>.<minorVersion>
-            // where machineName, majorVersion and minorVersion is read from library.json
+            // - <machineName>-<majorVersion>.<minorVersion> where machineName,
+            //   majorVersion and minorVersion is read from library.json
             if (
                 directoryName !== jsonData.machineName &&
                 directoryName !==
@@ -766,22 +783,30 @@ export default class PackageValidator {
         pathPrefix: string,
         error: AggregateH5pError
     ): Promise<{ jsonData: any; filenames: string[] }> => {
+        log.debug(`Checking if library can be skipped`);
         if (
             skipInstalledLibraries &&
-            this.libraryManager.libraryExists(jsonData) &&
-            !this.libraryManager.isPatchedLibrary(jsonData)
+            (await this.libraryManager.libraryExists(jsonData)) &&
+            !(await this.libraryManager.isPatchedLibrary(jsonData))
         ) {
+            log.debug(
+                `Skipping already installed library ${LibraryName.toUberName(
+                    jsonData
+                )}`
+            );
             return undefined;
         }
         return { jsonData, filenames };
     };
 
     /**
-     * Checks if all JavaScript and CSS file references in the preloaded section of the library metadata are present in the package.
+     * Checks if all JavaScript and CSS file references in the preloaded section
+     * of the library metadata are present in the package.
      * @param filenames zip entries in the package
      * @param jsonData data of the library.json file.
      * @param error The error object to use
-     * @returns {Promise<{filenames: string[], jsonData: any}>} the unchanged data passed to the rule
+     * @returns {Promise<{filenames: string[], jsonData: any}>} the unchanged
+     * data passed to the rule
      */
     private libraryPreloadedFilesMustExist = async (
         { filenames, jsonData }: { jsonData: any; filenames: string[] },
@@ -792,7 +817,8 @@ export default class PackageValidator {
             `checking if all js and css file references in the preloaded section of the library metadata are present in package`
         );
         const uberName = `${jsonData.machineName}-${jsonData.majorVersion}.${jsonData.minorVersion}`;
-        // check if all JavaScript files that must be preloaded are part of the package
+        // check if all JavaScript files that must be preloaded are part of the
+        // package
         if (jsonData.preloadedJs) {
             await Promise.all(
                 jsonData.preloadedJs.map((file) =>
@@ -823,8 +849,8 @@ export default class PackageValidator {
     };
 
     /**
-     * Checks if a library is compatible to the core version running.
-     * Does not throw a ValidationError.
+     * Checks if a library is compatible to the core version running. Does not
+     * throw a ValidationError.
      * @param filenames zip entries in the package
      * @param jsonData jsonData of the library.json file.
      * @param error The error object to use
@@ -854,8 +880,8 @@ export default class PackageValidator {
     }
 
     /**
-     * Tries to open the file in the ZIP archive in memory and parse it as JSON. Will throw errors
-     * if the file cannot be read or is no valid JSON.
+     * Tries to open the file in the ZIP archive in memory and parse it as JSON.
+     * Will throw errors if the file cannot be read or is no valid JSON.
      * @param filename The entry to read
      * @returns The read JSON as an object
      */
@@ -876,7 +902,8 @@ export default class PackageValidator {
      * @param filenames All (relevant) zip entries of the package.
      * @param ubername The name of the library to check
      * @param error the error object
-     * @returns the object from library.json with additional data from semantics.json, the language files and the icon.
+     * @returns the object from library.json with additional data from
+     * semantics.json, the language files and the icon.
      */
     private async validateLibrary(
         filenames: string[],
@@ -908,7 +935,7 @@ export default class PackageValidator {
                         { name: ubername }
                     )
                 )
-                .addRule(this.skipInstalledLibraries(true))
+                .addRule(this.skipInstalledLibraries(skipInstalledLibraries))
                 .addRule(this.mustBeCompatibleToCoreVersion)
                 .addRule(this.libraryMustHaveMatchingDirectoryName(ubername))
                 .addRule(this.libraryPreloadedFilesMustExist)
@@ -916,8 +943,10 @@ export default class PackageValidator {
                 .validate(filenames, pathPrefix, error);
         } catch (e) {
             if (e instanceof AggregateH5pError) {
-                // Don't rethrow a ValidationError (and thus abort validation) as other libraries can still be validated, too. This is fine as the
-                // error values are appended to the ValidationError and the error will be thrown at some point anyway.
+                // Don't rethrow a ValidationError (and thus abort validation)
+                // as other libraries can still be validated, too. This is fine
+                // as the error values are appended to the ValidationError and
+                // the error will be thrown at some point anyway.
                 return false;
             }
             throw e;

--- a/packages/h5p-server/src/PackageValidator.ts
+++ b/packages/h5p-server/src/PackageValidator.ts
@@ -122,6 +122,7 @@ export default class PackageValidator {
 
         const result = await new ValidatorBuilder()
             .addRule(this.fileSizeMustBeWithinLimits)
+            .addRule(throwErrorsNowRule)
             .addRule(this.returnTrue)
             .validate(await zipArchive.readEntries(), '');
 
@@ -182,7 +183,12 @@ export default class PackageValidator {
                 this.jsonMustConformToSchema(
                     'h5p.json',
                     this.h5pMetadataValidator,
-                    'invalid-h5p-json-file-2'
+                    'invalid-h5p-json-file-2',
+                    'unable-to-parse-package',
+                    undefined,
+                    {
+                        filename: 'h5p.json'
+                    }
                 ),
                 checkContent
             )
@@ -195,7 +201,13 @@ export default class PackageValidator {
                 checkContent
             )
             .addRuleWhen(
-                this.jsonMustBeParsable('content/content.json'),
+                this.jsonMustBeParsable(
+                    'content/content.json',
+                    'unable-to-parse-package',
+                    undefined,
+                    undefined,
+                    { filename: 'content/content.json' }
+                ),
                 checkContent
             )
             .addRule(throwErrorsNowRule)

--- a/packages/h5p-server/src/helpers/AggregateH5pError.ts
+++ b/packages/h5p-server/src/helpers/AggregateH5pError.ts
@@ -34,6 +34,7 @@ export default class AggregateH5pError extends H5pError {
         this.errors.push(error);
         this.message = `${this.errorId}:${this.getErrors()
             .map((e) => e.message)
+            .sort()
             .join(',')}`;
         return this;
     }

--- a/packages/h5p-server/src/helpers/ValidatorBuilder.ts
+++ b/packages/h5p-server/src/helpers/ValidatorBuilder.ts
@@ -100,6 +100,12 @@ export class ValidatorBuilder {
             // occur step by step
             // eslint-disable-next-line no-await-in-loop
             returnValue = await rule(returnValue, pathPrefix, error);
+            if (returnValue === undefined) {
+                // An undefined return value means that the validation should be
+                // aborted because it's not necessary (e.g. because it would be
+                // redundant to validate an already installed library)
+                break;
+            }
         }
         return returnValue;
     }

--- a/packages/h5p-server/src/helpers/ValidatorBuilder.ts
+++ b/packages/h5p-server/src/helpers/ValidatorBuilder.ts
@@ -1,56 +1,71 @@
 import AggregateH5pError from './AggregateH5pError';
 
 /**
- * A ValidatorBuilder can be used to chain validation rules by calling addRule(...) multiple times
- * and by starting the validation by calling validate(...). The ValidatorBuilder then calls
- * each rule in the order they were added.
+ * A ValidatorBuilder can be used to chain validation rules by calling
+ * addRule(...) multiple times and by starting the validation by calling
+ * validate(...). The ValidatorBuilder then calls each rule in the order they
+ * were added.
  *
  * Each validation rule is a function that requires two parameters:
  *   - a content object
  *   - an error object
  *
- * The content object contains the content that should be validated. Typically this content object
- * is also returned by the validation rule as it is passed on as the first paramter to the next rule.
- * In some cases rules can return a different (or mutated) content object if transformations are
- * necessary.
+ * The content object contains the content that should be validated. Typically
+ * this content object is also returned by the validation rule as it is passed
+ * on as the first paramter to the next rule. In some cases rules can return a
+ * different (or mutated) content object if transformations are necessary.
  *
- * The error object is of type ValidationError and is used to report back errors to the caller of
- * validate. (Every call to validate should be wrapped in a try-catch block). To cover cases
- * in which the validation process doesn't have to be interrupted if there is a validation error
- * the rule can call error.addError(...) to append another error message to the error object.
- * The error object has to be thrown later, e.g. by adding the throwErrorsNowRule to the builder.
- * If validation needs to be stopped right away, the rule function should throw the error object
- * passed to it (it should not create a new error object because there might be other messages
- * in the error object already).
+ * The error object is of type ValidationError and is used to report back errors
+ * to the caller of validate. (Every call to validate should be wrapped in a
+ * try-catch block). To cover cases in which the validation process doesn't have
+ * to be interrupted if there is a validation error the rule can call
+ * error.addError(...) to append another error message to the error object. The
+ * error object has to be thrown later, e.g. by adding the throwErrorsNowRule to
+ * the builder. If validation needs to be stopped right away, the rule function
+ * should throw the error object passed to it (it should not create a new error
+ * object because there might be other messages in the error object already).
  */
 export class ValidatorBuilder {
     constructor() {
         this.rules = [];
     }
 
-    private rules: ((content: any, error: AggregateH5pError) => any)[];
+    private rules: ((
+        content: any,
+        pathPrefix: string,
+        error: AggregateH5pError
+    ) => any)[];
 
     /**
-     * Adds a rule to the validator. Chain this method together to create complex validators.
-     * @param {(content: any, error: AggregateH5pError) => any} rule rule to add
+     * Adds a rule to the validator. Chain this method together to create
+     * complex validators.
+     * @param rule rule to add
      * @returns
      */
     public addRule(
-        rule: (content: any, error: AggregateH5pError) => any
+        rule: (
+            content: any,
+            pathPrefix: string,
+            error: AggregateH5pError
+        ) => any
     ): ValidatorBuilder {
         this.rules.push(rule);
         return this;
     }
 
     /**
-     * Adds a rule to the validator if the condition is met.
-     * Chain this method together to create complex validators.
-     * @param {(content: any, error: AggregateH5pError) => any} rule rule to add
+     * Adds a rule to the validator if the condition is met. Chain this method
+     * together to create complex validators.
+     * @param rule rule to add
      * @param condition the condition (rule is added if it is true)
      * @returns
      */
     public addRuleWhen(
-        rule: (content: any, error: AggregateH5pError) => any,
+        rule: (
+            content: any,
+            pathPrefix: string,
+            error: AggregateH5pError
+        ) => any,
         condition: boolean
     ): ValidatorBuilder {
         if (condition) {
@@ -61,12 +76,16 @@ export class ValidatorBuilder {
 
     /**
      * Executes the validation.
-     * @param data The data to validate. This parameters is passed to the first rule as the first parameter.
-     * @param error an optional error object. A new one is created if none is passed in here.
-     * @returns Returns the object that is returned by the last rule if everything is valid or throws a ValidationError if not
+     * @param data The data to validate. This parameters is passed to the first
+     * rule as the first parameter.
+     * @param error an optional error object. A new one is created if none is
+     * passed in here.
+     * @returns Returns the object that is returned by the last rule if
+     * everything is valid or throws a ValidationError if not
      */
     public async validate(
         data: any,
+        pathPrefix: string,
         error: AggregateH5pError = new AggregateH5pError(
             'package-validation-failed',
             {},
@@ -77,20 +96,27 @@ export class ValidatorBuilder {
     ): Promise<any> {
         let returnValue = data;
         for (const rule of this.rules) {
-            // promises need to be called iteratively here as validation has to occur step by step
-            returnValue = await rule(returnValue, error);
+            // promises need to be called iteratively here as validation has to
+            // occur step by step
+            // eslint-disable-next-line no-await-in-loop
+            returnValue = await rule(returnValue, pathPrefix, error);
         }
         return returnValue;
     }
 }
 
 /**
- * This rule throws the ValidationError object passed to it if there are any messages in it.
+ * This rule throws the ValidationError object passed to it if there are any
+ * messages in it.
  * @param data The data (ignored by this rule)
  * @param error The error to throw if there are any
  * @returns the unchanged data object
  */
-export function throwErrorsNowRule(data: any, error: AggregateH5pError): any {
+export function throwErrorsNowRule(
+    data: any,
+    pathPrefix: string,
+    error: AggregateH5pError
+): any {
     if (error.hasErrors()) {
         throw error;
     }

--- a/packages/h5p-server/test/H5PEditor.saving.test.ts
+++ b/packages/h5p-server/test/H5PEditor.saving.test.ts
@@ -19,8 +19,8 @@ import {
 import User from './User';
 import { fsImplementations, H5PEditor } from '../src';
 import H5PConfig from '../src/implementation/H5PConfig';
-import PackageValidator from '../src/PackageValidator';
 import UrlGenerator from '../src/UrlGenerator';
+import { validatePackage } from './helpers/PackageValidatorHelper';
 
 describe('H5PEditor', () => {
     function createH5PEditor(
@@ -756,13 +756,8 @@ describe('H5PEditor', () => {
                         writeStream.close();
 
                         // check if saved H5P package is valid
-                        const validator = new PackageValidator(config);
                         await expect(
-                            validator.validateExtractedPackage(
-                                h5pFilePath,
-                                true,
-                                true
-                            )
+                            validatePackage(config, h5pFilePath, true, true)
                         ).resolves.toEqual(true);
                     },
                     { keep: false, postfix: '.h5p' }

--- a/packages/h5p-server/test/H5PEditor.saving.test.ts
+++ b/packages/h5p-server/test/H5PEditor.saving.test.ts
@@ -757,7 +757,13 @@ describe('H5PEditor', () => {
 
                         // check if saved H5P package is valid
                         await expect(
-                            validatePackage(config, h5pFilePath, true, true)
+                            validatePackage(
+                                h5pEditor.libraryManager,
+                                config,
+                                h5pFilePath,
+                                true,
+                                true
+                            )
                         ).resolves.toEqual(true);
                     },
                     { keep: false, postfix: '.h5p' }

--- a/packages/h5p-server/test/H5PEditor.saving.test.ts
+++ b/packages/h5p-server/test/H5PEditor.saving.test.ts
@@ -758,7 +758,11 @@ describe('H5PEditor', () => {
                         // check if saved H5P package is valid
                         const validator = new PackageValidator(config);
                         await expect(
-                            validator.validatePackage(h5pFilePath, true, true)
+                            validator.validateExtractedPackage(
+                                h5pFilePath,
+                                true,
+                                true
+                            )
                         ).resolves.toEqual(true);
                     },
                     { keep: false, postfix: '.h5p' }

--- a/packages/h5p-server/test/PackageValidator.test.ts
+++ b/packages/h5p-server/test/PackageValidator.test.ts
@@ -3,14 +3,27 @@ import * as path from 'path';
 import H5PConfig from '../src/implementation/H5PConfig';
 import { validatePackage } from './helpers/PackageValidatorHelper';
 
+const libraryManagerMock = {
+    isPatchedLibrary: () => Promise.resolve(undefined),
+    libraryExists: () => Promise.resolve(false)
+} as any;
+
 describe('validating H5P files', () => {
     it('correctly validates valid h5p files', async () => {
         const h5pFile1 = path.resolve('test/data/validator/valid1.h5p');
         const h5pFile2 = path.resolve('test/data/validator/valid2.h5p');
 
-        let result = await validatePackage(new H5PConfig(null), h5pFile1);
+        let result = await validatePackage(
+            libraryManagerMock,
+            new H5PConfig(null),
+            h5pFile1
+        );
         expect(result).toBeDefined();
-        result = await validatePackage(new H5PConfig(null), h5pFile2);
+        result = await validatePackage(
+            libraryManagerMock,
+            new H5PConfig(null),
+            h5pFile2
+        );
         expect(result).toBeDefined();
     });
 
@@ -18,7 +31,7 @@ describe('validating H5P files', () => {
         const h5pFile = path.resolve('test/data/validator/corrupt_archive.h5p');
 
         await expect(
-            validatePackage(new H5PConfig(null), h5pFile)
+            validatePackage(libraryManagerMock, new H5PConfig(null), h5pFile)
         ).rejects.toThrow('unable-to-unzip');
     });
 
@@ -27,9 +40,9 @@ describe('validating H5P files', () => {
         const config = new H5PConfig(null);
         config.maxFileSize = 1024;
 
-        await expect(validatePackage(config, h5pFile)).rejects.toThrow(
-            'package-validation-failed:file-size-too-large'
-        );
+        await expect(
+            validatePackage(libraryManagerMock, config, h5pFile)
+        ).rejects.toThrow('package-validation-failed:file-size-too-large');
     });
 
     it('rejects too large total content size', async () => {
@@ -37,9 +50,9 @@ describe('validating H5P files', () => {
         const config = new H5PConfig(null);
         config.maxTotalSize = 10;
 
-        await expect(validatePackage(config, h5pFile)).rejects.toThrow(
-            'package-validation-failed:total-size-too-large'
-        );
+        await expect(
+            validatePackage(libraryManagerMock, config, h5pFile)
+        ).rejects.toThrow('package-validation-failed:total-size-too-large');
     });
 
     it('rejects invalid file extensions', async () => {
@@ -48,9 +61,9 @@ describe('validating H5P files', () => {
         config.libraryWhitelist = 'json js css';
         config.contentWhitelist = 'json';
 
-        await expect(validatePackage(config, h5pFile)).rejects.toThrow(
-            'package-validation-failed:not-in-whitelist'
-        );
+        await expect(
+            validatePackage(libraryManagerMock, config, h5pFile)
+        ).rejects.toThrow('package-validation-failed:not-in-whitelist');
     });
 
     it('rejects broken json files', async () => {
@@ -62,10 +75,10 @@ describe('validating H5P files', () => {
         );
 
         await expect(
-            validatePackage(new H5PConfig(null), h5pFile1)
+            validatePackage(libraryManagerMock, new H5PConfig(null), h5pFile1)
         ).rejects.toThrow('package-validation-failed:unable-to-parse-package');
         await expect(
-            validatePackage(new H5PConfig(null), h5pFile2)
+            validatePackage(libraryManagerMock, new H5PConfig(null), h5pFile2)
         ).rejects.toThrow('package-validation-failed:unable-to-parse-package');
     });
 
@@ -75,7 +88,7 @@ describe('validating H5P files', () => {
         );
 
         await expect(
-            validatePackage(new H5PConfig(null), h5pFile)
+            validatePackage(libraryManagerMock, new H5PConfig(null), h5pFile)
         ).rejects.toThrow('package-validation-failed:invalid-h5p-json-file-2');
     });
 
@@ -85,7 +98,7 @@ describe('validating H5P files', () => {
         );
 
         await expect(
-            validatePackage(new H5PConfig(null), h5pFile)
+            validatePackage(libraryManagerMock, new H5PConfig(null), h5pFile)
         ).rejects.toThrow('package-validation-failed:invalid-library-name');
     });
 
@@ -95,7 +108,7 @@ describe('validating H5P files', () => {
         );
 
         await expect(
-            validatePackage(new H5PConfig(null), h5pFile)
+            validatePackage(libraryManagerMock, new H5PConfig(null), h5pFile)
         ).rejects.toThrow(
             'package-validation-failed:invalid-schema-library-json-file'
         );
@@ -107,7 +120,7 @@ describe('validating H5P files', () => {
         );
 
         await expect(
-            validatePackage(new H5PConfig(null), h5pFile)
+            validatePackage(libraryManagerMock, new H5PConfig(null), h5pFile)
         ).rejects.toThrow('package-validation-failed:library-file-missing');
     });
 
@@ -117,7 +130,7 @@ describe('validating H5P files', () => {
         );
 
         await expect(
-            validatePackage(new H5PConfig(null), h5pFile)
+            validatePackage(libraryManagerMock, new H5PConfig(null), h5pFile)
         ).rejects.toThrow(
             'package-validation-failed:library-directory-name-mismatch'
         );
@@ -129,7 +142,7 @@ describe('validating H5P files', () => {
         );
 
         await expect(
-            validatePackage(new H5PConfig(null), h5pFile)
+            validatePackage(libraryManagerMock, new H5PConfig(null), h5pFile)
         ).rejects.toThrow(
             'package-validation-failed:invalid-language-file-json'
         );
@@ -141,9 +154,9 @@ describe('validating H5P files', () => {
         );
         const config = new H5PConfig(null);
         config.coreApiVersion.minor = 1;
-        await expect(validatePackage(config, h5pFile)).rejects.toThrow(
-            'package-validation-failed:api-version-unsupported'
-        );
+        await expect(
+            validatePackage(libraryManagerMock, config, h5pFile)
+        ).rejects.toThrow('package-validation-failed:api-version-unsupported');
     });
 
     it('detects errors in several libraries', async () => {
@@ -151,7 +164,9 @@ describe('validating H5P files', () => {
             'test/data/validator/2-invalid-libraries.h5p'
         );
         const config = new H5PConfig(null);
-        await expect(validatePackage(config, h5pFile)).rejects.toThrow(
+        await expect(
+            validatePackage(libraryManagerMock, config, h5pFile)
+        ).rejects.toThrow(
             'package-validation-failed:invalid-language-file,invalid-schema-library-json-file'
         );
     });

--- a/packages/h5p-server/test/PackageValidator.test.ts
+++ b/packages/h5p-server/test/PackageValidator.test.ts
@@ -9,18 +9,18 @@ describe('validating H5P files', () => {
         const h5pFile2 = path.resolve('test/data/validator/valid2.h5p');
 
         const validator = new PackageValidator(new H5PConfig(null));
-        let result = await validator.validatePackage(h5pFile1);
+        let result = await validator.validateExtractedPackage(h5pFile1);
         expect(result).toBeDefined();
-        result = await validator.validatePackage(h5pFile2);
+        result = await validator.validateExtractedPackage(h5pFile2);
         expect(result).toBeDefined();
     });
 
     it('rejects non-valid zip files', async () => {
         const h5pFile = path.resolve('test/data/validator/corrupt_archive.h5p');
         const validator = new PackageValidator(new H5PConfig(null));
-        await expect(validator.validatePackage(h5pFile)).rejects.toThrow(
-            'unable-to-unzip'
-        );
+        await expect(
+            validator.validateExtractedPackage(h5pFile)
+        ).rejects.toThrow('unable-to-unzip');
     });
 
     it('rejects too large content', async () => {
@@ -29,9 +29,9 @@ describe('validating H5P files', () => {
         config.maxFileSize = 1024;
 
         const validator = new PackageValidator(config);
-        await expect(validator.validatePackage(h5pFile)).rejects.toThrow(
-            'package-validation-failed:file-size-too-large'
-        );
+        await expect(
+            validator.validateExtractedPackage(h5pFile)
+        ).rejects.toThrow('package-validation-failed:file-size-too-large');
     });
 
     it('rejects too large total content size', async () => {
@@ -40,9 +40,9 @@ describe('validating H5P files', () => {
         config.maxTotalSize = 10;
 
         const validator = new PackageValidator(config);
-        await expect(validator.validatePackage(h5pFile)).rejects.toThrow(
-            'package-validation-failed:total-size-too-large'
-        );
+        await expect(
+            validator.validateExtractedPackage(h5pFile)
+        ).rejects.toThrow('package-validation-failed:total-size-too-large');
     });
 
     it('rejects invalid file extensions', async () => {
@@ -52,9 +52,9 @@ describe('validating H5P files', () => {
         config.contentWhitelist = 'json';
 
         const validator = new PackageValidator(config);
-        await expect(validator.validatePackage(h5pFile)).rejects.toThrow(
-            'package-validation-failed:not-in-whitelist'
-        );
+        await expect(
+            validator.validateExtractedPackage(h5pFile)
+        ).rejects.toThrow('package-validation-failed:not-in-whitelist');
     });
 
     it('rejects broken json files', async () => {
@@ -66,12 +66,12 @@ describe('validating H5P files', () => {
         );
 
         const validator = new PackageValidator(new H5PConfig(null));
-        await expect(validator.validatePackage(h5pFile1)).rejects.toThrow(
-            'package-validation-failed:unable-to-parse-package'
-        );
-        await expect(validator.validatePackage(h5pFile2)).rejects.toThrow(
-            'package-validation-failed:unable-to-parse-package'
-        );
+        await expect(
+            validator.validateExtractedPackage(h5pFile1)
+        ).rejects.toThrow('package-validation-failed:unable-to-parse-package');
+        await expect(
+            validator.validateExtractedPackage(h5pFile2)
+        ).rejects.toThrow('package-validation-failed:unable-to-parse-package');
     });
 
     it('rejects files with h5p.json not conforming to schema', async () => {
@@ -79,9 +79,9 @@ describe('validating H5P files', () => {
             'test/data/validator/invalid-h5p-json-schema.h5p'
         );
         const validator = new PackageValidator(new H5PConfig(null));
-        await expect(validator.validatePackage(h5pFile)).rejects.toThrow(
-            'package-validation-failed:invalid-h5p-json-file-2'
-        );
+        await expect(
+            validator.validateExtractedPackage(h5pFile)
+        ).rejects.toThrow('package-validation-failed:invalid-h5p-json-file-2');
     });
 
     it('rejects files with malformed library directory names', async () => {
@@ -89,9 +89,9 @@ describe('validating H5P files', () => {
             'test/data/validator/malformed-library-directory.h5p'
         );
         const validator = new PackageValidator(new H5PConfig(null));
-        await expect(validator.validatePackage(h5pFile)).rejects.toThrow(
-            'package-validation-failed:invalid-library-name'
-        );
+        await expect(
+            validator.validateExtractedPackage(h5pFile)
+        ).rejects.toThrow('package-validation-failed:invalid-library-name');
     });
 
     it('rejects files with library.json not conforming to schema', async () => {
@@ -99,7 +99,9 @@ describe('validating H5P files', () => {
             'test/data/validator/invalid-library-json.h5p'
         );
         const validator = new PackageValidator(new H5PConfig(null));
-        await expect(validator.validatePackage(h5pFile)).rejects.toThrow(
+        await expect(
+            validator.validateExtractedPackage(h5pFile)
+        ).rejects.toThrow(
             'package-validation-failed:invalid-schema-library-json-file'
         );
     });
@@ -109,9 +111,9 @@ describe('validating H5P files', () => {
             'test/data/validator/missing-preloaded-js.h5p'
         );
         const validator = new PackageValidator(new H5PConfig(null));
-        await expect(validator.validatePackage(h5pFile)).rejects.toThrow(
-            'package-validation-failed:library-file-missing'
-        );
+        await expect(
+            validator.validateExtractedPackage(h5pFile)
+        ).rejects.toThrow('package-validation-failed:library-file-missing');
     });
 
     it('rejects files with invalid library directory names', async () => {
@@ -119,7 +121,9 @@ describe('validating H5P files', () => {
             'test/data/validator/invalid-library-directory-name.h5p'
         );
         const validator = new PackageValidator(new H5PConfig(null));
-        await expect(validator.validatePackage(h5pFile)).rejects.toThrow(
+        await expect(
+            validator.validateExtractedPackage(h5pFile)
+        ).rejects.toThrow(
             'package-validation-failed:library-directory-name-mismatch'
         );
     });
@@ -129,7 +133,9 @@ describe('validating H5P files', () => {
             'test/data/validator/invalid-language-file-json.h5p'
         );
         const validator = new PackageValidator(new H5PConfig(null));
-        await expect(validator.validatePackage(h5pFile)).rejects.toThrow(
+        await expect(
+            validator.validateExtractedPackage(h5pFile)
+        ).rejects.toThrow(
             'package-validation-failed:invalid-language-file-json'
         );
     });
@@ -141,9 +147,9 @@ describe('validating H5P files', () => {
         const config = new H5PConfig(null);
         config.coreApiVersion.minor = 1;
         const validator = new PackageValidator(config);
-        await expect(validator.validatePackage(h5pFile)).rejects.toThrow(
-            'package-validation-failed:api-version-unsupported'
-        );
+        await expect(
+            validator.validateExtractedPackage(h5pFile)
+        ).rejects.toThrow('package-validation-failed:api-version-unsupported');
     });
 
     it('detects errors in several libraries', async () => {
@@ -152,8 +158,8 @@ describe('validating H5P files', () => {
         );
         const config = new H5PConfig(null);
         const validator = new PackageValidator(config);
-        await expect(validator.validatePackage(h5pFile)).rejects.toThrow(
-            'package-validation-failed:invalid-language-file'
-        );
+        await expect(
+            validator.validateExtractedPackage(h5pFile)
+        ).rejects.toThrow('package-validation-failed:invalid-language-file');
     });
 });

--- a/packages/h5p-server/test/PackageValidator.test.ts
+++ b/packages/h5p-server/test/PackageValidator.test.ts
@@ -170,4 +170,21 @@ describe('validating H5P files', () => {
             'package-validation-failed:invalid-language-file,invalid-schema-library-json-file'
         );
     });
+
+    it('skips library validation when library is already installed', async () => {
+        const h5pFile = path.resolve(
+            'test/data/validator/missing-preloaded-js.h5p'
+        );
+        const config = new H5PConfig(null);
+        await expect(
+            validatePackage(
+                {
+                    isPatchedLibrary: () => Promise.resolve(false),
+                    libraryExists: () => Promise.resolve(true)
+                } as any,
+                config,
+                h5pFile
+            )
+        ).resolves.toBeDefined();
+    });
 });

--- a/packages/h5p-server/test/PackageValidator.test.ts
+++ b/packages/h5p-server/test/PackageValidator.test.ts
@@ -1,25 +1,24 @@
 import * as path from 'path';
 
 import H5PConfig from '../src/implementation/H5PConfig';
-import PackageValidator from '../src/PackageValidator';
+import { validatePackage } from './helpers/PackageValidatorHelper';
 
 describe('validating H5P files', () => {
     it('correctly validates valid h5p files', async () => {
         const h5pFile1 = path.resolve('test/data/validator/valid1.h5p');
         const h5pFile2 = path.resolve('test/data/validator/valid2.h5p');
 
-        const validator = new PackageValidator(new H5PConfig(null));
-        let result = await validator.validateExtractedPackage(h5pFile1);
+        let result = await validatePackage(new H5PConfig(null), h5pFile1);
         expect(result).toBeDefined();
-        result = await validator.validateExtractedPackage(h5pFile2);
+        result = await validatePackage(new H5PConfig(null), h5pFile2);
         expect(result).toBeDefined();
     });
 
     it('rejects non-valid zip files', async () => {
         const h5pFile = path.resolve('test/data/validator/corrupt_archive.h5p');
-        const validator = new PackageValidator(new H5PConfig(null));
+
         await expect(
-            validator.validateExtractedPackage(h5pFile)
+            validatePackage(new H5PConfig(null), h5pFile)
         ).rejects.toThrow('unable-to-unzip');
     });
 
@@ -28,10 +27,9 @@ describe('validating H5P files', () => {
         const config = new H5PConfig(null);
         config.maxFileSize = 1024;
 
-        const validator = new PackageValidator(config);
-        await expect(
-            validator.validateExtractedPackage(h5pFile)
-        ).rejects.toThrow('package-validation-failed:file-size-too-large');
+        await expect(validatePackage(config, h5pFile)).rejects.toThrow(
+            'package-validation-failed:file-size-too-large'
+        );
     });
 
     it('rejects too large total content size', async () => {
@@ -39,10 +37,9 @@ describe('validating H5P files', () => {
         const config = new H5PConfig(null);
         config.maxTotalSize = 10;
 
-        const validator = new PackageValidator(config);
-        await expect(
-            validator.validateExtractedPackage(h5pFile)
-        ).rejects.toThrow('package-validation-failed:total-size-too-large');
+        await expect(validatePackage(config, h5pFile)).rejects.toThrow(
+            'package-validation-failed:total-size-too-large'
+        );
     });
 
     it('rejects invalid file extensions', async () => {
@@ -51,10 +48,9 @@ describe('validating H5P files', () => {
         config.libraryWhitelist = 'json js css';
         config.contentWhitelist = 'json';
 
-        const validator = new PackageValidator(config);
-        await expect(
-            validator.validateExtractedPackage(h5pFile)
-        ).rejects.toThrow('package-validation-failed:not-in-whitelist');
+        await expect(validatePackage(config, h5pFile)).rejects.toThrow(
+            'package-validation-failed:not-in-whitelist'
+        );
     });
 
     it('rejects broken json files', async () => {
@@ -65,12 +61,11 @@ describe('validating H5P files', () => {
             'test/data/validator/broken-content-json.h5p'
         );
 
-        const validator = new PackageValidator(new H5PConfig(null));
         await expect(
-            validator.validateExtractedPackage(h5pFile1)
+            validatePackage(new H5PConfig(null), h5pFile1)
         ).rejects.toThrow('package-validation-failed:unable-to-parse-package');
         await expect(
-            validator.validateExtractedPackage(h5pFile2)
+            validatePackage(new H5PConfig(null), h5pFile2)
         ).rejects.toThrow('package-validation-failed:unable-to-parse-package');
     });
 
@@ -78,9 +73,9 @@ describe('validating H5P files', () => {
         const h5pFile = path.resolve(
             'test/data/validator/invalid-h5p-json-schema.h5p'
         );
-        const validator = new PackageValidator(new H5PConfig(null));
+
         await expect(
-            validator.validateExtractedPackage(h5pFile)
+            validatePackage(new H5PConfig(null), h5pFile)
         ).rejects.toThrow('package-validation-failed:invalid-h5p-json-file-2');
     });
 
@@ -88,9 +83,9 @@ describe('validating H5P files', () => {
         const h5pFile = path.resolve(
             'test/data/validator/malformed-library-directory.h5p'
         );
-        const validator = new PackageValidator(new H5PConfig(null));
+
         await expect(
-            validator.validateExtractedPackage(h5pFile)
+            validatePackage(new H5PConfig(null), h5pFile)
         ).rejects.toThrow('package-validation-failed:invalid-library-name');
     });
 
@@ -98,9 +93,9 @@ describe('validating H5P files', () => {
         const h5pFile = path.resolve(
             'test/data/validator/invalid-library-json.h5p'
         );
-        const validator = new PackageValidator(new H5PConfig(null));
+
         await expect(
-            validator.validateExtractedPackage(h5pFile)
+            validatePackage(new H5PConfig(null), h5pFile)
         ).rejects.toThrow(
             'package-validation-failed:invalid-schema-library-json-file'
         );
@@ -110,9 +105,9 @@ describe('validating H5P files', () => {
         const h5pFile = path.resolve(
             'test/data/validator/missing-preloaded-js.h5p'
         );
-        const validator = new PackageValidator(new H5PConfig(null));
+
         await expect(
-            validator.validateExtractedPackage(h5pFile)
+            validatePackage(new H5PConfig(null), h5pFile)
         ).rejects.toThrow('package-validation-failed:library-file-missing');
     });
 
@@ -120,9 +115,9 @@ describe('validating H5P files', () => {
         const h5pFile = path.resolve(
             'test/data/validator/invalid-library-directory-name.h5p'
         );
-        const validator = new PackageValidator(new H5PConfig(null));
+
         await expect(
-            validator.validateExtractedPackage(h5pFile)
+            validatePackage(new H5PConfig(null), h5pFile)
         ).rejects.toThrow(
             'package-validation-failed:library-directory-name-mismatch'
         );
@@ -132,9 +127,9 @@ describe('validating H5P files', () => {
         const h5pFile = path.resolve(
             'test/data/validator/invalid-language-file-json.h5p'
         );
-        const validator = new PackageValidator(new H5PConfig(null));
+
         await expect(
-            validator.validateExtractedPackage(h5pFile)
+            validatePackage(new H5PConfig(null), h5pFile)
         ).rejects.toThrow(
             'package-validation-failed:invalid-language-file-json'
         );
@@ -146,10 +141,9 @@ describe('validating H5P files', () => {
         );
         const config = new H5PConfig(null);
         config.coreApiVersion.minor = 1;
-        const validator = new PackageValidator(config);
-        await expect(
-            validator.validateExtractedPackage(h5pFile)
-        ).rejects.toThrow('package-validation-failed:api-version-unsupported');
+        await expect(validatePackage(config, h5pFile)).rejects.toThrow(
+            'package-validation-failed:api-version-unsupported'
+        );
     });
 
     it('detects errors in several libraries', async () => {
@@ -157,9 +151,8 @@ describe('validating H5P files', () => {
             'test/data/validator/2-invalid-libraries.h5p'
         );
         const config = new H5PConfig(null);
-        const validator = new PackageValidator(config);
-        await expect(
-            validator.validateExtractedPackage(h5pFile)
-        ).rejects.toThrow('package-validation-failed:invalid-language-file');
+        await expect(validatePackage(config, h5pFile)).rejects.toThrow(
+            'package-validation-failed:invalid-language-file'
+        );
     });
 });

--- a/packages/h5p-server/test/PackageValidator.test.ts
+++ b/packages/h5p-server/test/PackageValidator.test.ts
@@ -152,7 +152,7 @@ describe('validating H5P files', () => {
         );
         const config = new H5PConfig(null);
         await expect(validatePackage(config, h5pFile)).rejects.toThrow(
-            'package-validation-failed:invalid-language-file'
+            'package-validation-failed:invalid-language-file,invalid-schema-library-json-file'
         );
     });
 });

--- a/packages/h5p-server/test/helpers/PackageValidatorHelper.ts
+++ b/packages/h5p-server/test/helpers/PackageValidatorHelper.ts
@@ -4,14 +4,16 @@ import fsExtra from 'fs-extra';
 import PackageImporter from '../../src/PackageImporter';
 import PackageValidator from '../../src/PackageValidator';
 import { IH5PConfig } from '../../src/types';
+import { LibraryManager } from '../../src';
 
 export async function validatePackage(
+    libraryManager: LibraryManager,
     config: IH5PConfig,
     packagePath: string,
     checkContent: boolean = true,
     checkLibraries: boolean = true
 ): Promise<any> {
-    const packageValidator = new PackageValidator(config);
+    const packageValidator = new PackageValidator(config, libraryManager);
     // no need to check result as the validator throws an exception if there is an error
     await packageValidator.validateFileSizes(packagePath);
     // we don't use withDir here, to have better error handling (catch & finally block below)

--- a/packages/h5p-server/test/helpers/PackageValidatorHelper.ts
+++ b/packages/h5p-server/test/helpers/PackageValidatorHelper.ts
@@ -1,0 +1,41 @@
+import { dir } from 'tmp-promise';
+import fsExtra from 'fs-extra';
+
+import PackageImporter from '../../src/PackageImporter';
+import PackageValidator from '../../src/PackageValidator';
+import { IH5PConfig } from '../../src/types';
+
+export async function validatePackage(
+    config: IH5PConfig,
+    packagePath: string,
+    checkContent: boolean = true,
+    checkLibraries: boolean = true
+): Promise<any> {
+    const packageValidator = new PackageValidator(config);
+    // no need to check result as the validator throws an exception if there is an error
+    await packageValidator.validateFileSizes(packagePath);
+    // we don't use withDir here, to have better error handling (catch & finally block below)
+    const { path: tempDirPath } = await dir();
+
+    try {
+        await PackageImporter.extractPackage(packagePath, tempDirPath, {
+            includeContent: checkContent,
+            includeLibraries: checkLibraries,
+            includeMetadata: checkContent
+        });
+
+        return await packageValidator.validateExtractedPackage(
+            tempDirPath,
+            checkContent,
+            checkLibraries
+        );
+
+        // eslint-disable-next-line no-useless-catch
+    } catch (error) {
+        // if we don't do this, finally weirdly just swallows the errors
+        throw error;
+    } finally {
+        // clean up temporary files in any case
+        await fsExtra.remove(tempDirPath);
+    }
+}

--- a/packages/h5p-server/test/integration/H5PEditor.saveH5P.test.ts
+++ b/packages/h5p-server/test/integration/H5PEditor.saveH5P.test.ts
@@ -15,7 +15,7 @@ describe('H5PEditor.saveH5P()', () => {
                 const contentPath = path.resolve(`test/data/hub-content`);
                 const contentTypes = await fsExtra.readdir(contentPath);
 
-                Promise.all(
+                await Promise.all(
                     contentTypes.map(async (contentType) => {
                         const { h5pEditor } = createH5PEditor(tempDirPath);
 
@@ -37,7 +37,8 @@ describe('H5PEditor.saveH5P()', () => {
                             user
                         );
                     })
-                ).then(() => done());
+                );
+                done();
             },
             { keep: false, unsafeCleanup: true }
         );

--- a/packages/h5p-server/test/integration/Validation.test.ts
+++ b/packages/h5p-server/test/integration/Validation.test.ts
@@ -21,7 +21,7 @@ describe('validate all H5P files from the Hub', () => {
             config.contentWhitelist += ' html';
             const validator = new PackageValidator(config);
             await expect(
-                validator.validatePackage(`${directory}/${file}`)
+                validator.validateExtractedPackage(`${directory}/${file}`)
             ).resolves.toBeDefined();
         });
     }

--- a/packages/h5p-server/test/integration/Validation.test.ts
+++ b/packages/h5p-server/test/integration/Validation.test.ts
@@ -4,6 +4,11 @@ import * as path from 'path';
 import H5PConfig from '../../src/implementation/H5PConfig';
 import { validatePackage } from '../helpers/PackageValidatorHelper';
 
+const libraryManagerMock = {
+    isPatchedLibrary: () => Promise.resolve(undefined),
+    libraryExists: () => Promise.resolve(false)
+} as any;
+
 describe('validate all H5P files from the Hub', () => {
     const directory = `${path.resolve('')}/test/data/hub-content/`;
     let files;
@@ -20,7 +25,11 @@ describe('validate all H5P files from the Hub', () => {
             const config = new H5PConfig(null);
             config.contentWhitelist += ' html';
             await expect(
-                validatePackage(config, `${directory}/${file}`)
+                validatePackage(
+                    libraryManagerMock,
+                    config,
+                    `${directory}/${file}`
+                )
             ).resolves.toBeDefined();
         });
     }

--- a/packages/h5p-server/test/integration/Validation.test.ts
+++ b/packages/h5p-server/test/integration/Validation.test.ts
@@ -2,7 +2,7 @@ import * as fsExtra from 'fs-extra';
 import * as path from 'path';
 
 import H5PConfig from '../../src/implementation/H5PConfig';
-import PackageValidator from '../../src/PackageValidator';
+import { validatePackage } from '../helpers/PackageValidatorHelper';
 
 describe('validate all H5P files from the Hub', () => {
     const directory = `${path.resolve('')}/test/data/hub-content/`;
@@ -19,9 +19,8 @@ describe('validate all H5P files from the Hub', () => {
         it(`${file}`, async () => {
             const config = new H5PConfig(null);
             config.contentWhitelist += ' html';
-            const validator = new PackageValidator(config);
             await expect(
-                validator.validateExtractedPackage(`${directory}/${file}`)
+                validatePackage(config, `${directory}/${file}`)
             ).resolves.toBeDefined();
         });
     }


### PR DESCRIPTION
To speed up the super slow validator for large files, the files of h5p packages are now extracted to temporary storage before validating them.

The validator now also skips already installed libraries (if major, minor and patch version are the same) as they aren't installed anyway.