### PR TITLE
chore(h5p-rest-example-client): remove unused http-proxy-middleware dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7698,15 +7698,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/@types/http-proxy": {
-            "version": "1.17.17",
-            "resolved": "https://registry.npmjs.org/@types/http-proxy/-/http-proxy-1.17.17.tgz",
-            "integrity": "sha512-ED6LB+Z1AVylNTu7hdzuBqOgMnvG/ld6wGCG8wFnAzKX5uyW2K3WD52v0gnLCTK/VLpXtKckgWuyScYK6cSPaw==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/node": "*"
-            }
-        },
         "node_modules/@types/is-empty": {
             "version": "1.2.3",
             "dev": true,
@@ -7801,6 +7792,7 @@
         },
         "node_modules/@types/node": {
             "version": "25.3.0",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "undici-types": "~7.18.0"
@@ -9841,6 +9833,7 @@
         },
         "node_modules/braces": {
             "version": "3.0.3",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "fill-range": "^7.1.1"
@@ -12277,6 +12270,7 @@
             "version": "4.0.7",
             "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
             "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/events": {
@@ -12601,6 +12595,7 @@
         },
         "node_modules/fill-range": {
             "version": "7.1.1",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "to-regex-range": "^5.0.1"
@@ -13327,20 +13322,6 @@
                 "url": "https://opencollective.com/express"
             }
         },
-        "node_modules/http-proxy": {
-            "version": "1.18.1",
-            "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.1.tgz",
-            "integrity": "sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==",
-            "license": "MIT",
-            "dependencies": {
-                "eventemitter3": "^4.0.0",
-                "follow-redirects": "^1.0.0",
-                "requires-port": "^1.0.0"
-            },
-            "engines": {
-                "node": ">=8.0.0"
-            }
-        },
         "node_modules/http-proxy-agent": {
             "version": "7.0.2",
             "dev": true,
@@ -13351,23 +13332,6 @@
             },
             "engines": {
                 "node": ">= 14"
-            }
-        },
-        "node_modules/http-proxy-middleware": {
-            "version": "3.0.7",
-            "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-3.0.7.tgz",
-            "integrity": "sha512-iwbQltVlx8bCrqePUM8C+hllHvdawVhQJaLrj1X7qllkvFQdXFsr16pW/mo9+JDVjN+QO2XUx9jd8SmoFkE5qw==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/http-proxy": "^1.17.15",
-                "debug": "^4.3.6",
-                "http-proxy": "^1.18.1",
-                "is-glob": "^4.0.3",
-                "is-plain-object": "^5.0.0",
-                "micromatch": "^4.0.8"
-            },
-            "engines": {
-                "node": "^14.18.0 || ^16.10.0 || >=18.0.0"
             }
         },
         "node_modules/https-proxy-agent": {
@@ -14184,6 +14148,7 @@
         },
         "node_modules/is-extglob": {
             "version": "2.1.1",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
@@ -14230,6 +14195,7 @@
         },
         "node_modules/is-glob": {
             "version": "4.0.3",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "is-extglob": "^2.1.1"
@@ -14301,6 +14267,7 @@
         },
         "node_modules/is-number": {
             "version": "7.0.0",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=0.12.0"
@@ -16781,19 +16748,6 @@
             ],
             "license": "MIT"
         },
-        "node_modules/micromatch": {
-            "version": "4.0.8",
-            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
-            "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
-            "license": "MIT",
-            "dependencies": {
-                "braces": "^3.0.3",
-                "picomatch": "^2.3.1"
-            },
-            "engines": {
-                "node": ">=8.6"
-            }
-        },
         "node_modules/mime-db": {
             "version": "1.52.0",
             "license": "MIT",
@@ -18883,6 +18837,7 @@
         },
         "node_modules/picomatch": {
             "version": "2.3.1",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8.6"
@@ -19889,12 +19844,6 @@
             "engines": {
                 "node": ">=0.10.0"
             }
-        },
-        "node_modules/requires-port": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-            "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
-            "license": "MIT"
         },
         "node_modules/resolve": {
             "version": "2.0.0-next.5",
@@ -21124,6 +21073,7 @@
         },
         "node_modules/to-regex-range": {
             "version": "5.0.1",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "is-number": "^7.0.0"
@@ -21762,6 +21712,7 @@
         },
         "node_modules/undici-types": {
             "version": "7.18.2",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/unified": {
@@ -24062,7 +24013,6 @@
                 "@fortawesome/react-fontawesome": "3.2.0",
                 "@lumieducation/h5p-react": "^10.0.4",
                 "bootstrap": "5.3.8",
-                "http-proxy-middleware": "3.0.7",
                 "react": "19.2.4",
                 "react-bootstrap": "2.10.10",
                 "react-dom": "19.2.4"

--- a/packages/h5p-rest-example-client/package.json
+++ b/packages/h5p-rest-example-client/package.json
@@ -9,7 +9,6 @@
         "@lumieducation/h5p-react": "^10.0.4",
         "bootstrap": "5.3.8",
         "react": "19.2.4",
-        "http-proxy-middleware": "3.0.7",
         "react-bootstrap": "2.10.10",
         "react-dom": "19.2.4"
     },


### PR DESCRIPTION
## Summary
- `http-proxy-middleware` was a direct dependency of `packages/h5p-rest-example-client` but was never imported anywhere in the code.
- The dev-server proxy config lives in `vite.config.ts` and uses Vite's built-in `server.proxy` option instead.
- Found while triaging renovate PR #4487 (bump to v4) — flagged there as an unused-dependency candidate for cleanup.

## Test plan
- [x] `npm run build`
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm test`
- [x] Built `h5p-rest-example-client` directly via `vite build` to confirm it's unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)