### PR TITLE
chore(deps): update fs-extra to v10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15715,11 +15715,6 @@
                 "safer-buffer": "^2.0.2",
                 "tweetnacl": "~0.14.0"
             },
-            "bin": {
-                "sshpk-conv": "bin/sshpk-conv",
-                "sshpk-sign": "bin/sshpk-sign",
-                "sshpk-verify": "bin/sshpk-verify"
-            },
             "engines": {
                 "node": ">=0.10.0"
             }

--- a/packages/h5p-examples/package-lock.json
+++ b/packages/h5p-examples/package-lock.json
@@ -14,7 +14,7 @@
 				"cache-manager-redis-store": "2.0.0",
 				"express": "4.17.1",
 				"express-fileupload": "^1.2.1",
-				"fs-extra": "9.1.0",
+				"fs-extra": "10.0.0",
 				"i18next": "20.6.1",
 				"i18next-fs-backend": "1.1.1",
 				"i18next-http-middleware": "3.1.4",
@@ -251,14 +251,6 @@
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/async/-/async-3.2.0.tgz",
 			"integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw=="
-		},
-		"node_modules/at-least-node": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
-			"integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
-			"engines": {
-				"node": ">= 4.0.0"
-			}
 		},
 		"node_modules/axios": {
 			"version": "0.21.1",
@@ -828,17 +820,16 @@
 			"dev": true
 		},
 		"node_modules/fs-extra": {
-			"version": "9.1.0",
-			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-			"integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.0.tgz",
+			"integrity": "sha512-C5owb14u9eJwizKGdchcDUQeFtlSHHthBk8pbX9Vc1PFZrLombudjDnNns88aYslCyF6IY5SUw3Roz6xShcEIQ==",
 			"dependencies": {
-				"at-least-node": "^1.0.0",
 				"graceful-fs": "^4.2.0",
 				"jsonfile": "^6.0.1",
 				"universalify": "^2.0.0"
 			},
 			"engines": {
-				"node": ">=10"
+				"node": ">=12"
 			}
 		},
 		"node_modules/fs.realpath": {
@@ -2231,11 +2222,6 @@
 			"resolved": "https://registry.npmjs.org/async/-/async-3.2.0.tgz",
 			"integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw=="
 		},
-		"at-least-node": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
-			"integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg=="
-		},
 		"axios": {
 			"version": "0.21.1",
 			"resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
@@ -2668,11 +2654,10 @@
 			"dev": true
 		},
 		"fs-extra": {
-			"version": "9.1.0",
-			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-			"integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.0.tgz",
+			"integrity": "sha512-C5owb14u9eJwizKGdchcDUQeFtlSHHthBk8pbX9Vc1PFZrLombudjDnNns88aYslCyF6IY5SUw3Roz6xShcEIQ==",
 			"requires": {
-				"at-least-node": "^1.0.0",
 				"graceful-fs": "^4.2.0",
 				"jsonfile": "^6.0.1",
 				"universalify": "^2.0.0"

--- a/packages/h5p-examples/package.json
+++ b/packages/h5p-examples/package.json
@@ -28,7 +28,7 @@
         "cache-manager-redis-store": "2.0.0",
         "express": "4.17.1",
         "express-fileupload": "^1.2.1",
-        "fs-extra": "9.1.0",
+        "fs-extra": "10.0.0",
         "i18next": "20.6.1",
         "i18next-fs-backend": "1.1.1",
         "i18next-http-middleware": "3.1.4",

--- a/packages/h5p-examples/test/e2e/helpers/upload.ts
+++ b/packages/h5p-examples/test/e2e/helpers/upload.ts
@@ -10,8 +10,7 @@ declare module 'puppeteer' {
     }
 }
 
-// eslint-disable-next-line vars-on-top, no-var
-declare var window;
+declare const window;
 
 let serverHost;
 let browser: puppeteer.Browser;

--- a/packages/h5p-express/package-lock.json
+++ b/packages/h5p-express/package-lock.json
@@ -19,7 +19,7 @@
 				"axios-mock-adapter": "1.20.0",
 				"body-parser": "1.19.0",
 				"express-fileupload": "1.2.1",
-				"fs-extra": "9.1.0",
+				"fs-extra": "10.0.0",
 				"supertest": "6.1.6",
 				"tmp-promise": "3.0.2"
 			}
@@ -147,15 +147,6 @@
 			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
 			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
 			"dev": true
-		},
-		"node_modules/at-least-node": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
-			"integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
-			"dev": true,
-			"engines": {
-				"node": ">= 4.0.0"
-			}
 		},
 		"node_modules/axios": {
 			"version": "0.21.1",
@@ -520,18 +511,17 @@
 			}
 		},
 		"node_modules/fs-extra": {
-			"version": "9.1.0",
-			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-			"integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.0.tgz",
+			"integrity": "sha512-C5owb14u9eJwizKGdchcDUQeFtlSHHthBk8pbX9Vc1PFZrLombudjDnNns88aYslCyF6IY5SUw3Roz6xShcEIQ==",
 			"dev": true,
 			"dependencies": {
-				"at-least-node": "^1.0.0",
 				"graceful-fs": "^4.2.0",
 				"jsonfile": "^6.0.1",
 				"universalify": "^2.0.0"
 			},
 			"engines": {
-				"node": ">=10"
+				"node": ">=12"
 			}
 		},
 		"node_modules/fs.realpath": {
@@ -1348,12 +1338,6 @@
 			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
 			"dev": true
 		},
-		"at-least-node": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
-			"integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
-			"dev": true
-		},
 		"axios": {
 			"version": "0.21.1",
 			"resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
@@ -1640,12 +1624,11 @@
 			"integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
 		},
 		"fs-extra": {
-			"version": "9.1.0",
-			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-			"integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.0.tgz",
+			"integrity": "sha512-C5owb14u9eJwizKGdchcDUQeFtlSHHthBk8pbX9Vc1PFZrLombudjDnNns88aYslCyF6IY5SUw3Roz6xShcEIQ==",
 			"dev": true,
 			"requires": {
-				"at-least-node": "^1.0.0",
 				"graceful-fs": "^4.2.0",
 				"jsonfile": "^6.0.1",
 				"universalify": "^2.0.0"

--- a/packages/h5p-express/package.json
+++ b/packages/h5p-express/package.json
@@ -56,7 +56,7 @@
         "axios-mock-adapter": "1.20.0",
         "body-parser": "1.19.0",
         "express-fileupload": "1.2.1",
-        "fs-extra": "9.1.0",
+        "fs-extra": "10.0.0",
         "supertest": "6.1.6",
         "tmp-promise": "3.0.2"
     }

--- a/packages/h5p-html-exporter/package-lock.json
+++ b/packages/h5p-html-exporter/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "9.0.0",
 			"license": "GPL-3.0-or-later",
 			"dependencies": {
-				"fs-extra": "9.1.0",
+				"fs-extra": "10.0.0",
 				"mime-types": "^2.1.26",
 				"postcss": "^8.1.10",
 				"postcss-clean": "^1.1.0",
@@ -62,14 +62,6 @@
 			},
 			"engines": {
 				"node": ">=4"
-			}
-		},
-		"node_modules/at-least-node": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
-			"integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
-			"engines": {
-				"node": ">= 4.0.0"
 			}
 		},
 		"node_modules/balanced-match": {
@@ -297,17 +289,16 @@
 			"dev": true
 		},
 		"node_modules/fs-extra": {
-			"version": "9.1.0",
-			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-			"integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.0.tgz",
+			"integrity": "sha512-C5owb14u9eJwizKGdchcDUQeFtlSHHthBk8pbX9Vc1PFZrLombudjDnNns88aYslCyF6IY5SUw3Roz6xShcEIQ==",
 			"dependencies": {
-				"at-least-node": "^1.0.0",
 				"graceful-fs": "^4.2.0",
 				"jsonfile": "^6.0.1",
 				"universalify": "^2.0.0"
 			},
 			"engines": {
-				"node": ">=10"
+				"node": ">=12"
 			}
 		},
 		"node_modules/fs.realpath": {
@@ -1018,11 +1009,6 @@
 				"color-convert": "^1.9.0"
 			}
 		},
-		"at-least-node": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
-			"integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg=="
-		},
 		"balanced-match": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -1189,11 +1175,10 @@
 			"dev": true
 		},
 		"fs-extra": {
-			"version": "9.1.0",
-			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-			"integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.0.tgz",
+			"integrity": "sha512-C5owb14u9eJwizKGdchcDUQeFtlSHHthBk8pbX9Vc1PFZrLombudjDnNns88aYslCyF6IY5SUw3Roz6xShcEIQ==",
 			"requires": {
-				"at-least-node": "^1.0.0",
 				"graceful-fs": "^4.2.0",
 				"jsonfile": "^6.0.1",
 				"universalify": "^2.0.0"

--- a/packages/h5p-html-exporter/package.json
+++ b/packages/h5p-html-exporter/package.json
@@ -44,7 +44,7 @@
     ],
     "dependencies": {
         "@lumieducation/h5p-server": "^9.0.0",
-        "fs-extra": "9.1.0",
+        "fs-extra": "10.0.0",
         "mime-types": "^2.1.26",
         "postcss": "^8.1.10",
         "postcss-clean": "^1.1.0",

--- a/packages/h5p-mongos3/package-lock.json
+++ b/packages/h5p-mongos3/package-lock.json
@@ -17,7 +17,7 @@
 				"@types/fs-extra": "9.0.12",
 				"@types/mongodb": "3.6.20",
 				"@types/stream-buffers": "3.0.4",
-				"fs-extra": "9.1.0",
+				"fs-extra": "10.0.0",
 				"promisepipe": "3.0.0",
 				"stream-mock": "2.0.5"
 			}
@@ -63,15 +63,6 @@
 			"dev": true,
 			"dependencies": {
 				"@types/node": "*"
-			}
-		},
-		"node_modules/at-least-node": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
-			"integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
-			"dev": true,
-			"engines": {
-				"node": ">= 4.0.0"
 			}
 		},
 		"node_modules/aws-sdk": {
@@ -162,18 +153,17 @@
 			}
 		},
 		"node_modules/fs-extra": {
-			"version": "9.1.0",
-			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-			"integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.0.tgz",
+			"integrity": "sha512-C5owb14u9eJwizKGdchcDUQeFtlSHHthBk8pbX9Vc1PFZrLombudjDnNns88aYslCyF6IY5SUw3Roz6xShcEIQ==",
 			"dev": true,
 			"dependencies": {
-				"at-least-node": "^1.0.0",
 				"graceful-fs": "^4.2.0",
 				"jsonfile": "^6.0.1",
 				"universalify": "^2.0.0"
 			},
 			"engines": {
-				"node": ">=10"
+				"node": ">=12"
 			}
 		},
 		"node_modules/graceful-fs": {
@@ -493,12 +483,6 @@
 				"@types/node": "*"
 			}
 		},
-		"at-least-node": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
-			"integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
-			"dev": true
-		},
 		"aws-sdk": {
 			"version": "2.990.0",
 			"resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.990.0.tgz",
@@ -560,12 +544,11 @@
 			"integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
 		},
 		"fs-extra": {
-			"version": "9.1.0",
-			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-			"integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.0.tgz",
+			"integrity": "sha512-C5owb14u9eJwizKGdchcDUQeFtlSHHthBk8pbX9Vc1PFZrLombudjDnNns88aYslCyF6IY5SUw3Roz6xShcEIQ==",
 			"dev": true,
 			"requires": {
-				"at-least-node": "^1.0.0",
 				"graceful-fs": "^4.2.0",
 				"jsonfile": "^6.0.1",
 				"universalify": "^2.0.0"

--- a/packages/h5p-mongos3/package.json
+++ b/packages/h5p-mongos3/package.json
@@ -54,7 +54,7 @@
         "@types/fs-extra": "9.0.12",
         "@types/mongodb": "3.6.20",
         "@types/stream-buffers": "3.0.4",
-        "fs-extra": "9.1.0",
+        "fs-extra": "10.0.0",
         "promisepipe": "3.0.0",
         "stream-mock": "2.0.5"
     }

--- a/packages/h5p-rest-example-server/package-lock.json
+++ b/packages/h5p-rest-example-server/package-lock.json
@@ -14,7 +14,7 @@
 				"cache-manager-redis-store": "2.0.0",
 				"express": "4.17.1",
 				"express-fileupload": "1.2.1",
-				"fs-extra": "9.1.0",
+				"fs-extra": "10.0.0",
 				"i18next": "20.6.1",
 				"i18next-fs-backend": "1.1.1",
 				"i18next-http-middleware": "3.1.4",
@@ -232,14 +232,6 @@
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/async/-/async-3.2.0.tgz",
 			"integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw=="
-		},
-		"node_modules/at-least-node": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
-			"integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
-			"engines": {
-				"node": ">= 4.0.0"
-			}
 		},
 		"node_modules/balanced-match": {
 			"version": "1.0.2",
@@ -587,17 +579,16 @@
 			}
 		},
 		"node_modules/fs-extra": {
-			"version": "9.1.0",
-			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-			"integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.0.tgz",
+			"integrity": "sha512-C5owb14u9eJwizKGdchcDUQeFtlSHHthBk8pbX9Vc1PFZrLombudjDnNns88aYslCyF6IY5SUw3Roz6xShcEIQ==",
 			"dependencies": {
-				"at-least-node": "^1.0.0",
 				"graceful-fs": "^4.2.0",
 				"jsonfile": "^6.0.1",
 				"universalify": "^2.0.0"
 			},
 			"engines": {
-				"node": ">=10"
+				"node": ">=12"
 			}
 		},
 		"node_modules/fs.realpath": {
@@ -1669,11 +1660,6 @@
 			"resolved": "https://registry.npmjs.org/async/-/async-3.2.0.tgz",
 			"integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw=="
 		},
-		"at-least-node": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
-			"integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg=="
-		},
 		"balanced-match": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -1952,11 +1938,10 @@
 			"integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
 		},
 		"fs-extra": {
-			"version": "9.1.0",
-			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-			"integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.0.tgz",
+			"integrity": "sha512-C5owb14u9eJwizKGdchcDUQeFtlSHHthBk8pbX9Vc1PFZrLombudjDnNns88aYslCyF6IY5SUw3Roz6xShcEIQ==",
 			"requires": {
-				"at-least-node": "^1.0.0",
 				"graceful-fs": "^4.2.0",
 				"jsonfile": "^6.0.1",
 				"universalify": "^2.0.0"

--- a/packages/h5p-rest-example-server/package.json
+++ b/packages/h5p-rest-example-server/package.json
@@ -22,7 +22,7 @@
         "cache-manager-redis-store": "2.0.0",
         "express": "4.17.1",
         "express-fileupload": "1.2.1",
-        "fs-extra": "9.1.0",
+        "fs-extra": "10.0.0",
         "i18next": "20.6.1",
         "i18next-fs-backend": "1.1.1",
         "i18next-http-middleware": "3.1.4",

--- a/packages/h5p-server/package-lock.json
+++ b/packages/h5p-server/package-lock.json
@@ -16,7 +16,7 @@
 				"crc": "^3.8.0",
 				"debug": "^4.1.1",
 				"flat": "^5.0.2",
-				"fs-extra": "^9.0.0",
+				"fs-extra": "^10.0.0",
 				"get-all-files": "^3.0.0",
 				"https-proxy-agent": "^5.0.0",
 				"image-size": "^1.0.0",
@@ -345,14 +345,6 @@
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/async/-/async-3.2.0.tgz",
 			"integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw=="
-		},
-		"node_modules/at-least-node": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
-			"integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
-			"engines": {
-				"node": ">= 4.0.0"
-			}
 		},
 		"node_modules/axios": {
 			"version": "0.21.1",
@@ -755,17 +747,16 @@
 			}
 		},
 		"node_modules/fs-extra": {
-			"version": "9.1.0",
-			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-			"integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.0.tgz",
+			"integrity": "sha512-C5owb14u9eJwizKGdchcDUQeFtlSHHthBk8pbX9Vc1PFZrLombudjDnNns88aYslCyF6IY5SUw3Roz6xShcEIQ==",
 			"dependencies": {
-				"at-least-node": "^1.0.0",
 				"graceful-fs": "^4.2.0",
 				"jsonfile": "^6.0.1",
 				"universalify": "^2.0.0"
 			},
 			"engines": {
-				"node": ">=10"
+				"node": ">=12"
 			}
 		},
 		"node_modules/fs.realpath": {
@@ -1824,11 +1815,6 @@
 			"resolved": "https://registry.npmjs.org/async/-/async-3.2.0.tgz",
 			"integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw=="
 		},
-		"at-least-node": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
-			"integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg=="
-		},
 		"axios": {
 			"version": "0.21.1",
 			"resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
@@ -2096,11 +2082,10 @@
 			"integrity": "sha512-yLR6WaE2lbF0x4K2qE2p9PEXKLDjUjnR/xmjS3wHAYxtlsI9MLLBJUZirAHKzUZDGLxje7w/cXR49WOUo4rbsA=="
 		},
 		"fs-extra": {
-			"version": "9.1.0",
-			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-			"integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.0.tgz",
+			"integrity": "sha512-C5owb14u9eJwizKGdchcDUQeFtlSHHthBk8pbX9Vc1PFZrLombudjDnNns88aYslCyF6IY5SUw3Roz6xShcEIQ==",
 			"requires": {
-				"at-least-node": "^1.0.0",
 				"graceful-fs": "^4.2.0",
 				"jsonfile": "^6.0.1",
 				"universalify": "^2.0.0"

--- a/packages/h5p-server/package.json
+++ b/packages/h5p-server/package.json
@@ -52,7 +52,7 @@
         "crc": "^3.8.0",
         "debug": "^4.1.1",
         "flat": "^5.0.2",
-        "fs-extra": "^9.0.0",
+        "fs-extra": "^10.0.0",
         "get-all-files": "^3.0.0",
         "https-proxy-agent": "^5.0.0",
         "image-size": "^1.0.0",

--- a/packages/h5p-server/src/helpers/Logger.ts
+++ b/packages/h5p-server/src/helpers/Logger.ts
@@ -1,11 +1,10 @@
-import debug from 'debug';
+import debugModule from 'debug';
 
 enum LogLevelNumber {
     error,
     warn,
     info,
     verbose,
-    // eslint-disable-next-line @typescript-eslint/no-shadow
     debug,
     silly
 }
@@ -22,9 +21,8 @@ export default class Logger {
     constructor(scope: string) {
         this.scope = scope;
 
-        const d = debug(`h5p:${this.scope}`);
+        const d = debugModule(`h5p:${this.scope}`);
 
-        // eslint-disable-next-line no-multi-assign
         this.DEBUG = d;
         this.ERROR = d;
         this.INFO = d;

--- a/packages/h5p-server/test/H5PEditor.getLibraryData.test.ts
+++ b/packages/h5p-server/test/H5PEditor.getLibraryData.test.ts
@@ -14,7 +14,9 @@ describe('aggregating data from library folders for the editor', () => {
             null,
             null
         );
-        const libraryManager = new LibraryManager(new FileLibraryStorage(''));
+        const libraryManager = new LibraryManager(
+            new FileLibraryStorage(`${__dirname}/../../../test/data/libraries`)
+        );
 
         Object.assign(libraryManager, {
             listAddons: () => Promise.resolve([]),
@@ -57,7 +59,9 @@ describe('aggregating data from library folders for the editor', () => {
             null,
             null
         );
-        const libraryManager = new LibraryManager(new FileLibraryStorage(''));
+        const libraryManager = new LibraryManager(
+            new FileLibraryStorage(`${__dirname}/../../../test/data/libraries`)
+        );
 
         Object.assign(libraryManager, {
             listAddons: () => Promise.resolve([]),
@@ -91,13 +95,15 @@ describe('aggregating data from library folders for the editor', () => {
 
     it('includes assets of preloaded and editor dependencies', () => {
         const h5pEditor = new H5PEditor(
-            null, // eslint-disable-next-line prefer-object-spread
-            Object.assign({}, new H5PConfig(null), { baseUrl: '/h5p' }),
+            null,
+            new H5PConfig(null, { baseUrl: '/h5p' }),
             null,
             null,
             null
         );
-        const libraryManager = new LibraryManager(new FileLibraryStorage(''));
+        const libraryManager = new LibraryManager(
+            new FileLibraryStorage(`${__dirname}/../../../test/data/libraries`)
+        );
 
         Object.assign(libraryManager, {
             listAddons: () => Promise.resolve([]),
@@ -185,13 +191,14 @@ describe('aggregating data from library folders for the editor', () => {
     it('includes dependencies of dependencies in the javascript field', () => {
         const h5pEditor = new H5PEditor(
             null,
-            // eslint-disable-next-line prefer-object-spread
-            Object.assign({}, new H5PConfig(null), { baseUrl: '/h5p' }),
+            new H5PConfig(null, { baseUrl: '/h5p' }),
             null,
             null,
             null
         );
-        const libraryManager = new LibraryManager(new FileLibraryStorage(''));
+        const libraryManager = new LibraryManager(
+            new FileLibraryStorage(`${__dirname}/../../../test/data/libraries`)
+        );
 
         Object.assign(libraryManager, {
             listAddons: () => Promise.resolve([]),
@@ -294,7 +301,9 @@ describe('aggregating data from library folders for the editor', () => {
             null,
             null
         );
-        const libraryManager = new LibraryManager(new FileLibraryStorage(''));
+        const libraryManager = new LibraryManager(
+            new FileLibraryStorage(`${__dirname}/../../../test/data/libraries`)
+        );
 
         Object.assign(libraryManager, {
             listAddons: () => Promise.resolve([]),
@@ -367,13 +376,14 @@ describe('aggregating data from library folders for the editor', () => {
 
         const h5pEditor = new H5PEditor(
             null,
-            // eslint-disable-next-line prefer-object-spread
-            Object.assign({}, new H5PConfig(null), { baseUrl: '/h5p' }),
+            new H5PConfig(null, { baseUrl: '/h5p' }),
             null,
             null,
             null
         );
-        const libraryManager = new LibraryManager(new FileLibraryStorage(''));
+        const libraryManager = new LibraryManager(
+            new FileLibraryStorage(`${__dirname}/../../../test/data/libraries`)
+        );
 
         Object.assign(libraryManager, {
             listAddons: () => Promise.resolve([]),
@@ -440,13 +450,14 @@ describe('aggregating data from library folders for the editor', () => {
     it('lists dependencies in correct order', () => {
         const h5pEditor = new H5PEditor(
             null,
-            // eslint-disable-next-line prefer-object-spread
-            Object.assign({}, new H5PConfig(null), { baseUrl: '/h5p' }),
+            new H5PConfig(null, { baseUrl: '/h5p' }),
             null,
             null,
             null
         );
-        const libraryManager = new LibraryManager(new FileLibraryStorage(''));
+        const libraryManager = new LibraryManager(
+            new FileLibraryStorage(`${__dirname}/../../../test/data/libraries`)
+        );
 
         Object.assign(libraryManager, {
             listAddons: () => Promise.resolve([]),


### PR DESCRIPTION
We might have a memory leak / open handles, as the html exporter tests don't finish properly now.