### PR TITLE
fix: retrieve metadataSettings from library.json

### DIFF
--- a/packages/h5p-server/src/H5PEditor.ts
+++ b/packages/h5p-server/src/H5PEditor.ts
@@ -456,7 +456,7 @@ export default class H5PEditor {
                             }
                             return {
                                 majorVersion: loadedLibrary.majorVersion,
-                                metadataSettings: null,
+                                metadataSettings: loadedLibrary.metadataSettings || null,
                                 minorVersion: loadedLibrary.minorVersion,
                                 name: loadedLibrary.machineName,
                                 restricted: false,


### PR DESCRIPTION
cc @JPSchellenberg 

When H5P core creates the form for a content type, it will add a metadata button and an extra title field unless the content type specifies not to using the `metadataSettings` property in its _library.json_ file (or unless H5P core has some hardwired rule). That makes sense for H5P.Shape used in H5P.CoursePresentation, for instance - adding metadata/copyright information to a rectangle feels like overkill :-)

It seems that the node.js port already can handle the `metadataSettings` property, but it's always set to `null` and thus leads to metadata buttons and extra title fields popping up where they are not supposed to. Probably some forgotten update after initially creating the port.

When merged in, the value of the `metadataSettings` property from _library.son_ will be retrieved and used this fixing the aforementioned issue. I kept the `null` for when the `metadataSettings` property is not set in library.json. Should not be strictly necessary, but since it was set to `null` explicitly, I didn't want to potentially mess with callers that explicitly check the returned value for `null` instead of for a null-ish value.