### PR TITLE
feat(html-exporter)!: html exporter can display rights & licenses and embed code

### DIFF
--- a/packages/h5p-examples/src/express.ts
+++ b/packages/h5p-examples/src/express.ts
@@ -208,7 +208,11 @@ const start = async (): Promise<void> => {
     server.get('/h5p/html/:contentId', async (req, res) => {
         const html = await htmlExporter.createSingleBundle(
             req.params.contentId,
-            (req as any).user
+            (req as any).user,
+            {
+                language: req.language ?? 'en',
+                showLicenseButton: true
+            }
         );
         res.setHeader(
             'Content-disposition',

--- a/packages/h5p-html-exporter/src/HtmlExporter.ts
+++ b/packages/h5p-html-exporter/src/HtmlExporter.ts
@@ -19,7 +19,8 @@ import {
     ContentFileScanner,
     LibraryManager,
     streamToString,
-    IIntegration
+    IIntegration,
+    ITranslationFunction
 } from '@lumieducation/h5p-server';
 import upath from 'upath';
 
@@ -95,12 +96,16 @@ export default class HtmlExporter {
         protected config: IH5PConfig,
         protected coreFilePath: string,
         protected editorFilePath: string,
-        protected template?: IExporterTemplate
+        protected template?: IExporterTemplate,
+        translationFunction?: ITranslationFunction
     ) {
         this.player = new H5PPlayer(
             this.libraryStorage,
             this.contentStorage,
-            this.config
+            this.config,
+            undefined,
+            undefined,
+            translationFunction
         );
         this.coreSuffix = `${this.config.baseUrl + this.config.coreUrl}/`;
         this.editorSuffix = `${

--- a/packages/h5p-html-exporter/src/framedTemplate.ts
+++ b/packages/h5p-html-exporter/src/framedTemplate.ts
@@ -1,0 +1,35 @@
+import { IIntegration } from '@lumieducation/h5p-server';
+
+export default (
+    integration: IIntegration,
+    scriptsBundle: string,
+    stylesBundle: string,
+    contentId: string
+): string => `
+<!doctype html>
+    <html class="h5p-iframe">
+    <head>
+        <meta charset="utf-8">                    
+        <script>H5PIntegration = ${JSON.stringify({
+            ...integration,
+            baseUrl: '.',
+            url: '.',
+            ajax: { setFinished: '', contentUserData: '' },
+            saveFreq: false,
+            libraryUrl: ''
+        })};
+
+        if (new URLSearchParams(window.location.search).get('embed') == 'true') {
+            H5PIntegration.contents['cid-' + '${contentId}'].displayOptions.embed = false;
+        } else {
+            H5PIntegration.contents['cid-' + '${contentId}'].embedCode = '<iframe src=\"' + window.location.protocol + "//" + window.location.host + window.location.pathname + '?embed=true' + '\" width=\":w\" height=\":h\" frameborder=\"0\" allowfullscreen=\"allowfullscreen\"></iframe>';
+            H5PIntegration.contents['cid-' + '${contentId}'].resizeCode = '';
+        }
+            
+        ${scriptsBundle}</script>
+        <style>${stylesBundle}</style>
+    </head>
+    <body>
+        <div class="h5p-content lag" data-content-id="${contentId}"></div>                
+    </body>
+</html>`;

--- a/packages/h5p-html-exporter/src/minimalTemplate.ts
+++ b/packages/h5p-html-exporter/src/minimalTemplate.ts
@@ -1,0 +1,28 @@
+import { IIntegration } from '@lumieducation/h5p-server';
+
+export default (
+    integration: IIntegration,
+    scriptsBundle: string,
+    stylesBundle: string,
+    contentId: string
+): string =>
+    `
+<!doctype html>
+<html class="h5p-iframe">
+    <head>
+        <meta charset="utf-8">                    
+        <script>H5PIntegration = ${JSON.stringify({
+            ...integration,
+            baseUrl: '.',
+            url: '.',
+            ajax: { setFinished: '', contentUserData: '' },
+            saveFreq: false,
+            libraryUrl: ''
+        })};
+        ${scriptsBundle}</script>
+        <style>${stylesBundle}</style>
+    </head>
+    <body>
+        <div class="h5p-content lag" data-content-id="${contentId}"></div>                
+    </body>
+</html>`;

--- a/packages/h5p-html-exporter/test/HtmlExporter.test.ts
+++ b/packages/h5p-html-exporter/test/HtmlExporter.test.ts
@@ -11,9 +11,10 @@ import FileLibraryStorage from '../../h5p-server/src/implementation/fs/FileLibra
 import H5PConfig from '../../h5p-server/src/implementation/H5PConfig';
 import LibraryManager from '../../h5p-server/src/LibraryManager';
 import PackageImporter from '../../h5p-server/src/PackageImporter';
+import HtmlExporter from '../src/HtmlExporter';
+import { IIntegration } from '../../h5p-server/src/types';
 
 import User from './User';
-import HtmlExporter from '../src/HtmlExporter';
 
 let browser: puppeteer.Browser;
 let page: puppeteer.Page;
@@ -252,7 +253,7 @@ describe('HtmlExporter template', () => {
             path.resolve(`${__dirname}/../../h5p-examples/h5p/core`),
             path.resolve(`${__dirname}/../../h5p-examples/h5p/editor`),
             (
-                integration: string,
+                integration: IIntegration,
                 scriptsBundle: string,
                 stylesBundle: string,
                 contentId2: string

--- a/packages/h5p-server/src/H5PPlayer.ts
+++ b/packages/h5p-server/src/H5PPlayer.ts
@@ -133,7 +133,7 @@ export default class H5PPlayer {
             showLicenseButton?: boolean;
         }
     ): Promise<string | any> {
-        log.info(`rendering page for ${contentId}`);
+        log.debug(`rendering page for ${contentId} in language ${language}`);
 
         let parameters: ContentParameters;
         if (!options?.parametersOverride) {

--- a/packages/h5p-server/src/SemanticsLocalizer.ts
+++ b/packages/h5p-server/src/SemanticsLocalizer.ts
@@ -30,6 +30,7 @@ export default class SemanticsLocalizer {
         language: string,
         localizeAllFields?: boolean
     ): any {
+        log.debug(`Localizing semantics into ${language}`);
         return this.walkSemanticsRecursive(
             semantics,
             language,


### PR DESCRIPTION
The HTML exporter can now display license information ("rights of use") and an embed code, if the user wishes. 

BREAKING CHANGES:
The template passed into the HTML exporter has a new signature. The integration object is now an IIntegration object instead of a string. You can use JSON.stringify(integration) to get the old string object.