### PR TITLE
fix(h5p-mongos3): s3 lifecycle helper not taking effect

### DIFF
--- a/packages/h5p-mongos3/src/S3TemporaryFileStorage.ts
+++ b/packages/h5p-mongos3/src/S3TemporaryFileStorage.ts
@@ -445,7 +445,7 @@ export default class S3TemporaryFileStorage implements ITemporaryFileStorage {
                         LifecycleConfiguration: {
                             Rules: [
                                 {
-                                    Filter: { Prefix: '/' },
+                                    Filter: { Prefix: '' },
                                     Status: 'Enabled',
                                     Expiration: {
                                         Days: roundToNearestDay(


### PR DESCRIPTION
It turns out [the '/' prefix](https://github.com/Lumieducation/H5P-Nodejs-library/blob/85c7b0ba8985f315c99f6efdb76dbb74709b19e6/packages/h5p-mongos3/src/S3TemporaryFileStorage.ts#L448) for the lifecycle filter results in zero object matches, so objects are never deleted.

AWS [docs excerpt](https://docs.aws.amazon.com/AmazonS3/latest/userguide/lifecycle-configuration-examples.html#lifecycle-config-ex1):

> If you want the S3 Lifecycle rule to apply to all objects in the bucket, specify an empty prefix.

Before this change (in the test), the Expiration property of the object metadata was undefined. But now it's populated e.g. 
```
expiry-date="Thu, 10 Mar 2022 00:00:00 GMT", rule-id=""
```

I added `correctClockSkew: true` to `inits3` because without it, the following error is thrown on my machine:
```
RequestTimeTooSkewed: The difference between the request time and the server's time is too large.
```

Fixes #2126 