### PR TITLE
2688 contentFilesUrlPlayerOverride does not load from H5PConfig

### DIFF
--- a/packages/h5p-server/src/implementation/H5PConfig.ts
+++ b/packages/h5p-server/src/implementation/H5PConfig.ts
@@ -116,6 +116,7 @@ export default class H5PConfig implements IH5PConfig {
      */
     public async load(): Promise<H5PConfig> {
         await this.loadSettingFromStorage('baseUrl');
+        await this.loadSettingFromStorage('contentFilesUrlPlayerOverride');
         await this.loadSettingFromStorage('contentHubEnabled');
         await this.loadSettingFromStorage('contentHubMetadataRefreshInterval');
         await this.loadSettingFromStorage('contentTypeCacheRefreshInterval');
@@ -146,6 +147,7 @@ export default class H5PConfig implements IH5PConfig {
      * Saves all changeable settings to storage. (Should be called when a setting was changed.)
      */
     public async save(): Promise<void> {
+        await this.saveSettingToStorage('contentFilesUrlPlayerOverride');
         await this.saveSettingToStorage('contentHubEnabled');
         await this.saveSettingToStorage('contentHubMetadataRefreshInterval');
         await this.saveSettingToStorage('contentTypeCacheRefreshInterval');


### PR DESCRIPTION
Hey,

the `contentFilesUrlPlayerOverride` option is not loaded from a config file. The option is missing in the `load()` and `save()` methods of the H5PConfig. This feature is needed to enable the content delivery directly from the object-storage:
https://docs.lumi.education/npm-packages/h5p-mongos3/mongo-s3-content-storage#increasing-scalability-by-getting-content-files-directly-from-s3


https://lumi-education.canny.io/bug-report/p/images-and-audio-clips-not-working

I added these and it works on the test-server, but I haven't found tests for H5PConfig. Are these missing or did I just not see them?