### PR TITLE
feat: update H5P core from 1.27 to 1.28

### DIFF
--- a/packages/h5p-rest-example-server/package.json
+++ b/packages/h5p-rest-example-server/package.json
@@ -7,7 +7,7 @@
     "scripts": {
         "build": "npx tsc -P ./tsconfig.build.json",
         "clean": "rm -rf h5p && rm -rf build && rm -rf coverage && rm -rf node_modules",
-        "prepare": "sh download-core.sh 829524eaf81fe3f3a295d0e843812be4735f51fc 80b3b281ee9d064b563f242e8ee7a0026b5bf205",
+        "prepare": "sh download-core.sh 2aeb0b83fa603e331381b3a6b8bf42c3773ba140 ab2daa18bd61b19e7f8729e22eec88f3b637a868",
         "start:watch": "npx ts-node-dev --deps --respawn src/index.ts",
         "start": "npx ts-node -P ./tsconfig.build.json src/index.ts",
         "start:shared-state:watch": "npx ts-node-dev --deps --respawn src/indexSharedState.ts",

--- a/packages/h5p-server/src/editorAssetList.json
+++ b/packages/h5p-server/src/editorAssetList.json
@@ -59,10 +59,14 @@
     },
     "styles": {
         "core": [
+            "styles/h5p-fonts.css",
             "styles/h5p.css",
             "styles/h5p-confirmation-dialog.css",
-            "styles/h5p-core-button.css",
-            "styles/h5p-fonts.css"
+            "styles/h5p-core-button.css",            
+            "styles/h5p-theme.css",
+            "styles/h5p-theme-variables.css",
+            "styles/h5p-tooltip.css",
+            "styles/h5p-table.css"
         ],
         "editor": [
             "libs/cropper.css",

--- a/packages/h5p-server/src/editorAssetList.json
+++ b/packages/h5p-server/src/editorAssetList.json
@@ -61,7 +61,8 @@
         "core": [
             "styles/h5p.css",
             "styles/h5p-confirmation-dialog.css",
-            "styles/h5p-core-button.css"
+            "styles/h5p-core-button.css",
+            "styles/h5p-fonts.css"
         ],
         "editor": [
             "libs/cropper.css",

--- a/packages/h5p-server/src/implementation/H5PConfig.ts
+++ b/packages/h5p-server/src/implementation/H5PConfig.ts
@@ -34,7 +34,7 @@ export default class H5PConfig implements IH5PConfig {
         'json png jpg jpeg gif bmp tif tiff webm mp4 ogg mp3 m4a wav vtt webvtt gltf glb txt';
     public coreApiVersion: { major: number; minor: number } = {
         major: 1,
-        minor: 27
+        minor: 28
     };
     public coreUrl: string = '/core';
     public customization: {
@@ -69,7 +69,7 @@ export default class H5PConfig implements IH5PConfig {
     public enableLrsContentTypes: boolean = true;
     public exportMaxContentPathLength: number = 255;
     public fetchingDisabled: 0 | 1 = 0;
-    public h5pVersion: string = '1.27.0';
+    public h5pVersion: string = '1.28.0';
     public hubContentTypesEndpoint: string =
         'https://hub-api.h5p.org/v1/content-types/';
     public hubRegistrationEndpoint: string = 'https://hub-api.h5p.org/v1/sites';

--- a/packages/h5p-server/src/playerAssetList.json
+++ b/packages/h5p-server/src/playerAssetList.json
@@ -15,12 +15,14 @@
     },
     "styles": {
         "core": [
+            "styles/h5p-fonts.css",
             "styles/h5p.css",
             "styles/h5p-confirmation-dialog.css",
             "styles/h5p-core-button.css",
+            "styles/h5p-theme.css",
+            "styles/h5p-theme-variables.css",
             "styles/h5p-tooltip.css",
-            "styles/h5p-table.css",
-            "styles/h5p-fonts.css"
+            "styles/h5p-table.css"
         ]
     }
 }

--- a/packages/h5p-server/src/playerAssetList.json
+++ b/packages/h5p-server/src/playerAssetList.json
@@ -19,7 +19,8 @@
             "styles/h5p-confirmation-dialog.css",
             "styles/h5p-core-button.css",
             "styles/h5p-tooltip.css",
-            "styles/h5p-table.css"
+            "styles/h5p-table.css",
+            "styles/h5p-fonts.css"
         ]
     }
 }

--- a/packages/h5p-server/test/H5PPlayer.loadDependencies.test.ts
+++ b/packages/h5p-server/test/H5PPlayer.loadDependencies.test.ts
@@ -64,7 +64,7 @@ describe('Loading dependencies', () => {
                 metadataOverride: h5pObject as any
             })
             .then((model) => {
-                expect((model as any).styles.slice(6)).toEqual([
+                expect((model as any).styles.slice(8)).toEqual([
                     '/h5p/libraries/Foo-4.2/foo1.css?version=4.2.0',
                     '/h5p/libraries/Foo-4.2/foo2.css?version=4.2.0',
                     '/h5p/libraries/Bar-2.1/bar.css?version=2.1.0'
@@ -148,7 +148,7 @@ describe('Loading dependencies', () => {
                 metadataOverride: h5pObject as any
             })
             .then((model) => {
-                expect((model as any).styles.slice(6)).toEqual([
+                expect((model as any).styles.slice(8)).toEqual([
                     '/h5p/libraries/Foo-4.2/foo1.css?version=4.2.0',
                     '/h5p/libraries/Foo-4.2/foo2.css?version=4.2.0',
                     '/h5p/libraries/Bar-2.1/bar.css?version=2.1.0'
@@ -243,7 +243,7 @@ describe('Loading dependencies', () => {
                 metadataOverride: h5pObject as any
             })
             .then((model) => {
-                expect((model as any).styles.slice(6)).toEqual([
+                expect((model as any).styles.slice(8)).toEqual([
                     '/h5p/libraries/Baz-3.3/baz.css?version=3.3.0',
                     '/h5p/libraries/Bar-2.1/bar.css?version=2.1.0',
                     '/h5p/libraries/Foo-4.2/foo.css?version=4.2.0'
@@ -331,7 +331,7 @@ describe('Loading dependencies', () => {
                 metadataOverride: h5pObject as any
             })
             .then((model) => {
-                expect((model as any).styles.slice(6)).toEqual([
+                expect((model as any).styles.slice(8)).toEqual([
                     '/h5p/libraries/Baz-3.3/baz.css?version=3.3.0',
                     '/h5p/libraries/Bar-2.1/bar.css?version=2.1.0',
                     '/h5p/libraries/Foo-4.2/foo.css?version=4.2.0'
@@ -423,7 +423,7 @@ describe('Loading dependencies', () => {
                 metadataOverride: h5pObject as any
             })
             .then((model) => {
-                expect((model as any).styles.slice(6)).toEqual([
+                expect((model as any).styles.slice(8)).toEqual([
                     '/h5p/libraries/Baz-3.3/baz.css?version=3.3.0',
                     '/h5p/libraries/Bar-2.1/bar.css?version=2.1.0',
                     '/h5p/libraries/Foo-4.2/foo.css?version=4.2.0'
@@ -530,12 +530,14 @@ describe('Loading dependencies', () => {
         ]);
 
         expect(model.styles).toEqual([
+            `/baseUrl/coreUrl/styles/h5p-fonts.css?version=${config.h5pVersion}`,
             `/baseUrl/coreUrl/styles/h5p.css?version=${config.h5pVersion}`,
             `/baseUrl/coreUrl/styles/h5p-confirmation-dialog.css?version=${config.h5pVersion}`,
             `/baseUrl/coreUrl/styles/h5p-core-button.css?version=${config.h5pVersion}`,
+            `/baseUrl/coreUrl/styles/h5p-theme.css?version=${config.h5pVersion}`,
+            `/baseUrl/coreUrl/styles/h5p-theme-variables.css?version=${config.h5pVersion}`,
             `/baseUrl/coreUrl/styles/h5p-tooltip.css?version=${config.h5pVersion}`,
             `/baseUrl/coreUrl/styles/h5p-table.css?version=${config.h5pVersion}`,
-            `/baseUrl/coreUrl/styles/h5p-fonts.css?version=${config.h5pVersion}`,
             `/baseUrl/libraryUrl/Baz-3.3/baz.css?version=3.3.0`,
             `/baseUrl/libraryUrl/Bar-2.1/bar.css?version=2.1.0`,
             `/baseUrl/libraryUrl/Foo-4.2/foo.css?version=4.2.0`

--- a/packages/h5p-server/test/H5PPlayer.loadDependencies.test.ts
+++ b/packages/h5p-server/test/H5PPlayer.loadDependencies.test.ts
@@ -64,7 +64,7 @@ describe('Loading dependencies', () => {
                 metadataOverride: h5pObject as any
             })
             .then((model) => {
-                expect((model as any).styles.slice(5)).toEqual([
+                expect((model as any).styles.slice(6)).toEqual([
                     '/h5p/libraries/Foo-4.2/foo1.css?version=4.2.0',
                     '/h5p/libraries/Foo-4.2/foo2.css?version=4.2.0',
                     '/h5p/libraries/Bar-2.1/bar.css?version=2.1.0'
@@ -148,7 +148,7 @@ describe('Loading dependencies', () => {
                 metadataOverride: h5pObject as any
             })
             .then((model) => {
-                expect((model as any).styles.slice(5)).toEqual([
+                expect((model as any).styles.slice(6)).toEqual([
                     '/h5p/libraries/Foo-4.2/foo1.css?version=4.2.0',
                     '/h5p/libraries/Foo-4.2/foo2.css?version=4.2.0',
                     '/h5p/libraries/Bar-2.1/bar.css?version=2.1.0'
@@ -243,7 +243,7 @@ describe('Loading dependencies', () => {
                 metadataOverride: h5pObject as any
             })
             .then((model) => {
-                expect((model as any).styles.slice(5)).toEqual([
+                expect((model as any).styles.slice(6)).toEqual([
                     '/h5p/libraries/Baz-3.3/baz.css?version=3.3.0',
                     '/h5p/libraries/Bar-2.1/bar.css?version=2.1.0',
                     '/h5p/libraries/Foo-4.2/foo.css?version=4.2.0'
@@ -331,7 +331,7 @@ describe('Loading dependencies', () => {
                 metadataOverride: h5pObject as any
             })
             .then((model) => {
-                expect((model as any).styles.slice(5)).toEqual([
+                expect((model as any).styles.slice(6)).toEqual([
                     '/h5p/libraries/Baz-3.3/baz.css?version=3.3.0',
                     '/h5p/libraries/Bar-2.1/bar.css?version=2.1.0',
                     '/h5p/libraries/Foo-4.2/foo.css?version=4.2.0'
@@ -423,7 +423,7 @@ describe('Loading dependencies', () => {
                 metadataOverride: h5pObject as any
             })
             .then((model) => {
-                expect((model as any).styles.slice(5)).toEqual([
+                expect((model as any).styles.slice(6)).toEqual([
                     '/h5p/libraries/Baz-3.3/baz.css?version=3.3.0',
                     '/h5p/libraries/Bar-2.1/bar.css?version=2.1.0',
                     '/h5p/libraries/Foo-4.2/foo.css?version=4.2.0'
@@ -535,6 +535,7 @@ describe('Loading dependencies', () => {
             `/baseUrl/coreUrl/styles/h5p-core-button.css?version=${config.h5pVersion}`,
             `/baseUrl/coreUrl/styles/h5p-tooltip.css?version=${config.h5pVersion}`,
             `/baseUrl/coreUrl/styles/h5p-table.css?version=${config.h5pVersion}`,
+            `/baseUrl/coreUrl/styles/h5p-fonts.css?version=${config.h5pVersion}`,
             `/baseUrl/libraryUrl/Baz-3.3/baz.css?version=3.3.0`,
             `/baseUrl/libraryUrl/Bar-2.1/bar.css?version=2.1.0`,
             `/baseUrl/libraryUrl/Foo-4.2/foo.css?version=4.2.0`

--- a/packages/h5p-server/test/__snapshots__/H5PPlayer.renderHtmlPage.test.ts.snap
+++ b/packages/h5p-server/test/__snapshots__/H5PPlayer.renderHtmlPage.test.ts.snap
@@ -6,22 +6,23 @@ exports[`Rendering the HTML page > includes custom scripts and styles in the gen
 <head>
     <meta charset="utf-8">
    
-    <link rel="stylesheet" href="/h5p/core/styles/h5p.css?version=1.27.0"/>
-    <link rel="stylesheet" href="/h5p/core/styles/h5p-confirmation-dialog.css?version=1.27.0"/>
-    <link rel="stylesheet" href="/h5p/core/styles/h5p-core-button.css?version=1.27.0"/>
-    <link rel="stylesheet" href="/h5p/core/styles/h5p-tooltip.css?version=1.27.0"/>
-    <link rel="stylesheet" href="/h5p/core/styles/h5p-table.css?version=1.27.0"/>
+    <link rel="stylesheet" href="/h5p/core/styles/h5p.css?version=1.28.0"/>
+    <link rel="stylesheet" href="/h5p/core/styles/h5p-confirmation-dialog.css?version=1.28.0"/>
+    <link rel="stylesheet" href="/h5p/core/styles/h5p-core-button.css?version=1.28.0"/>
+    <link rel="stylesheet" href="/h5p/core/styles/h5p-tooltip.css?version=1.28.0"/>
+    <link rel="stylesheet" href="/h5p/core/styles/h5p-table.css?version=1.28.0"/>
+    <link rel="stylesheet" href="/h5p/core/styles/h5p-fonts.css?version=1.28.0"/>
     <link rel="stylesheet" href="/test.css"/>
-    <script src="/h5p/core/js/jquery.js?version=1.27.0"></script>
-    <script src="/h5p/core/js/h5p.js?version=1.27.0"></script>
-    <script src="/h5p/core/js/h5p-event-dispatcher.js?version=1.27.0"></script>
-    <script src="/h5p/core/js/h5p-x-api-event.js?version=1.27.0"></script>
-    <script src="/h5p/core/js/h5p-x-api.js?version=1.27.0"></script>
-    <script src="/h5p/core/js/h5p-content-type.js?version=1.27.0"></script>
-    <script src="/h5p/core/js/h5p-confirmation-dialog.js?version=1.27.0"></script>
-    <script src="/h5p/core/js/h5p-action-bar.js?version=1.27.0"></script>
-    <script src="/h5p/core/js/request-queue.js?version=1.27.0"></script>
-    <script src="/h5p/core/js/h5p-tooltip.js?version=1.27.0"></script>
+    <script src="/h5p/core/js/jquery.js?version=1.28.0"></script>
+    <script src="/h5p/core/js/h5p.js?version=1.28.0"></script>
+    <script src="/h5p/core/js/h5p-event-dispatcher.js?version=1.28.0"></script>
+    <script src="/h5p/core/js/h5p-x-api-event.js?version=1.28.0"></script>
+    <script src="/h5p/core/js/h5p-x-api.js?version=1.28.0"></script>
+    <script src="/h5p/core/js/h5p-content-type.js?version=1.28.0"></script>
+    <script src="/h5p/core/js/h5p-confirmation-dialog.js?version=1.28.0"></script>
+    <script src="/h5p/core/js/h5p-action-bar.js?version=1.28.0"></script>
+    <script src="/h5p/core/js/request-queue.js?version=1.28.0"></script>
+    <script src="/h5p/core/js/h5p-tooltip.js?version=1.28.0"></script>
     <script src="/test.js"></script>
 
     <script>
@@ -56,24 +57,25 @@ exports[`Rendering the HTML page > includes custom scripts and styles in the gen
   },
   "core": {
     "scripts": [
-      "/h5p/core/js/jquery.js?version=1.27.0",
-      "/h5p/core/js/h5p.js?version=1.27.0",
-      "/h5p/core/js/h5p-event-dispatcher.js?version=1.27.0",
-      "/h5p/core/js/h5p-x-api-event.js?version=1.27.0",
-      "/h5p/core/js/h5p-x-api.js?version=1.27.0",
-      "/h5p/core/js/h5p-content-type.js?version=1.27.0",
-      "/h5p/core/js/h5p-confirmation-dialog.js?version=1.27.0",
-      "/h5p/core/js/h5p-action-bar.js?version=1.27.0",
-      "/h5p/core/js/request-queue.js?version=1.27.0",
-      "/h5p/core/js/h5p-tooltip.js?version=1.27.0",
+      "/h5p/core/js/jquery.js?version=1.28.0",
+      "/h5p/core/js/h5p.js?version=1.28.0",
+      "/h5p/core/js/h5p-event-dispatcher.js?version=1.28.0",
+      "/h5p/core/js/h5p-x-api-event.js?version=1.28.0",
+      "/h5p/core/js/h5p-x-api.js?version=1.28.0",
+      "/h5p/core/js/h5p-content-type.js?version=1.28.0",
+      "/h5p/core/js/h5p-confirmation-dialog.js?version=1.28.0",
+      "/h5p/core/js/h5p-action-bar.js?version=1.28.0",
+      "/h5p/core/js/request-queue.js?version=1.28.0",
+      "/h5p/core/js/h5p-tooltip.js?version=1.28.0",
       "/test.js"
     ],
     "styles": [
-      "/h5p/core/styles/h5p.css?version=1.27.0",
-      "/h5p/core/styles/h5p-confirmation-dialog.css?version=1.27.0",
-      "/h5p/core/styles/h5p-core-button.css?version=1.27.0",
-      "/h5p/core/styles/h5p-tooltip.css?version=1.27.0",
-      "/h5p/core/styles/h5p-table.css?version=1.27.0",
+      "/h5p/core/styles/h5p.css?version=1.28.0",
+      "/h5p/core/styles/h5p-confirmation-dialog.css?version=1.28.0",
+      "/h5p/core/styles/h5p-core-button.css?version=1.28.0",
+      "/h5p/core/styles/h5p-tooltip.css?version=1.28.0",
+      "/h5p/core/styles/h5p-table.css?version=1.28.0",
+      "/h5p/core/styles/h5p-fonts.css?version=1.28.0",
       "/test.css"
     ]
   },
@@ -278,21 +280,22 @@ exports[`Rendering the HTML page > uses default renderer and integration values 
 <head>
     <meta charset="utf-8">
    
-    <link rel="stylesheet" href="/h5p/core/styles/h5p.css?version=1.27.0"/>
-    <link rel="stylesheet" href="/h5p/core/styles/h5p-confirmation-dialog.css?version=1.27.0"/>
-    <link rel="stylesheet" href="/h5p/core/styles/h5p-core-button.css?version=1.27.0"/>
-    <link rel="stylesheet" href="/h5p/core/styles/h5p-tooltip.css?version=1.27.0"/>
-    <link rel="stylesheet" href="/h5p/core/styles/h5p-table.css?version=1.27.0"/>
-    <script src="/h5p/core/js/jquery.js?version=1.27.0"></script>
-    <script src="/h5p/core/js/h5p.js?version=1.27.0"></script>
-    <script src="/h5p/core/js/h5p-event-dispatcher.js?version=1.27.0"></script>
-    <script src="/h5p/core/js/h5p-x-api-event.js?version=1.27.0"></script>
-    <script src="/h5p/core/js/h5p-x-api.js?version=1.27.0"></script>
-    <script src="/h5p/core/js/h5p-content-type.js?version=1.27.0"></script>
-    <script src="/h5p/core/js/h5p-confirmation-dialog.js?version=1.27.0"></script>
-    <script src="/h5p/core/js/h5p-action-bar.js?version=1.27.0"></script>
-    <script src="/h5p/core/js/request-queue.js?version=1.27.0"></script>
-    <script src="/h5p/core/js/h5p-tooltip.js?version=1.27.0"></script>
+    <link rel="stylesheet" href="/h5p/core/styles/h5p.css?version=1.28.0"/>
+    <link rel="stylesheet" href="/h5p/core/styles/h5p-confirmation-dialog.css?version=1.28.0"/>
+    <link rel="stylesheet" href="/h5p/core/styles/h5p-core-button.css?version=1.28.0"/>
+    <link rel="stylesheet" href="/h5p/core/styles/h5p-tooltip.css?version=1.28.0"/>
+    <link rel="stylesheet" href="/h5p/core/styles/h5p-table.css?version=1.28.0"/>
+    <link rel="stylesheet" href="/h5p/core/styles/h5p-fonts.css?version=1.28.0"/>
+    <script src="/h5p/core/js/jquery.js?version=1.28.0"></script>
+    <script src="/h5p/core/js/h5p.js?version=1.28.0"></script>
+    <script src="/h5p/core/js/h5p-event-dispatcher.js?version=1.28.0"></script>
+    <script src="/h5p/core/js/h5p-x-api-event.js?version=1.28.0"></script>
+    <script src="/h5p/core/js/h5p-x-api.js?version=1.28.0"></script>
+    <script src="/h5p/core/js/h5p-content-type.js?version=1.28.0"></script>
+    <script src="/h5p/core/js/h5p-confirmation-dialog.js?version=1.28.0"></script>
+    <script src="/h5p/core/js/h5p-action-bar.js?version=1.28.0"></script>
+    <script src="/h5p/core/js/request-queue.js?version=1.28.0"></script>
+    <script src="/h5p/core/js/h5p-tooltip.js?version=1.28.0"></script>
 
     <script>
         window.H5PIntegration = {
@@ -326,23 +329,24 @@ exports[`Rendering the HTML page > uses default renderer and integration values 
   },
   "core": {
     "scripts": [
-      "/h5p/core/js/jquery.js?version=1.27.0",
-      "/h5p/core/js/h5p.js?version=1.27.0",
-      "/h5p/core/js/h5p-event-dispatcher.js?version=1.27.0",
-      "/h5p/core/js/h5p-x-api-event.js?version=1.27.0",
-      "/h5p/core/js/h5p-x-api.js?version=1.27.0",
-      "/h5p/core/js/h5p-content-type.js?version=1.27.0",
-      "/h5p/core/js/h5p-confirmation-dialog.js?version=1.27.0",
-      "/h5p/core/js/h5p-action-bar.js?version=1.27.0",
-      "/h5p/core/js/request-queue.js?version=1.27.0",
-      "/h5p/core/js/h5p-tooltip.js?version=1.27.0"
+      "/h5p/core/js/jquery.js?version=1.28.0",
+      "/h5p/core/js/h5p.js?version=1.28.0",
+      "/h5p/core/js/h5p-event-dispatcher.js?version=1.28.0",
+      "/h5p/core/js/h5p-x-api-event.js?version=1.28.0",
+      "/h5p/core/js/h5p-x-api.js?version=1.28.0",
+      "/h5p/core/js/h5p-content-type.js?version=1.28.0",
+      "/h5p/core/js/h5p-confirmation-dialog.js?version=1.28.0",
+      "/h5p/core/js/h5p-action-bar.js?version=1.28.0",
+      "/h5p/core/js/request-queue.js?version=1.28.0",
+      "/h5p/core/js/h5p-tooltip.js?version=1.28.0"
     ],
     "styles": [
-      "/h5p/core/styles/h5p.css?version=1.27.0",
-      "/h5p/core/styles/h5p-confirmation-dialog.css?version=1.27.0",
-      "/h5p/core/styles/h5p-core-button.css?version=1.27.0",
-      "/h5p/core/styles/h5p-tooltip.css?version=1.27.0",
-      "/h5p/core/styles/h5p-table.css?version=1.27.0"
+      "/h5p/core/styles/h5p.css?version=1.28.0",
+      "/h5p/core/styles/h5p-confirmation-dialog.css?version=1.28.0",
+      "/h5p/core/styles/h5p-core-button.css?version=1.28.0",
+      "/h5p/core/styles/h5p-tooltip.css?version=1.28.0",
+      "/h5p/core/styles/h5p-table.css?version=1.28.0",
+      "/h5p/core/styles/h5p-fonts.css?version=1.28.0"
     ]
   },
   "l10n": {

--- a/packages/h5p-server/test/__snapshots__/H5PPlayer.renderHtmlPage.test.ts.snap
+++ b/packages/h5p-server/test/__snapshots__/H5PPlayer.renderHtmlPage.test.ts.snap
@@ -6,12 +6,14 @@ exports[`Rendering the HTML page > includes custom scripts and styles in the gen
 <head>
     <meta charset="utf-8">
    
+    <link rel="stylesheet" href="/h5p/core/styles/h5p-fonts.css?version=1.28.0"/>
     <link rel="stylesheet" href="/h5p/core/styles/h5p.css?version=1.28.0"/>
     <link rel="stylesheet" href="/h5p/core/styles/h5p-confirmation-dialog.css?version=1.28.0"/>
     <link rel="stylesheet" href="/h5p/core/styles/h5p-core-button.css?version=1.28.0"/>
+    <link rel="stylesheet" href="/h5p/core/styles/h5p-theme.css?version=1.28.0"/>
+    <link rel="stylesheet" href="/h5p/core/styles/h5p-theme-variables.css?version=1.28.0"/>
     <link rel="stylesheet" href="/h5p/core/styles/h5p-tooltip.css?version=1.28.0"/>
     <link rel="stylesheet" href="/h5p/core/styles/h5p-table.css?version=1.28.0"/>
-    <link rel="stylesheet" href="/h5p/core/styles/h5p-fonts.css?version=1.28.0"/>
     <link rel="stylesheet" href="/test.css"/>
     <script src="/h5p/core/js/jquery.js?version=1.28.0"></script>
     <script src="/h5p/core/js/h5p.js?version=1.28.0"></script>
@@ -70,12 +72,14 @@ exports[`Rendering the HTML page > includes custom scripts and styles in the gen
       "/test.js"
     ],
     "styles": [
+      "/h5p/core/styles/h5p-fonts.css?version=1.28.0",
       "/h5p/core/styles/h5p.css?version=1.28.0",
       "/h5p/core/styles/h5p-confirmation-dialog.css?version=1.28.0",
       "/h5p/core/styles/h5p-core-button.css?version=1.28.0",
+      "/h5p/core/styles/h5p-theme.css?version=1.28.0",
+      "/h5p/core/styles/h5p-theme-variables.css?version=1.28.0",
       "/h5p/core/styles/h5p-tooltip.css?version=1.28.0",
       "/h5p/core/styles/h5p-table.css?version=1.28.0",
-      "/h5p/core/styles/h5p-fonts.css?version=1.28.0",
       "/test.css"
     ]
   },
@@ -280,12 +284,14 @@ exports[`Rendering the HTML page > uses default renderer and integration values 
 <head>
     <meta charset="utf-8">
    
+    <link rel="stylesheet" href="/h5p/core/styles/h5p-fonts.css?version=1.28.0"/>
     <link rel="stylesheet" href="/h5p/core/styles/h5p.css?version=1.28.0"/>
     <link rel="stylesheet" href="/h5p/core/styles/h5p-confirmation-dialog.css?version=1.28.0"/>
     <link rel="stylesheet" href="/h5p/core/styles/h5p-core-button.css?version=1.28.0"/>
+    <link rel="stylesheet" href="/h5p/core/styles/h5p-theme.css?version=1.28.0"/>
+    <link rel="stylesheet" href="/h5p/core/styles/h5p-theme-variables.css?version=1.28.0"/>
     <link rel="stylesheet" href="/h5p/core/styles/h5p-tooltip.css?version=1.28.0"/>
     <link rel="stylesheet" href="/h5p/core/styles/h5p-table.css?version=1.28.0"/>
-    <link rel="stylesheet" href="/h5p/core/styles/h5p-fonts.css?version=1.28.0"/>
     <script src="/h5p/core/js/jquery.js?version=1.28.0"></script>
     <script src="/h5p/core/js/h5p.js?version=1.28.0"></script>
     <script src="/h5p/core/js/h5p-event-dispatcher.js?version=1.28.0"></script>
@@ -341,12 +347,14 @@ exports[`Rendering the HTML page > uses default renderer and integration values 
       "/h5p/core/js/h5p-tooltip.js?version=1.28.0"
     ],
     "styles": [
+      "/h5p/core/styles/h5p-fonts.css?version=1.28.0",
       "/h5p/core/styles/h5p.css?version=1.28.0",
       "/h5p/core/styles/h5p-confirmation-dialog.css?version=1.28.0",
       "/h5p/core/styles/h5p-core-button.css?version=1.28.0",
+      "/h5p/core/styles/h5p-theme.css?version=1.28.0",
+      "/h5p/core/styles/h5p-theme-variables.css?version=1.28.0",
       "/h5p/core/styles/h5p-tooltip.css?version=1.28.0",
-      "/h5p/core/styles/h5p-table.css?version=1.28.0",
-      "/h5p/core/styles/h5p-fonts.css?version=1.28.0"
+      "/h5p/core/styles/h5p-table.css?version=1.28.0"
     ]
   },
   "l10n": {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,7 +1,7 @@
 # If the editor and core files are missing, we download them from GitHub.
 if [ ! -d "packages/h5p-examples/h5p/editor" ] || [ ! -d "packages/h5p-examples/h5p/core" ]
 then    
-    sh packages/h5p-examples/download-core.sh 829524eaf81fe3f3a295d0e843812be4735f51fc 80b3b281ee9d064b563f242e8ee7a0026b5bf205
+    sh packages/h5p-examples/download-core.sh 2aeb0b83fa603e331381b3a6b8bf42c3773ba140 ab2daa18bd61b19e7f8729e22eec88f3b637a868
 else
     echo "Not downloading H5P Core and Editor files as they are already present!"
 fi


### PR DESCRIPTION
- Update commit SHAs in scripts/install.sh and h5p-rest-example-server
  - h5p-php-library: 2aeb0b83fa603e331381b3a6b8bf42c3773ba140
  - h5p-editor-php-library: ab2daa18bd61b19e7f8729e22eec88f3b637a868
- Bump coreApiVersion to 1.28 and h5pVersion to 1.28.0 in H5PConfig.ts
- Add styles/h5p-fonts.css to player and editor asset lists (new in 1.28: defines @font-face for Open Sans v40, Inter, h5p icons)
- Update test snapshots for new version string