### PR TITLE
fix(h5p-webcomponents): editor waits for initialization before saving

### DIFF
--- a/packages/h5p-webcomponents/src/h5p-editor.ts
+++ b/packages/h5p-webcomponents/src/h5p-editor.ts
@@ -252,12 +252,14 @@ export class H5PEditorComponent extends HTMLElement {
         contentId: string;
         metadata: IContentMetadata;
     }> => {
-        this.initLock.acquireAsync();
+        // We don't want to allow saving until the editor is loaded, so we wait
+        // for the init lock.
+        await this.initLock.acquireAsync();
         try {
             if (this.editorInstance === undefined) {
                 this.dispatchAndThrowError(
                     'save-error',
-                    'editorInstance of h5p editor not defined.'
+                    'editorInstance of h5p editor not defined. Something went wrong during the initialization of the H5P editor.'
                 );
             }
             if (!this.saveContentCallback) {


### PR DESCRIPTION
This might fix https://github.com/Lumieducation/Lumi/issues/1786, but as I can't reproduce the error, I'm not certain. It still won't hurt to delay saving until the initialization has finished.