### PR TITLE
fix(h5p-server): content type cache always shows most recent version

### DIFF
--- a/packages/h5p-server/src/LibraryManager.ts
+++ b/packages/h5p-server/src/LibraryManager.ts
@@ -478,7 +478,7 @@ export default class LibraryManager {
                     return installedLib;
                 })
             )
-        ).sort((lib1, lib2) => lib1.compare(lib2));
+        ).sort((lib1, lib2) => lib1.compareVersions(lib2));
 
         const returnObject = {};
         for (const library of libraries) {


### PR DESCRIPTION
There was a bug if the title of libraries was changed between version updates.
Closes #1558 .