### PR TITLE
fix(h5p-server): replace get-all-files with a native readdir helper

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12751,19 +12751,6 @@
                 "node": ">=6.9.0"
             }
         },
-        "node_modules/get-all-files": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/get-all-files/-/get-all-files-6.0.1.tgz",
-            "integrity": "sha512-v+4nprScu7g/wq3/43Urx/nUek+a80hdALEvnwzIsMjji5nWFYEGhjfLhLBlH/s74aI0kYeI50OsxSZW+jHIDg==",
-            "deprecated": "Use fs.readdir and fs.readdirSync with the recursive: true option instead (since Node v18.17.0).",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 22"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/TomerAberbach"
-            }
-        },
         "node_modules/get-caller-file": {
             "version": "2.0.5",
             "dev": true,
@@ -24111,7 +24098,6 @@
                 "cache-manager": "^4.0.0",
                 "debug": "^4.3.4",
                 "flat": "^6.0.0",
-                "get-all-files": "^6.0.0",
                 "https-proxy-agent": "^9.0.0",
                 "jsonpath": "^1.1.1",
                 "magic-bytes.js": "^1.13.0",

--- a/packages/h5p-server/package.json
+++ b/packages/h5p-server/package.json
@@ -52,7 +52,6 @@
         "cache-manager": "^4.0.0",
         "debug": "^4.3.4",
         "flat": "^6.0.0",
-        "get-all-files": "^6.0.0",
         "https-proxy-agent": "^9.0.0",
         "jsonpath": "^1.1.1",
         "magic-bytes.js": "^1.13.0",

--- a/packages/h5p-server/src/ContentStorer.ts
+++ b/packages/h5p-server/src/ContentStorer.ts
@@ -1,5 +1,5 @@
 import path from 'path';
-import { getAllFiles } from 'get-all-files';
+import { getAllFiles } from './helpers/getAllFiles';
 import { Stream } from 'stream';
 import { rm, access, readFile } from 'fs/promises';
 import { createReadStream } from 'fs';
@@ -196,7 +196,7 @@ export default class ContentStorer {
             )
         );
         const otherContentFiles: string[] = (
-            await getAllFiles(path.join(packageDirectory, 'content')).toArray()
+            await getAllFiles(path.join(packageDirectory, 'content'))
         ).filter(
             (file: string) =>
                 file.substr(packageDirectoryLength) !== 'content.json'

--- a/packages/h5p-server/src/LibraryManager.ts
+++ b/packages/h5p-server/src/LibraryManager.ts
@@ -1,5 +1,5 @@
 import { Readable } from 'stream';
-import { getAllFiles } from 'get-all-files';
+import { getAllFiles } from './helpers/getAllFiles';
 import { readFile } from 'fs/promises';
 import { createReadStream } from 'fs';
 
@@ -756,7 +756,7 @@ export default class LibraryManager {
     ): Promise<void> {
         log.info(`copying library files from ${fromDirectory}`);
         const fromDirectoryLength = fromDirectory.length + 1;
-        const files = await getAllFiles(fromDirectory).toArray();
+        const files = await getAllFiles(fromDirectory);
         await Promise.all(
             files.map((fileFullPath: string) => {
                 const fileLocalPath: string =

--- a/packages/h5p-server/src/PackageValidator.ts
+++ b/packages/h5p-server/src/PackageValidator.ts
@@ -2,7 +2,7 @@ import Ajv, { ValidateFunction } from 'ajv';
 import ajvKeywords from 'ajv-keywords';
 import * as path from 'path';
 import * as yauzl from 'yauzl-promise';
-import { getAllFiles } from 'get-all-files';
+import { getAllFiles } from './helpers/getAllFiles';
 import { readdir, readFile } from 'fs/promises';
 
 import AggregateH5pError from './helpers/AggregateH5pError';
@@ -154,7 +154,7 @@ export default class PackageValidator {
         await this.initializeJsonValidators();
 
         const packagePathLength = packagePath.length + 1;
-        const files = (await getAllFiles(packagePath).toArray()).map((f) =>
+        const files = (await getAllFiles(packagePath)).map((f) =>
             f.substr(packagePathLength).replace(/\\/g, '/')
         );
 

--- a/packages/h5p-server/src/helpers/getAllFiles.ts
+++ b/packages/h5p-server/src/helpers/getAllFiles.ts
@@ -1,0 +1,21 @@
+import { readdir } from 'fs/promises';
+import { sep } from 'path';
+
+/**
+ * Recursively lists all files (not directories) under dirname. Paths are
+ * built by concatenating dirname verbatim (not path.join, which would
+ * normalize away any `..` segments) with each file's relative path, since
+ * several callers strip the literal `dirname` string off the front of each
+ * result.
+ */
+export async function getAllFiles(dirname: string): Promise<string[]> {
+    const base = dirname.endsWith(sep) ? dirname : `${dirname}${sep}`;
+    const entries = await readdir(base, { withFileTypes: true });
+    const files = await Promise.all(
+        entries.map((entry) => {
+            const fullPath = `${base}${entry.name}`;
+            return entry.isDirectory() ? getAllFiles(fullPath) : [fullPath];
+        })
+    );
+    return files.flat();
+}

--- a/packages/h5p-server/src/implementation/fs/DirectoryTemporaryFileStorage.ts
+++ b/packages/h5p-server/src/implementation/fs/DirectoryTemporaryFileStorage.ts
@@ -10,7 +10,7 @@ import {
     writeFile
 } from 'fs/promises';
 
-import { getAllFiles } from 'get-all-files';
+import { getAllFiles } from '../../helpers/getAllFiles';
 import path from 'path';
 import promisepipe from 'promisepipe';
 
@@ -150,7 +150,7 @@ export default class DirectoryTemporaryFileStorage implements ITemporaryFileStor
                 users.map(async (u) => {
                     const basePath = this.getAbsoluteUserDirectoryPath(u);
                     const basePathLength = basePath.length + 1;
-                    const filesOfUser = await getAllFiles(basePath).toArray();
+                    const filesOfUser = await getAllFiles(basePath);
                     return Promise.all(
                         filesOfUser
                             .map((f) => f.substr(basePathLength))

--- a/packages/h5p-server/src/implementation/fs/FileContentStorage.ts
+++ b/packages/h5p-server/src/implementation/fs/FileContentStorage.ts
@@ -1,6 +1,6 @@
 import { createReadStream, createWriteStream, mkdirSync, ReadStream } from 'fs';
 import { Stream } from 'stream';
-import { getAllFiles } from 'get-all-files';
+import { getAllFiles } from '../../helpers/getAllFiles';
 import path from 'path';
 import promisepipe from 'promisepipe';
 import { access, mkdir, readdir, rm, stat, writeFile } from 'fs/promises';
@@ -457,7 +457,7 @@ export default class FileContentStorage implements IContentStorage {
         const contentDirectoryPathLength = contentDirectoryPath.length + 1;
         const absolutePaths = await getAllFiles(
             path.join(contentDirectoryPath)
-        ).toArray();
+        );
         const contentPath = path.join(contentDirectoryPath, 'content.json');
         const h5pPath = path.join(contentDirectoryPath, 'h5p.json');
         return absolutePaths

--- a/packages/h5p-server/src/implementation/fs/FileContentUserDataStorage.ts
+++ b/packages/h5p-server/src/implementation/fs/FileContentUserDataStorage.ts
@@ -1,5 +1,5 @@
 import path from 'path';
-import { getAllFiles } from 'get-all-files';
+import { getAllFiles } from '../../helpers/getAllFiles';
 import { readFile, rm, writeFile } from 'fs/promises';
 import { existsSync, mkdirSync } from 'fs';
 
@@ -74,7 +74,7 @@ export default class FileContentUserDataStorage implements IContentUserDataStora
     public async getContentUserDataByUser(
         user: IUser
     ): Promise<IContentUserData[]> {
-        const files = await getAllFiles(this.directory).toArray();
+        const files = await getAllFiles(this.directory);
         const result: IContentUserData[] = [];
         for (const file of files) {
             if (!file.endsWith('-userdata.json')) {
@@ -194,7 +194,7 @@ export default class FileContentUserDataStorage implements IContentUserDataStora
     }
 
     public async deleteAllContentUserDataByUser(user: IUser): Promise<void> {
-        const files = await getAllFiles(this.directory).toArray();
+        const files = await getAllFiles(this.directory);
         for (const file of files) {
             if (!file.endsWith('-userdata.json')) {
                 continue;
@@ -359,7 +359,7 @@ export default class FileContentUserDataStorage implements IContentUserDataStora
     public async getFinishedDataByUser(
         user: IUser
     ): Promise<IFinishedUserData[]> {
-        const files = await getAllFiles(this.directory).toArray();
+        const files = await getAllFiles(this.directory);
         const result: IFinishedUserData[] = [];
         for (const file of files) {
             if (!file.endsWith('-finished.json')) {
@@ -415,7 +415,7 @@ export default class FileContentUserDataStorage implements IContentUserDataStora
     }
 
     public async deleteFinishedDataByUser(user: IUser): Promise<void> {
-        const files = await getAllFiles(this.directory).toArray();
+        const files = await getAllFiles(this.directory);
         for (const file of files) {
             if (!file.endsWith('-finished.json')) {
                 continue;

--- a/packages/h5p-server/src/implementation/fs/FileLibraryStorage.ts
+++ b/packages/h5p-server/src/implementation/fs/FileLibraryStorage.ts
@@ -1,5 +1,5 @@
 import { Readable } from 'stream';
-import { getAllFiles } from 'get-all-files';
+import { getAllFiles } from '../../helpers/getAllFiles';
 import path from 'path';
 import promisepipe from 'promisepipe';
 import { createReadStream, createWriteStream, mkdirSync } from 'fs';
@@ -447,7 +447,7 @@ export default class FileLibraryStorage implements ILibraryStorage {
     public async listFiles(library: ILibraryName): Promise<string[]> {
         const libPath = this.getDirectoryPath(library);
         const libPathLength = libPath.length + 1;
-        return (await getAllFiles(libPath).toArray())
+        return (await getAllFiles(libPath))
             .map((p) => p.substr(libPathLength))
             .filter((p) => !this.isIgnored(p))
             .map((p) => p.replace(/\\/g, '/'))


### PR DESCRIPTION
## Summary
`get-all-files@6.0.1` ships an exports-only `package.json` that `packages/h5p-server/tsconfig.build.json`'s `moduleResolution: "node"` can't resolve for types, breaking `tsc` with `TS2307` on every file that imports it (7 files). The build still produces working JS — `tsc` emits despite the errors, and `build.sh` has no `set -e` so the non-zero exit gets masked by the trailing `cp` — which is why this has been silently green in CI. But the type errors are real and worth fixing at the root instead of living with them.

The package's own deprecation notice recommends the native replacement (`fs.readdir` with `recursive: true`, available since Node 18.17; this repo requires Node ≥22.12). I looked into that directly and it turned out to be unsafe for this codebase specifically: several call sites strip the literal `dirname` argument off the front of each returned path via `.substr(dirname.length + 1)`, and the test suite legitimately passes directory paths containing `..` segments. Both `fs.readdir(dir, { recursive: true, withFileTypes: true })` and `fs.promises.glob` normalize/resolve paths internally in ways that silently break that offset (verified: `readdir`'s `recursive: true` even does this *inconsistently* — top-level entries keep the literal path, nested ones get resolved), and `glob` additionally drops dotfiles by default, which would silently break loading this library's own dotfile-named language resources (e.g. `language/.en.json`).

So `packages/h5p-server/src/helpers/getAllFiles.ts` walks one directory level at a time (mirroring what `get-all-files` does internally) and builds paths via string concatenation rather than `path.join`, preserving the exact-prefix invariant the callers rely on regardless of `..` segments.

## Changes
- Add `packages/h5p-server/src/helpers/getAllFiles.ts`
- Swap the import in all 7 call sites (`PackageValidator.ts`, `ContentStorer.ts`, `LibraryManager.ts`, `FileLibraryStorage.ts`, `FileContentUserDataStorage.ts`, `DirectoryTemporaryFileStorage.ts`, `FileContentStorage.ts`)
- Drop the `get-all-files` dependency entirely

## Test plan
- [x] `npm run build:h5p-server` — 0 type errors (down from 7)
- [x] Full `npm test` (pre-push hook) — 38 files / 310 tests passing
- [x] `npx eslint` / `npx prettier --check` on all touched files — clean
- [x] Specifically re-verified `LibraryManager.test.ts`'s parallel-install race-condition test (which passes a `..`-containing directory path) deterministically across repeated runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ee2upCLWw7L3zVnRDmR8Ja