### PR TITLE
Allow '@' character in the file name.

### DIFF
--- a/packages/h5p-mongos3/src/S3Utils.ts
+++ b/packages/h5p-mongos3/src/S3Utils.ts
@@ -32,7 +32,7 @@ export function validateFilename(
     // expect for ranges of non-printable ASCII characters:
     // &$@=;:+ ,?\\{^}%`]'">[~<#
 
-    if ((invalidCharactersRegExp ?? /[^A-Za-z0-9\-._!()/]/g).test(filename)) {
+    if ((invalidCharactersRegExp ?? /[^A-Za-z0-9\-._!()@/]/g).test(filename)) {
         log.error(`Found illegal character in filename: ${filename}`);
         throw new H5pError('illegal-filename', { filename }, 400);
     }
@@ -56,7 +56,7 @@ export function sanitizeFilename(
 ): string {
     return generalizedSanitizeFilename(
         filename,
-        invalidCharactersRegExp ?? /[^A-Za-z0-9\-._!()/]/g,
+        invalidCharactersRegExp ?? /[^A-Za-z0-9\-._!()@/]/g,
         maxFileLength
     );
 }


### PR DESCRIPTION
Added '@' character to the allowed list of filename characters.

US-ASCII characters are allowed for S3 bucket. Character '@' is a part of US-ASCII.

Reference: http://www.columbia.edu/kermit/ascii.html

H5P content indeed contains filenames with '@' characters. 

For example the file at:
[https://github.com/h5p/timelinejs/blob/stable/css/fancybox_sprite%402x.png](https://github.com/h5p/timelinejs/blob/stable/css/fancybox_sprite%402x.png)