### PR TITLE
fix(h5p-server): dir temporary storage works with sub-directories

### DIFF
--- a/packages/h5p-server/src/implementation/fs/DirectoryTemporaryFileStorage.ts
+++ b/packages/h5p-server/src/implementation/fs/DirectoryTemporaryFileStorage.ts
@@ -127,12 +127,12 @@ export default class DirectoryTemporaryFileStorage
         return (
             await Promise.all(
                 users.map(async (u) => {
-                    const filesOfUser = await getAllFiles.async.array(
-                        this.getAbsoluteUserDirectoryPath(u)
-                    );
+                    const basePath = this.getAbsoluteUserDirectoryPath(u);
+                    const basePathLength = basePath.length + 1;
+                    const filesOfUser = await getAllFiles.async.array(basePath);
                     return Promise.all(
                         filesOfUser
-                            .map((f) => path.basename(f))
+                            .map((f) => f.substr(basePathLength))
                             .filter((f) => !f.endsWith('.metadata'))
                             .map((f) => this.getTemporaryFileInfo(f, u))
                     );

--- a/packages/h5p-server/test/TemporaryFileManager.test.ts
+++ b/packages/h5p-server/test/TemporaryFileManager.test.ts
@@ -99,8 +99,17 @@ describe('TemporaryFileManager', () => {
                         config
                     );
 
-                    // add file that will expire
-                    const expiringFilename = await tmpManager.addFile(
+                    // add files that will expire
+                    const expiringFilename1 = await tmpManager.addFile(
+                        'dir/expiring.json',
+                        fsExtra.createReadStream(
+                            path.resolve(
+                                'test/data/content-type-cache/real-content-types.json'
+                            )
+                        ),
+                        user
+                    );
+                    const expiringFilename2 = await tmpManager.addFile(
                         'expiring.json',
                         fsExtra.createReadStream(
                             path.resolve(
@@ -115,7 +124,7 @@ describe('TemporaryFileManager', () => {
 
                     // add second file that won't expire
                     const nonExpiringFilename = await tmpManager.addFile(
-                        'non-expiring.json',
+                        'dir/non-expiring.json',
                         fsExtra.createReadStream(
                             path.resolve(
                                 'test/data/content-type-cache/real-content-types.json'
@@ -134,7 +143,10 @@ describe('TemporaryFileManager', () => {
 
                     // check if only one file remains
                     await expect(
-                        tmpManager.getFileStream(expiringFilename, user)
+                        tmpManager.getFileStream(expiringFilename1, user)
+                    ).rejects.toThrow();
+                    await expect(
+                        tmpManager.getFileStream(expiringFilename2, user)
                     ).rejects.toThrow();
                     const stream = await tmpManager.getFileStream(
                         nonExpiringFilename,


### PR DESCRIPTION
Closes #1708 