### PR TITLE
fix(h5p-express): destroy s3-streams when http connections closes

### DIFF
--- a/packages/h5p-express/src/H5PAjaxRouter/H5PAjaxExpressController.ts
+++ b/packages/h5p-express/src/H5PAjaxRouter/H5PAjaxExpressController.ts
@@ -221,6 +221,7 @@ export default class H5PAjaxExpressController {
         readStream.on('error', (err) => {
             response.status(404).end();
         });
+        response.on('close', () => readStream.destroy());
         readStream.pipe(response);
     };
 
@@ -250,6 +251,7 @@ export default class H5PAjaxExpressController {
         readStream.on('error', (err) => {
             response.status(404).end();
         });
+        response.on('close', () => readStream.destroy());
         readStream.pipe(response);
     };
 }


### PR DESCRIPTION
Problem
When a client disconnects mid-transfer (navigation, page reload, timeout), the Express response closes but the upstream Readable (e.g. an S3 object stream) was left open. The stream would continue consuming data and hold its socket until the transfer completed or timed out naturally.

Under concurrent load this causes socket pool exhaustion in the AWS SDK (@smithy/node-http-handler), manifesting as:


socket usage at capacity=50 and 1098 additional requests are enqueued.
New requests queue indefinitely until they time out, effectively taking down file serving.

Fix
In H5PAjaxExpressController, both pipeStreamToResponse and pipeStreamToPartialResponse now register a close listener on the Express response that destroys the read stream immediately when the client disconnects:


response.on('close', () => readStream.destroy());
This ensures the underlying socket is released back to the pool on disconnect rather than being held until the full S3 object has been transferred. All content file, temporary file, and library file endpoints are covered since they all route through these two private methods.