### PR TITLE
fix(h5p-html-exporter): YouTube links now work in exported files

### DIFF
--- a/packages/h5p-html-exporter/src/loadFileOverrides.js
+++ b/packages/h5p-html-exporter/src/loadFileOverrides.js
@@ -26,8 +26,8 @@
     // that don't use H5P.ContentType.getLibraryFilePath.
     var nativeSetScriptAttribute = HTMLScriptElement.prototype.setAttribute;
     HTMLScriptElement.prototype.setAttribute = function (name, value) {
-        if (name === 'src') {
-            var match = value.match(/^.\/libraries\/([^?]+)\??.*$/)
+        if (name === 'src' && value instanceof String) {
+            var match = value.match(/^.\/libraries\/([^?]+)\??.*$/);
             if (match) {
                 const file = match[1];
                 if (furtherH5PInlineResources[file]) {
@@ -48,8 +48,8 @@
     // use H5P.ContentType.getLibraryFilePath.
     var nativeSetLinkAttribute = HTMLLinkElement.prototype.setAttribute;
     HTMLLinkElement.prototype.setAttribute = function (name, value) {
-        if (name === 'href') {
-            var match = value.match(/^.\/libraries\/([^?]+)\??.*$/)
+        if (name === 'href' && value instanceof String) {
+            var match = value.match(/^.\/libraries\/([^?]+)\??.*$/);
             if (match) {
                 const file = match[1];
                 if (furtherH5PInlineResources[file]) {

--- a/packages/h5p-html-exporter/src/loadFileOverrides.js
+++ b/packages/h5p-html-exporter/src/loadFileOverrides.js
@@ -26,7 +26,15 @@
     // that don't use H5P.ContentType.getLibraryFilePath.
     var nativeSetScriptAttribute = HTMLScriptElement.prototype.setAttribute;
     HTMLScriptElement.prototype.setAttribute = function (name, value) {
-        if (name === 'src' && value instanceof String) {
+        if (name === 'src') {
+            if (!(value instanceof String)) {
+                if (value.toString) {
+                    value = value.toString();
+                } else {
+                    nativeSetScriptAttribute.call(this, name, value);
+                    return;
+                }
+            }
             var match = value.match(/^.\/libraries\/([^?]+)\??.*$/);
             if (match) {
                 const file = match[1];
@@ -48,7 +56,15 @@
     // use H5P.ContentType.getLibraryFilePath.
     var nativeSetLinkAttribute = HTMLLinkElement.prototype.setAttribute;
     HTMLLinkElement.prototype.setAttribute = function (name, value) {
-        if (name === 'href' && value instanceof String) {
+        if (name === 'href') {
+            if (!(value instanceof String)) {
+                if (value.toString) {
+                    value = value.toString();
+                } else {
+                    nativeSetScriptAttribute.call(this, name, value);
+                    return;
+                }
+            }
             var match = value.match(/^.\/libraries\/([^?]+)\??.*$/);
             if (match) {
                 const file = match[1];


### PR DESCRIPTION
If users inserted YouTube links in videos and they were exported to a HTML package, H5P (or YouTube?) tries to assign some object to the 'src' property of a HTML script element. Our code that checks for library file references when src attributes are assigned, assumed the value would always be a string.