### PR TITLE
fix(h5p-server): fix the package exporter so it also exports addOns

### DIFF
--- a/packages/h5p-server/src/PackageExporter.ts
+++ b/packages/h5p-server/src/PackageExporter.ts
@@ -10,7 +10,8 @@ import {
     IContentMetadata,
     IUser,
     ContentPermission,
-    IPermissionSystem
+    IPermissionSystem,
+    ILibraryMetadata
 } from './types';
 import { ContentFileScanner } from './ContentFileScanner';
 import Logger from './helpers/Logger';
@@ -175,12 +176,22 @@ export default class PackageExporter {
             const dependencyGetter = new DependencyGetter(
                 this.libraryManager.libraryStorage
             );
-            const dependencies = await dependencyGetter.getDependentLibraries(
+            let dependencies = await dependencyGetter.getDependentLibraries(
                 metadata.preloadedDependencies
                     .concat(metadata.editorDependencies || [])
                     .concat(metadata.dynamicDependencies || []),
                 { editor: true, preloaded: true }
             );
+
+            if (this.libraryManager.libraryStorage?.listAddons) {
+                const addOns =
+                    await this.libraryManager.libraryStorage.listAddons();
+                const addOnNames = addOns.map((addOn) =>
+                    LibraryName.fromUberName(addOn.machineName)
+                );
+                dependencies = [...dependencies, ...addOnNames];
+            }
+
             for (const dependency of dependencies) {
                 const files = await this.libraryManager.listFiles(dependency);
                 for (const file of files) {
@@ -192,6 +203,30 @@ export default class PackageExporter {
                         `${LibraryName.toUberName(dependency)}/${file}`
                     );
                 }
+            }
+        }
+    }
+
+    /**
+     * Adds the editor addons to the zip
+     * to be playable.
+     */
+    private async addAddonsFiles(
+        metadata: IContentMetadata,
+        outputZipFile: yazl.ZipFile
+    ): Promise<void> {
+        let dependencies: ILibraryMetadata[] = [];
+        const libraryStorage = this.libraryManager.libraryStorage;
+        if (libraryStorage?.listAddons) {
+            dependencies = await libraryStorage.listAddons();
+        }
+        for (const dependency of dependencies) {
+            const files = await this.libraryManager.listFiles(dependency);
+            for (const file of files) {
+                outputZipFile.addReadStream(
+                    await this.libraryManager.getFileStream(dependency, file),
+                    `${LibraryName.toUberName(dependency)}/${file}`
+                );
             }
         }
     }

--- a/packages/h5p-server/src/PackageExporter.ts
+++ b/packages/h5p-server/src/PackageExporter.ts
@@ -10,8 +10,7 @@ import {
     IContentMetadata,
     IUser,
     ContentPermission,
-    IPermissionSystem,
-    ILibraryMetadata
+    IPermissionSystem
 } from './types';
 import { ContentFileScanner } from './ContentFileScanner';
 import Logger from './helpers/Logger';
@@ -186,10 +185,7 @@ export default class PackageExporter {
             if (this.libraryManager.libraryStorage?.listAddons) {
                 const addOns =
                     await this.libraryManager.libraryStorage.listAddons();
-                const addOnNames = addOns.map((addOn) =>
-                    LibraryName.fromUberName(addOn.machineName)
-                );
-                dependencies = [...dependencies, ...addOnNames];
+                dependencies = [...dependencies, ...addOns];
             }
 
             for (const dependency of dependencies) {
@@ -203,30 +199,6 @@ export default class PackageExporter {
                         `${LibraryName.toUberName(dependency)}/${file}`
                     );
                 }
-            }
-        }
-    }
-
-    /**
-     * Adds the editor addons to the zip
-     * to be playable.
-     */
-    private async addAddonsFiles(
-        metadata: IContentMetadata,
-        outputZipFile: yazl.ZipFile
-    ): Promise<void> {
-        let dependencies: ILibraryMetadata[] = [];
-        const libraryStorage = this.libraryManager.libraryStorage;
-        if (libraryStorage?.listAddons) {
-            dependencies = await libraryStorage.listAddons();
-        }
-        for (const dependency of dependencies) {
-            const files = await this.libraryManager.listFiles(dependency);
-            for (const file of files) {
-                outputZipFile.addReadStream(
-                    await this.libraryManager.getFileStream(dependency, file),
-                    `${LibraryName.toUberName(dependency)}/${file}`
-                );
             }
         }
     }

--- a/packages/h5p-server/test/PackageExporter.test.ts
+++ b/packages/h5p-server/test/PackageExporter.test.ts
@@ -1,4 +1,5 @@
 import * as path from 'path';
+import { Readable } from 'stream';
 import { withDir, withFile } from 'tmp-promise';
 import yauzl from 'yauzl-promise';
 import { mkdir } from 'fs/promises';
@@ -117,6 +118,106 @@ describe('PackageExporter', () => {
                 'packages/h5p-server/test/data/PackageExporter/long_content_file_name.h5p'
             ),
             50
+        );
+    });
+
+    it('includes installed addons in the exported package', async () => {
+        await withDir(
+            async ({ path: tmpDirPath }) => {
+                const contentDir = path.join(tmpDirPath, 'content');
+                const libraryDir = path.join(tmpDirPath, 'libraries');
+                await mkdir(contentDir, { recursive: true });
+                await mkdir(libraryDir, { recursive: true });
+
+                const user = new User();
+
+                const contentStorage = new FileContentStorage(contentDir);
+                const contentManager = new ContentManager(
+                    contentStorage,
+                    new LaissezFairePermissionSystem()
+                );
+                const libraryStorage = new FileLibraryStorage(libraryDir);
+                const libraryManager = new LibraryManager(libraryStorage);
+                const config = new H5PConfig(null);
+
+                const packageImporter = new PackageImporter(
+                    libraryManager,
+                    config,
+                    new LaissezFairePermissionSystem(),
+                    contentManager,
+                    new ContentStorer(contentManager, libraryManager, undefined)
+                );
+
+                const contentId = (
+                    await packageImporter.addPackageLibrariesAndContent(
+                        path.resolve('test/data/validator/valid2.h5p'),
+                        user
+                    )
+                ).id;
+
+                // Install an addon library that is not a dependency of the
+                // content but should still be included in the export.
+                const addonLibrary = await libraryStorage.addLibrary(
+                    {
+                        machineName: 'H5P.TestAddon',
+                        majorVersion: 1,
+                        minorVersion: 0,
+                        patchVersion: 0,
+                        runnable: 0,
+                        title: 'Test addon',
+                        addTo: {
+                            player: {
+                                machineNames: ['*']
+                            }
+                        }
+                    } as any,
+                    false
+                );
+                const addonFileContent = 'console.log("addon");';
+                const addonFileStream = new Readable();
+                // eslint-disable-next-line no-underscore-dangle
+                addonFileStream._read = () => {};
+                addonFileStream.push(addonFileContent);
+                addonFileStream.push(null);
+                await libraryStorage.addFile(
+                    addonLibrary,
+                    'addon.js',
+                    addonFileStream
+                );
+
+                const packageExporter = new PackageExporter(
+                    libraryManager,
+                    contentStorage,
+                    { exportMaxContentPathLength: 255 }
+                );
+
+                await withFile(
+                    async (fileResult) => {
+                        const writeStream = createWriteStream(fileResult.path);
+                        await packageExporter.createPackage(
+                            contentId,
+                            writeStream,
+                            user
+                        );
+                        await new Promise<void>((resolve) => {
+                            writeStream.on('close', async () => {
+                                const zipFile = await yauzl.open(
+                                    fileResult.path
+                                );
+                                const entries = (
+                                    await zipFile.readEntries()
+                                ).map((e) => e.filename);
+                                expect(entries).toContain(
+                                    'H5P.TestAddon-1.0/addon.js'
+                                );
+                                resolve();
+                            });
+                        });
+                    },
+                    { postfix: '.h5p', keep: false }
+                );
+            },
+            { keep: false, unsafeCleanup: true }
         );
     });
 });


### PR DESCRIPTION
When exporting a content, the current implementation do not include the library storage's addOns.
In our case, this prevented content that required mathJax to be exported properly.

This PR (probably) fixes this.

cc @sr258 
cc @JPSchellenberg 