### PR TITLE
Feat/buffer sanitizer and malware scanners

### DIFF
--- a/docs/advanced/security.md
+++ b/docs/advanced/security.md
@@ -87,7 +87,7 @@ interface IFileSanitizer {
 
     /** Sanitizes files. The original file is expected to be replaced by the
      * sanitized file, so there is no new path to the sanitized file.*/
-    sanitize(file: string): Promise<FileSanitizerResult>;
+    sanitize(file: File): Promise<FileSanitizerResult>;
 }
 
 enum FileSanitizerResult {
@@ -97,9 +97,10 @@ enum FileSanitizerResult {
 }
 ```
 
-Note: Sanitization only works if you pass uploaded content files to {@link
-@lumieducation/h5p-server!H5PEditor.saveContentFile} as temporary files, not as
-in-memory streams!
+ Note: Sanitization works for uploaded content files that you pass to {@link
+ @lumieducation/h5p-server!H5PEditor.saveContentFile} using the {@link
+ @lumieducation/h5p-server!File} shape, regardless of whether they are backed by
+ temporary files on disk or in-memory buffers.
 
 ### Existing file sanitizers
 
@@ -175,7 +176,7 @@ interface IFileMalwareScanner {
 
     /** Scans a file for malware and returns whether it contains malware. */
     scan(
-        file: string
+        file: File
     ): Promise<{ result: MalwareScanResult; viruses?: string }>;
 }
 

--- a/docs/advanced/security.md
+++ b/docs/advanced/security.md
@@ -85,9 +85,20 @@ interface IFileSanitizer {
     /** The name of the scanner, e.g. SVG Sanitizer. Used in debug output */
     readonly name: string;
 
-    /** Sanitizes files. The original file is expected to be replaced by the
-     * sanitized file, so there is no new path to the sanitized file.*/
-    sanitize(file: File): Promise<FileSanitizerResult>;
+    /** Sanitizes the file at the given path. The original file is expected
+     * to be replaced by the sanitized file, so there is no new path to the
+     * sanitized file. */
+    sanitize(file: string): Promise<FileSanitizerResult>;
+
+    /**
+     * Optional: sanitizes an in-memory buffer without requiring it to be
+     * written to disk first. Implementations are expected to replace
+     * `file.data` with the sanitized buffer. Implementations that don't
+     * support buffer sanitization can omit this method; callers fall back
+     * to writing the buffer to a temporary file and calling `sanitize`
+     * instead.
+     */
+    sanitizeBuffer?(file: H5PFileBuffer): Promise<FileSanitizerResult>;
 }
 
 enum FileSanitizerResult {
@@ -97,10 +108,13 @@ enum FileSanitizerResult {
 }
 ```
 
- Note: Sanitization works for uploaded content files that you pass to {@link
- @lumieducation/h5p-server!H5PEditor.saveContentFile} using the {@link
- @lumieducation/h5p-server!File} shape, regardless of whether they are backed by
- temporary files on disk or in-memory buffers.
+Note: Sanitization works transparently for uploaded content files that you
+pass to {@link @lumieducation/h5p-server!H5PEditor.saveContentFile} using the
+{@link @lumieducation/h5p-server!H5PFile} shape, regardless of whether they
+are backed by temporary files on disk (`tempFilePath`) or in-memory buffers
+(`data`). If a sanitizer doesn't implement `sanitizeBuffer`, buffer-based
+uploads are automatically written to a temporary file before being passed to
+`sanitize`, so all sanitizers support both upload modes without extra work.
 
 ### Existing file sanitizers
 
@@ -174,9 +188,20 @@ interface IFileMalwareScanner {
     /** The name of the scanner, e.g. ClamAV */
     readonly name: string;
 
-    /** Scans a file for malware and returns whether it contains malware. */
+    /** Scans a file at the given path for malware and returns whether it
+     * contains malware. */
     scan(
-        file: File
+        file: string
+    ): Promise<{ result: MalwareScanResult; viruses?: string }>;
+
+    /**
+     * Optional: scans an in-memory buffer for malware without requiring it
+     * to be written to disk first. Implementations that don't support
+     * buffer scanning can omit this method; callers fall back to writing
+     * the buffer to a temporary file and calling `scan` instead.
+     */
+    scanBuffer?(
+        file: H5PFileBuffer
     ): Promise<{ result: MalwareScanResult; viruses?: string }>;
 }
 
@@ -187,9 +212,13 @@ enum MalwareScanResult {
 }
 ```
 
-Note: Malware scanning only works if you pass uploaded content files to {@link
-@lumieducation/h5p-server!H5PEditor.saveContentFile} as temporary files, not as
-in-memory streams!
+Note: Malware scanning works transparently for uploaded content files that
+you pass to {@link @lumieducation/h5p-server!H5PEditor.saveContentFile},
+regardless of whether they are backed by temporary files on disk
+(`tempFilePath`) or in-memory buffers (`data`). If a scanner doesn't
+implement `scanBuffer`, buffer-based uploads are automatically written to a
+temporary file before being passed to `scan`, so all scanners support both
+upload modes without extra work.
 
 ### Existing malware scanners
 

--- a/packages/h5p-clamav-scanner/README.md
+++ b/packages/h5p-clamav-scanner/README.md
@@ -36,7 +36,7 @@ const h5pEditor = new H5PEditor(
     // ... regular configuration ...
     // Add the scanner to the options parameter
     {
-        malwareScanners: [ clamAVScanner ]
+        malwareScanners: [clamAVScanner]
     }
 );
 ```
@@ -108,12 +108,15 @@ CLAMSCAN_ENABLED=true npm start
 Note:
 
 - The `CLAMSCAN_ENABLED` environment variable is part of the example code and
-won't work if you don't add specific support for it. It triggers the creation of
-a `ClamAVScanner` instance. You can use the other environment variables to
-configure the `ClamAVScanner` instance as needed.
-- Malware scanning only works of you pass uploaded content files to {@link
-@lumieducation/h5p-server!H5PEditor.saveContentFile} as temporary files, not as
-in-memory streams. Temporary file uploads are used by default, in the example
-(and could be disabled with the environment variable TEMP_UPLOADS=false). The
-environment variable TEMP_UPLOADS is part of the example code and won't work in
-your custom implementation, if you don't add explicit support for it.
+  won't work if you don't add specific support for it. It triggers the creation of
+  a `ClamAVScanner` instance. You can use the other environment variables to
+  configure the `ClamAVScanner` instance as needed.
+- Malware scanning works transparently for uploaded content files that you
+  pass to {@link @lumieducation/h5p-server!H5PEditor.saveContentFile}, whether
+  they are backed by temporary files on disk or in-memory buffers. `ClamAVScanner`
+  implements `scanBuffer`, so buffer-based uploads are scanned directly without
+  being written to disk first. Temporary file uploads are used by default, in the
+  example (and could be disabled with the environment variable
+  TEMP_UPLOADS=false). The environment variable TEMP_UPLOADS is part of the
+  example code and won't work in your custom implementation, if you don't add
+  explicit support for it.

--- a/packages/h5p-clamav-scanner/src/ClamAVScanner.ts
+++ b/packages/h5p-clamav-scanner/src/ClamAVScanner.ts
@@ -1,15 +1,24 @@
 import NodeClam from 'clamscan';
+import { Readable } from 'stream';
+import { withFile } from 'tmp-promise';
+import { writeFile } from 'fs/promises';
+import { basename, extname } from 'path';
 import { merge } from 'ts-deepmerge';
 
 import {
+    H5PFileBuffer,
     IFileMalwareScanner,
-    MalwareScanResult,
-    Logger
+    Logger,
+    MalwareScanResult
 } from '@lumieducation/h5p-server';
 
 import { removeUndefinedAttributesAndEmptyObjects } from './helpers';
 
 const log = new Logger('ClamAVScanner');
+
+export type ClamAVScannerOptions = {
+    clamdServiceEnabled: boolean;
+};
 
 /**
  * A light wrapper calling the ClamAV scanner to scan files for malware. It
@@ -23,8 +32,14 @@ export default class ClamAVScanner implements IFileMalwareScanner {
      * We have no public constructor, as we need to initialize the ClamAV
      * scanner asynchronously.
      * @param scanner
+     * @param clamdServiceEnabled true if the resolved scanner is the clamd
+     * daemon, which supports scanning a stream directly; false if it is the
+     * clamscan binary, which requires a file on disk.
      */
-    private constructor(private scanner: NodeClam) {
+    private constructor(
+        private scanner: NodeClam,
+        private readonly options: ClamAVScannerOptions
+    ) {
         log.debug('initialize');
     }
 
@@ -51,7 +66,7 @@ export default class ClamAVScanner implements IFileMalwareScanner {
         // is a direct property of the object — even if the value is null or
         // undefined."), we have to remove undefined properties from the
         // options.
-        const options: NodeClam.Options =
+        const clamScanOptions: NodeClam.Options =
             removeUndefinedAttributesAndEmptyObjects(
                 merge(
                     {
@@ -64,14 +79,25 @@ export default class ClamAVScanner implements IFileMalwareScanner {
                 )
             );
 
-        log.debug('Initializing ClamAV scanner with options:', options);
+        log.debug('Initializing ClamAV scanner with options:', clamScanOptions);
 
-        const clamScan = await new NodeClam().init(options);
+        const clamScan = await new NodeClam().init(clamScanOptions);
         log.debug(
             'ClamAV scanner initialized. Version:',
             await clamScan.getVersion()
         );
-        return new ClamAVScanner(clamScan);
+
+        // clamscan resolves during init() which binary/daemon it actually
+        // ended up using (it can fall back from the configured preference,
+        // e.g. if a socket/host/port is misconfigured or a binary isn't
+        // found). Reading that resolved value back instead of re-deriving it
+        // from the input options ourselves means we never get out of sync
+        // with clamscan's own fallback logic.
+        const clamdServiceEnabled =
+            (clamScan as unknown as { scanner: 'clamdscan' | 'clamscan' })
+                .scanner === 'clamdscan';
+
+        return new ClamAVScanner(clamScan, { clamdServiceEnabled });
     }
 
     /**
@@ -146,24 +172,72 @@ export default class ClamAVScanner implements IFileMalwareScanner {
     async scan(
         file: string
     ): Promise<{ result: MalwareScanResult; viruses?: string }> {
+        const fileName = basename(file);
+        log.debug(
+            'Scanning uploaded file',
+            fileName,
+            'with malware scanner',
+            this.name
+        );
+
         try {
-            log.debug(
-                'Scanning uploaded file',
-                file,
-                'with malware scanner',
-                this.name
-            );
-            const result = await this.scanner.isInfected(file);
-            if (result.isInfected) {
-                const viruses = result.viruses.join(',');
-                log.info('Uploaded file', file, 'is infected with:', viruses);
-                return { result: MalwareScanResult.MalwareFound, viruses };
-            }
-            log.debug('Uploaded file', file, 'is clean');
-            return { result: MalwareScanResult.Clean };
+            const scanResponse = await this.scanner.scanFile(file);
+            return this.buildScanResult(scanResponse, fileName);
         } catch (error) {
-            log.error('Error while scanning file', file, error);
+            log.error('Error while scanning file', fileName, error);
             return { result: MalwareScanResult.NotScanned };
         }
+    }
+
+    async scanBuffer(
+        file: H5PFileBuffer
+    ): Promise<{ result: MalwareScanResult; viruses?: string }> {
+        log.debug(
+            'Scanning uploaded buffer',
+            file.name,
+            'with malware scanner',
+            this.name
+        );
+
+        try {
+            const scanResponse = this.options.clamdServiceEnabled
+                ? await this.scanner.scanStream(Readable.from(file.data))
+                : await this.scanBufferWithTempFile(file.data, file.name);
+            return this.buildScanResult(scanResponse, file.name);
+        } catch (error) {
+            log.error('Error while scanning buffer', file.name, error);
+            return { result: MalwareScanResult.NotScanned };
+        }
+    }
+
+    private async scanBufferWithTempFile(
+        data: Buffer,
+        fileName: string
+    ): Promise<NodeClam.Response<{ file: string; isInfected: boolean }>> {
+        log.debug('Using temporary file scan for ClamAV binary');
+        return withFile(
+            async ({ path: tempFilePath }) => {
+                await writeFile(tempFilePath, data);
+                return this.scanner.scanFile(tempFilePath);
+            },
+            // basename() strips any path-traversal segments a malicious
+            // filename might contain; extname() only ever contributes a
+            // suffix like ".svg" to the generated temp path.
+            { postfix: extname(basename(fileName)) || undefined }
+        );
+    }
+
+    private buildScanResult(
+        response: NodeClam.Response<{ file: string; isInfected: boolean }>,
+        fileName: string
+    ): { result: MalwareScanResult; viruses?: string } {
+        if (response.isInfected) {
+            const viruses = response.viruses.join(',');
+            log.info('Uploaded file', fileName, 'is infected with:', viruses);
+            return { result: MalwareScanResult.MalwareFound, viruses };
+        }
+
+        log.debug('Uploaded file', fileName, 'is clean');
+        return { result: MalwareScanResult.Clean };
     }
 }

--- a/packages/h5p-clamav-scanner/src/ClamAVScanner.ts
+++ b/packages/h5p-clamav-scanner/src/ClamAVScanner.ts
@@ -189,6 +189,12 @@ export default class ClamAVScanner implements IFileMalwareScanner {
         }
     }
 
+    /**
+     * Scans an in-memory buffer for malware. If the underlying scanner is
+     * the clamd daemon, the buffer is streamed directly; otherwise it is
+     * written to a temporary file first, as the clamscan binary requires a
+     * file on disk.
+     */
     async scanBuffer(
         file: H5PFileBuffer
     ): Promise<{ result: MalwareScanResult; viruses?: string }> {

--- a/packages/h5p-clamav-scanner/src/ClamAVScanner.ts
+++ b/packages/h5p-clamav-scanner/src/ClamAVScanner.ts
@@ -33,8 +33,12 @@ export default class ClamAVScanner implements IFileMalwareScanner {
      * scanner asynchronously.
      * @param scanner
      * @param clamdServiceEnabled true if the resolved scanner is the clamd
-     * daemon, which supports scanning a stream directly; false if it is the
-     * clamscan binary, which requires a file on disk.
+     * daemon AND a socket/host/port connection to it was actually
+     * configured, which together are required for scanning a stream
+     * directly; false if it is the clamscan binary, or a clamdscan that
+     * would fall back to shelling out to the local binary because no
+     * daemon connection was configured, both of which require a file on
+     * disk.
      */
     private constructor(
         private scanner: NodeClam,
@@ -93,9 +97,33 @@ export default class ClamAVScanner implements IFileMalwareScanner {
         // found). Reading that resolved value back instead of re-deriving it
         // from the input options ourselves means we never get out of sync
         // with clamscan's own fallback logic.
+        //
+        // Note: clamscan's own default `this.scanner` is 'clamdscan' even
+        // when no socket/host/port was configured at all (it then shells out
+        // to the local clamdscan binary instead of talking to a daemon). In
+        // that case `scanStream` is not usable (it requires an actual
+        // socket/host/port connection), so we additionally require that a
+        // daemon connection was actually configured before treating the
+        // scanner as stream-capable.
+        const resolvedSettings = (
+            clamScan as unknown as {
+                settings: {
+                    clamdscan: {
+                        host?: false | string;
+                        port?: false | number;
+                        socket?: false | string;
+                    };
+                };
+            }
+        ).settings;
         const clamdServiceEnabled =
             (clamScan as unknown as { scanner: 'clamdscan' | 'clamscan' })
-                .scanner === 'clamdscan';
+                .scanner === 'clamdscan' &&
+            !!(
+                resolvedSettings.clamdscan.socket ||
+                resolvedSettings.clamdscan.port ||
+                resolvedSettings.clamdscan.host
+            );
 
         return new ClamAVScanner(clamScan, { clamdServiceEnabled });
     }

--- a/packages/h5p-clamav-scanner/test/ClamAVScanner.test.ts
+++ b/packages/h5p-clamav-scanner/test/ClamAVScanner.test.ts
@@ -1,8 +1,21 @@
+import { readFile, readdir } from 'fs/promises';
+import { tmpdir } from 'os';
 import path from 'path';
 
-import { MalwareScanResult } from '@lumieducation/h5p-server';
+import { H5PFileBuffer, MalwareScanResult } from '@lumieducation/h5p-server';
 
 import ClamAVScanner from '../src/ClamAVScanner';
+
+const createFileBuffer = (
+    filePath: string,
+    data: Buffer,
+    name?: string
+): H5PFileBuffer => ({
+    data,
+    mimetype: '',
+    name: name ?? path.basename(filePath),
+    size: data.length
+});
 
 describe('ClamAVScanner', () => {
     it('initializes ClamAV scanner', async () => {
@@ -10,28 +23,339 @@ describe('ClamAVScanner', () => {
         expect(clamAVScanner).toBeInstanceOf(ClamAVScanner);
     });
 
-    it('reports "Clean" for uninfected files', async () => {
-        const clamAVScanner = await ClamAVScanner.create();
-        await expect(
-            clamAVScanner.scan(path.resolve(__dirname, 'no-virus.txt'))
-        ).resolves.toMatchObject({ result: MalwareScanResult.Clean });
-    });
+    describe('scan files', () => {
+        it('reports "Clean" for uninfected files', async () => {
+            const clamAVScanner = await ClamAVScanner.create();
+            const filePath = path.resolve(__dirname, 'no-virus.txt');
+            await expect(clamAVScanner.scan(filePath)).resolves.toMatchObject({
+                result: MalwareScanResult.Clean
+            });
+        });
 
-    it('reports "MalwareFound" for infected files', async () => {
-        const clamAVScanner = await ClamAVScanner.create();
-        await expect(
-            clamAVScanner.scan(path.resolve(__dirname, 'eicar.txt'))
-        ).resolves.toMatchObject({
-            result: MalwareScanResult.MalwareFound,
-            viruses: expect.stringMatching(
-                /(^Win\.Test\.EICAR_HDB-1$)|(^Eicar-Test-Signature$)/
-            )
+        it('reports "MalwareFound" for infected files', async () => {
+            const clamAVScanner = await ClamAVScanner.create();
+            const filePath = path.resolve(__dirname, 'eicar.txt');
+            await expect(clamAVScanner.scan(filePath)).resolves.toMatchObject({
+                result: MalwareScanResult.MalwareFound,
+                viruses: expect.stringMatching(
+                    /(^Win\.Test\.EICAR_HDB-1$)|(^Eicar-Test-Signature$)/
+                )
+            });
+        });
+        it("doesn't break if it is set to non-existent file", async () => {
+            const clamAVScanner = await ClamAVScanner.create();
+            const filePath = path.resolve(__dirname, 'doesntexist.txt');
+            await expect(clamAVScanner.scan(filePath)).resolves.toMatchObject({
+                result: MalwareScanResult.NotScanned
+            });
         });
     });
-    it("doesn't break if it is set to non-existent file", async () => {
-        const clamAVScanner = await ClamAVScanner.create();
-        await expect(
-            clamAVScanner.scan(path.resolve(__dirname, 'doesntexist.txt'))
-        ).resolves.toMatchObject({ result: MalwareScanResult.NotScanned });
+
+    describe('scan buffers using ClamAV binary', () => {
+        it('reports "Clean" for uninfected buffers', async () => {
+            const clamAVScanner = await ClamAVScanner.create();
+            const filePath = path.resolve(__dirname, 'no-virus.txt');
+            const data = await readFile(filePath);
+            const file = createFileBuffer(filePath, data);
+            await expect(clamAVScanner.scanBuffer(file)).resolves.toMatchObject(
+                {
+                    result: MalwareScanResult.Clean
+                }
+            );
+        });
+        it('reports "MalwareFound" for infected buffers', async () => {
+            const clamAVScanner = await ClamAVScanner.create();
+            const filePath = path.resolve(__dirname, 'eicar.txt');
+            const data = await readFile(filePath);
+            const file = createFileBuffer(filePath, data);
+            await expect(clamAVScanner.scanBuffer(file)).resolves.toMatchObject(
+                {
+                    result: MalwareScanResult.MalwareFound,
+                    viruses: 'Eicar-Test-Signature'
+                }
+            );
+        });
+        it("doesn't break if it is an empty buffer", async () => {
+            const clamAVScanner = await ClamAVScanner.create();
+            const file = createFileBuffer('empty.txt', Buffer.alloc(0));
+            // An empty buffer is not infected, so it is scanned
+            // successfully and reported as clean rather than failing.
+            await expect(clamAVScanner.scanBuffer(file)).resolves.toMatchObject(
+                {
+                    result: MalwareScanResult.Clean
+                }
+            );
+        });
+
+        it('cleans up temporary files after scanning', async () => {
+            const clamAVScanner = await ClamAVScanner.create();
+            const filePath = path.resolve(__dirname, 'no-virus.txt');
+            const data = await readFile(filePath);
+            const file = createFileBuffer(filePath, data);
+
+            // Get temp directories before scan
+            const tmpDirPath = tmpdir();
+            const beforeScan = await readdir(tmpDirPath);
+
+            // Perform scan
+            await clamAVScanner.scanBuffer(file);
+
+            // Get temp directories after scan
+            const afterScan = await readdir(tmpDirPath);
+
+            // No new temporary files/directories should remain
+            const newEntries = afterScan.filter(
+                (name) => !beforeScan.includes(name)
+            );
+            expect(newEntries.length).toBe(0);
+        });
+
+        it('cleans up temporary files after multiple sequential scans', async () => {
+            const clamAVScanner = await ClamAVScanner.create();
+            const filePath = path.resolve(__dirname, 'no-virus.txt');
+            const data = await readFile(filePath);
+
+            // Get temp directories before scans
+            const tmpDirPath = tmpdir();
+            const beforeScan = await readdir(tmpDirPath);
+
+            // Perform multiple scans
+            for (let i = 0; i < 3; i++) {
+                const file = createFileBuffer(`test-file-${i}.txt`, data);
+                // eslint-disable-next-line no-await-in-loop
+                await clamAVScanner.scanBuffer(file);
+            }
+
+            // Get temp directories after scans
+            const afterScan = await readdir(tmpDirPath);
+
+            // No new temporary files/directories should remain
+            const newEntries = afterScan.filter(
+                (name) => !beforeScan.includes(name)
+            );
+            expect(newEntries.length).toBe(0);
+        });
+
+        it('cleans up temporary files even when virus is found', async () => {
+            const clamAVScanner = await ClamAVScanner.create();
+            const filePath = path.resolve(__dirname, 'eicar.txt');
+            const data = await readFile(filePath);
+            const file = createFileBuffer(filePath, data);
+
+            // Get temp directories before scan
+            const tmpDirPath = tmpdir();
+            const beforeScan = await readdir(tmpDirPath);
+
+            // Perform scan (should find virus)
+            const result = await clamAVScanner.scanBuffer(file);
+            expect(result.result).toBe(MalwareScanResult.MalwareFound);
+
+            // Get temp directories after scan
+            const afterScan = await readdir(tmpDirPath);
+
+            // No new temporary files/directories should remain
+            const newEntries = afterScan.filter(
+                (name) => !beforeScan.includes(name)
+            );
+            expect(newEntries.length).toBe(0);
+        });
+
+        it('sanitizes filenames with path traversal attempts', async () => {
+            const clamAVScanner = await ClamAVScanner.create();
+            const filePath = path.resolve(__dirname, 'no-virus.txt');
+            const data = await readFile(filePath);
+
+            // Create a file with a path traversal attempt in the name
+            const file = createFileBuffer(
+                filePath,
+                data,
+                '../../../etc/passwd'
+            );
+
+            // Should not throw and should scan successfully
+            const result = await clamAVScanner.scanBuffer(file);
+            expect(result.result).toBe(MalwareScanResult.Clean);
+        });
+
+        it('handles filenames with multiple path separators', async () => {
+            const clamAVScanner = await ClamAVScanner.create();
+            const filePath = path.resolve(__dirname, 'no-virus.txt');
+            const data = await readFile(filePath);
+
+            // Create a file with path separators in the name
+            const file = createFileBuffer(
+                filePath,
+                data,
+                'some/nested/path/file.txt'
+            );
+
+            // Should not throw and should scan successfully
+            const result = await clamAVScanner.scanBuffer(file);
+            expect(result.result).toBe(MalwareScanResult.Clean);
+        });
+
+        it('uses fallback filename when file.name is empty', async () => {
+            const clamAVScanner = await ClamAVScanner.create();
+            const filePath = path.resolve(__dirname, 'no-virus.txt');
+            const data = await readFile(filePath);
+
+            // Create a file with an empty name
+            const file = createFileBuffer(filePath, data, '');
+
+            // Should not throw and should scan successfully
+            const result = await clamAVScanner.scanBuffer(file);
+            expect(result.result).toBe(MalwareScanResult.Clean);
+        });
+    });
+
+    // These tests require a running ClamAV daemon and are skipped if no host/port config is provided
+    const clamdHost = process.env.CLAMDSCAN_HOST || 'localhost';
+    const clamdPort = process.env.CLAMDSCAN_PORT
+        ? Number(process.env.CLAMDSCAN_PORT)
+        : 3310;
+    const describeClamD =
+        process.env.CLAMDSCAN_HOST || process.env.CLAMDSCAN_PORT
+            ? describe
+            : describe.skip;
+
+    describeClamD('scan buffers using ClamAV daemon', () => {
+        it('reports "Clean" for uninfected buffers', async () => {
+            const clamAVScanner = await ClamAVScanner.create({
+                clamdscan: { host: clamdHost, port: clamdPort }
+            });
+            const filePath = path.resolve(__dirname, 'no-virus.txt');
+            const data = await readFile(filePath);
+            const file = createFileBuffer(filePath, data);
+            await expect(clamAVScanner.scanBuffer(file)).resolves.toMatchObject(
+                {
+                    result: MalwareScanResult.Clean
+                }
+            );
+        });
+        it('reports "MalwareFound" for infected buffers', async () => {
+            const clamAVScanner = await ClamAVScanner.create({
+                clamdscan: { host: clamdHost, port: clamdPort }
+            });
+            const filePath = path.resolve(__dirname, 'eicar.txt');
+            const data = await readFile(filePath);
+            const file = createFileBuffer(filePath, data);
+            await expect(clamAVScanner.scanBuffer(file)).resolves.toMatchObject(
+                {
+                    result: MalwareScanResult.MalwareFound,
+                    viruses: 'Eicar-Test-Signature'
+                }
+            );
+        });
+        it("doesn't break if it is an empty buffer", async () => {
+            const clamAVScanner = await ClamAVScanner.create({
+                clamdscan: { host: clamdHost, port: clamdPort }
+            });
+            const file = createFileBuffer('empty.txt', Buffer.alloc(0));
+            // An empty buffer is not infected, so it is scanned
+            // successfully and reported as clean rather than failing.
+            await expect(clamAVScanner.scanBuffer(file)).resolves.toMatchObject(
+                {
+                    result: MalwareScanResult.Clean
+                }
+            );
+        });
+    });
+
+    describe('clamdServiceEnabled logic', () => {
+        it('uses temp file scanning when preference is clamscan', async () => {
+            // When preference is 'clamscan', the resolved scanner is
+            // 'clamscan', so buffer scanning uses the temp-file strategy
+            const clamAVScanner = await ClamAVScanner.create({
+                preference: 'clamscan'
+            });
+            const filePath = path.resolve(__dirname, 'no-virus.txt');
+            const data = await readFile(filePath);
+            const file = createFileBuffer(filePath, data);
+
+            await expect(clamAVScanner.scanBuffer(file)).resolves.toMatchObject(
+                {
+                    result: MalwareScanResult.Clean
+                }
+            );
+        });
+
+        it('uses temp file scanning when no daemon config is provided', async () => {
+            // Without socket/port/host, the resolved scanner falls back to
+            // the clamscan binary
+            const clamAVScanner = await ClamAVScanner.create();
+            const filePath = path.resolve(__dirname, 'no-virus.txt');
+            const data = await readFile(filePath);
+            const file = createFileBuffer(filePath, data);
+
+            await expect(clamAVScanner.scanBuffer(file)).resolves.toMatchObject(
+                {
+                    result: MalwareScanResult.Clean
+                }
+            );
+        });
+
+        describeClamD('when a clamd daemon is reachable', () => {
+            it('uses stream scanning even when preference is left at its default', async () => {
+                // clamscan's own default preference is 'clamdscan', and
+                // ClamAVScanner now reads back the resolved scanner
+                // instead of re-deriving it from the input options, so
+                // this works without explicitly setting `preference`.
+                const clamAVScanner = await ClamAVScanner.create({
+                    clamdscan: { host: clamdHost, port: clamdPort }
+                });
+                const filePath = path.resolve(__dirname, 'no-virus.txt');
+                const data = await readFile(filePath);
+                const file = createFileBuffer(filePath, data);
+
+                await expect(
+                    clamAVScanner.scanBuffer(file)
+                ).resolves.toMatchObject({
+                    result: MalwareScanResult.Clean
+                });
+            });
+        });
+    });
+
+    describe('scan with string path input', () => {
+        it('reports "Clean" for uninfected files when passed as string path', async () => {
+            const clamAVScanner = await ClamAVScanner.create();
+            const filePath = path.resolve(__dirname, 'no-virus.txt');
+
+            await expect(clamAVScanner.scan(filePath)).resolves.toMatchObject({
+                result: MalwareScanResult.Clean
+            });
+        });
+
+        it('reports "MalwareFound" for infected files when passed as string path', async () => {
+            const clamAVScanner = await ClamAVScanner.create();
+            const filePath = path.resolve(__dirname, 'eicar.txt');
+
+            await expect(clamAVScanner.scan(filePath)).resolves.toMatchObject({
+                result: MalwareScanResult.MalwareFound,
+                viruses: expect.stringMatching(
+                    /(^Win\.Test\.EICAR_HDB-1$)|(^Eicar-Test-Signature$)/
+                )
+            });
+        });
+
+        it('reports "NotScanned" for non-existent files when passed as string path', async () => {
+            const clamAVScanner = await ClamAVScanner.create();
+            const filePath = path.resolve(__dirname, 'doesntexist.txt');
+
+            await expect(clamAVScanner.scan(filePath)).resolves.toMatchObject({
+                result: MalwareScanResult.NotScanned
+            });
+        });
+
+        it('normalizes string path to extract filename correctly', async () => {
+            const clamAVScanner = await ClamAVScanner.create();
+            // Use an absolute path with multiple directory components
+            const filePath = path.resolve(__dirname, 'no-virus.txt');
+
+            // Should work correctly - the normalization extracts basename for logging
+            await expect(clamAVScanner.scan(filePath)).resolves.toMatchObject({
+                result: MalwareScanResult.Clean
+            });
+        });
     });
 });

--- a/packages/h5p-express/src/LibraryAdministrationRouter/LibraryAdministrationController.ts
+++ b/packages/h5p-express/src/LibraryAdministrationRouter/LibraryAdministrationController.ts
@@ -3,6 +3,7 @@ import * as express from 'express';
 import {
     H5PEditor,
     H5pError,
+    H5PFile,
     IInstalledLibrary,
     ILibraryAdministrationOverviewItem,
     LibraryAdministration
@@ -109,13 +110,7 @@ export default class LibraryAdministrationExpressController {
     public postLibraries = async (
         req: express.Request & {
             files: {
-                file: {
-                    data?: Buffer;
-                    mimetype: string;
-                    name: string;
-                    size: number;
-                    tempFilePath?: string;
-                };
+                file: H5PFile;
             };
         },
         res: express.Response<{ installed: number; updated: number }>

--- a/packages/h5p-express/src/expressTypes.ts
+++ b/packages/h5p-express/src/expressTypes.ts
@@ -1,6 +1,6 @@
 import { Request } from 'express';
 
-import { IUser } from '@lumieducation/h5p-server';
+import { H5PFile, IUser } from '@lumieducation/h5p-server';
 
 export interface IRequestWithLanguage extends Request {
     language: string;
@@ -12,20 +12,8 @@ export interface IRequestWithUser extends Request {
 export interface IActionRequest extends IRequestWithUser {
     files:
         | {
-              file: {
-                  data?: Buffer;
-                  mimetype: string;
-                  name: string;
-                  size: number;
-                  tempFilePath?: string;
-              };
-              h5p: {
-                  data?: Buffer;
-                  mimetype: string;
-                  name: string;
-                  size: number;
-                  tempFilePath?: string;
-              };
+              file: H5PFile;
+              h5p: H5PFile;
           }
         | any;
 }

--- a/packages/h5p-express/test/H5PAjaxExpressRouter.test.ts
+++ b/packages/h5p-express/test/H5PAjaxExpressRouter.test.ts
@@ -3,16 +3,16 @@ import AxiosMockAdapter from 'axios-mock-adapter';
 import bodyParser from 'body-parser';
 import express from 'express';
 import fileUpload from 'express-fileupload';
+import { createReadStream } from 'fs';
+import { readFile } from 'fs/promises';
 import path from 'path';
 import supertest from 'supertest';
 import { dir } from 'tmp-promise';
-import { readFile } from 'fs/promises';
-import { createReadStream } from 'fs';
 
 import * as H5P from '@lumieducation/h5p-server';
 
-import User from './User';
 import H5PAjaxExpressRouter from '../src/H5PAjaxRouter/H5PAjaxExpressRouter';
+import User from './User';
 
 const axiosMock = new AxiosMockAdapter(axios);
 interface RequestEx extends express.Request {

--- a/packages/h5p-server/src/ContentStorer.ts
+++ b/packages/h5p-server/src/ContentStorer.ts
@@ -1,14 +1,17 @@
-import path from 'path';
-import { getAllFiles } from './helpers/getAllFiles';
-import { Stream } from 'stream';
-import { rm, access, readFile } from 'fs/promises';
 import { createReadStream } from 'fs';
+import { access, readFile, rm } from 'fs/promises';
+import path from 'path';
+import { Stream } from 'stream';
+import { getAllFiles } from './helpers/getAllFiles';
 
 import { ContentFileScanner, IFileReference } from './ContentFileScanner';
 import { validateFileContent } from './contentFileValidation';
 import ContentManager from './ContentManager';
+import generateFilename from './helpers/FilenameGenerator';
+import H5pError from './helpers/H5pError';
 import Logger from './helpers/Logger';
 import LibraryManager from './LibraryManager';
+import SemanticsEnforcer from './SemanticsEnforcer';
 import TemporaryFileManager from './TemporaryFileManager';
 import {
     ContentId,
@@ -21,9 +24,6 @@ import {
     IUser,
     MalwareScanResult
 } from './types';
-import generateFilename from './helpers/FilenameGenerator';
-import SemanticsEnforcer from './SemanticsEnforcer';
-import H5pError from './helpers/H5pError';
 
 const log = new Logger('ContentStorer');
 

--- a/packages/h5p-server/src/H5PAjaxEndpoint.ts
+++ b/packages/h5p-server/src/H5PAjaxEndpoint.ts
@@ -1,22 +1,23 @@
-import { Writable, Readable } from 'stream';
 import { lookup as mimeLookup } from 'mime-types';
+import { Readable, Writable } from 'stream';
 
-import {
-    IUser,
-    ILibraryDetailedDataForClient,
-    IHubInfo,
-    ContentId,
-    IContentMetadata,
-    ContentParameters,
-    ILibraryOverviewForClient,
-    IFileStats,
-    IAjaxResponse
-} from './types';
 import H5PEditor from './H5PEditor';
-import H5pError from './helpers/H5pError';
 import AjaxSuccessResponse from './helpers/AjaxSuccessResponse';
+import H5pError from './helpers/H5pError';
 import LibraryName from './LibraryName';
 import SemanticsEnforcer from './SemanticsEnforcer';
+import {
+    ContentId,
+    ContentParameters,
+    H5PFile,
+    IAjaxResponse,
+    IContentMetadata,
+    IFileStats,
+    IHubInfo,
+    ILibraryDetailedDataForClient,
+    ILibraryOverviewForClient,
+    IUser
+} from './types';
 
 /**
  * Each method in this class corresponds to a route that is called by the H5P
@@ -463,25 +464,13 @@ export default class H5PAjaxEndpoint {
             | { libraryParameters: string },
         language?: string,
         user?: IUser,
-        filesFile?: {
-            data?: Buffer;
-            mimetype: string;
-            name: string;
-            size: number;
-            tempFilePath?: string;
-        },
+        filesFile?: H5PFile,
         id?: string,
         translate?: (
             stringId: string,
             replacements: { [key: string]: any }
         ) => string,
-        libraryUploadFile?: {
-            data?: Buffer;
-            mimetype: string;
-            name: string;
-            size: number;
-            tempFilePath?: string;
-        },
+        libraryUploadFile?: H5PFile,
         hubId?: string
     ): Promise<
         | AjaxSuccessResponse

--- a/packages/h5p-server/src/H5PEditor.ts
+++ b/packages/h5p-server/src/H5PEditor.ts
@@ -22,7 +22,7 @@ import defaultRenderer from './renderers/default';
 
 import ContentUserDataManager from './ContentUserDataManager';
 
-import { validateContent } from './contentFileValidation';
+import { hasBufferData, validateContent } from './contentFileValidation';
 import ContentHub from './ContentHub';
 import ContentManager from './ContentManager';
 import { ContentMetadata } from './ContentMetadata';
@@ -709,10 +709,9 @@ export default class H5PEditor {
 
         try {
             if (file.mimetype.startsWith('image/')) {
-                const imageBuffer =
-                    file.data?.length > 0
-                        ? file.data
-                        : readFileSync(file.tempFilePath);
+                const imageBuffer = hasBufferData(file)
+                    ? file.data
+                    : readFileSync(file.tempFilePath);
                 const result = probeImageSize.sync(imageBuffer);
                 if (!result) {
                     throw new Error('Unsupported or corrupt image format');
@@ -766,7 +765,7 @@ export default class H5PEditor {
         cleanFilename = this.addDirectoryByMimetype(cleanFilename);
 
         let dataStream;
-        if (file.data?.length > 0) {
+        if (hasBufferData(file)) {
             dataStream = new PassThrough();
             dataStream.end(file.data);
         } else if (file.tempFilePath) {
@@ -1525,7 +1524,10 @@ export default class H5PEditor {
 
     /**
      * Sanitizes an uploaded file with a single sanitizer, using whichever
-     * mode the file was uploaded in (temporary file or in-memory buffer). See
+     * mode the file was uploaded in (temporary file or in-memory buffer).
+     * `file.data` is treated as authoritative whenever {@link hasBufferData}
+     * says so, matching the precedence used everywhere else a file is read
+     * (validation, malware scanning, persistence) — see
      * {@link scanForMalware} for the reasoning behind the fallback to a
      * temporary file for sanitizers that don't implement `sanitizeBuffer`.
      */
@@ -1533,32 +1535,40 @@ export default class H5PEditor {
         sanitizer: IFileSanitizer,
         file: H5PFile
     ): Promise<FileSanitizerResult> {
-        if (file.tempFilePath) {
-            return sanitizer.sanitize(file.tempFilePath);
-        }
-        if (sanitizer.sanitizeBuffer) {
-            return sanitizer.sanitizeBuffer(file as H5PFileBuffer);
-        }
-        return this.withBufferAsTempFile(
-            file.data,
-            file.name,
-            async (tempFilePath) => {
-                const result = await sanitizer.sanitize(tempFilePath);
-                file.data = await readFile(tempFilePath);
-                return result;
+        if (hasBufferData(file)) {
+            if (sanitizer.sanitizeBuffer) {
+                return sanitizer.sanitizeBuffer(file as H5PFileBuffer);
             }
-        );
+            return this.withBufferAsTempFile(
+                file.data,
+                file.name,
+                async (tempFilePath) => {
+                    const result = await sanitizer.sanitize(
+                        tempFilePath,
+                        file.name
+                    );
+                    file.data = await readFile(tempFilePath);
+                    return result;
+                }
+            );
+        }
+        if (file.tempFilePath) {
+            return sanitizer.sanitize(file.tempFilePath, file.name);
+        }
+        throw new Error('Either file.data or file.tempFilePath must be used!');
     }
 
     /**
      * Runs all configured malware scanners over an uploaded file.
      *
-     * For buffer-only uploads (no `tempFilePath`), scanners that implement
-     * `scanBuffer` use the buffer directly. If one or more scanners only
-     * implement the path-based `scan` method, a single shared temporary file
-     * is written up front and reused by all of them, instead of each
-     * scanner independently writing its own copy of the same buffer to
-     * disk.
+     * `file.data` is treated as authoritative whenever {@link hasBufferData}
+     * says so (matching the precedence used everywhere else a file is read),
+     * even if a `tempFilePath` is also present. For such uploads, scanners
+     * that implement `scanBuffer` use the buffer directly. If one or more
+     * scanners only implement the path-based `scan` method, a single shared
+     * temporary file is written up front from `file.data` and reused by all
+     * of them, instead of each scanner independently writing its own copy of
+     * the same buffer to disk.
      */
     private async scanAllForMalware(file: H5PFile): Promise<
         Array<{
@@ -1586,9 +1596,9 @@ export default class H5PEditor {
                 }))
             );
 
-        if (file.tempFilePath || !file.data) {
-            // Nothing to share: either a temp file already exists, or there
-            // is no buffer to fall back to.
+        if (!hasBufferData(file)) {
+            // Nothing to share: either there is no authoritative buffer, or
+            // a tempFilePath is the authoritative representation.
             return runAll(file);
         }
 
@@ -1600,14 +1610,22 @@ export default class H5PEditor {
         }
 
         return this.withBufferAsTempFile(file.data, file.name, (tempFilePath) =>
-            runAll({ ...file, tempFilePath })
+            // `data` is stripped here so that scanForMalware's
+            // hasBufferData-based precedence (data wins over tempFilePath)
+            // doesn't undo the sharing we just set up: this tempFilePath was
+            // written from this exact `file.data`, so both are equivalent,
+            // but the path-based scanners must be pointed at the one shared
+            // file rather than each writing their own copy of `data` again.
+            runAll({ ...file, data: undefined, tempFilePath })
         );
     }
 
     /**
      * Scans an uploaded file for malware with a single scanner, using
      * whichever mode the file was uploaded in (temporary file or in-memory
-     * buffer).
+     * buffer). `file.data` is treated as authoritative whenever
+     * {@link hasBufferData} says so, even if a `tempFilePath` is also
+     * present.
      *
      * Scanners are never handed a buffer unless they explicitly opted in by
      * implementing `scanBuffer`: `IFileMalwareScanner.scan(file: string)` is
@@ -1620,15 +1638,20 @@ export default class H5PEditor {
         scanner: IFileMalwareScanner,
         file: H5PFile
     ): Promise<{ result: MalwareScanResult; viruses?: string }> {
+        if (hasBufferData(file)) {
+            if (scanner.scanBuffer) {
+                return scanner.scanBuffer(file as H5PFileBuffer);
+            }
+            return this.withBufferAsTempFile(
+                file.data,
+                file.name,
+                (tempFilePath) => scanner.scan(tempFilePath)
+            );
+        }
         if (file.tempFilePath) {
             return scanner.scan(file.tempFilePath);
         }
-        if (scanner.scanBuffer) {
-            return scanner.scanBuffer(file as H5PFileBuffer);
-        }
-        return this.withBufferAsTempFile(file.data, file.name, (tempFilePath) =>
-            scanner.scan(tempFilePath)
-        );
+        throw new Error('Either file.data or file.tempFilePath must be used!');
     }
 
     private validateLanguageCode(languageCode: string): void {

--- a/packages/h5p-server/src/H5PEditor.ts
+++ b/packages/h5p-server/src/H5PEditor.ts
@@ -1,44 +1,52 @@
-import { withFile, file as createTempFile, FileResult } from 'tmp-promise';
-import { PassThrough, Writable, Readable } from 'stream';
 import Ajv, { ValidateFunction } from 'ajv';
 import ajvKeywords from 'ajv-keywords';
+import { createReadStream, createWriteStream, readFileSync } from 'fs';
+import { readFile, rm, writeFile } from 'fs/promises';
 import probeImageSize from 'probe-image-size';
 import mimeTypes from 'mime-types';
 import path from 'path';
 import promisepipe from 'promisepipe';
-import { rm } from 'fs/promises';
-import { createReadStream, createWriteStream, readFileSync } from 'fs';
+import { PassThrough, Readable, Writable } from 'stream';
+import { file as createTempFile, FileResult, withFile } from 'tmp-promise';
 
 import defaultClientStrings from '../assets/defaultClientStrings.json';
 import defaultCopyrightSemantics from '../assets/defaultCopyrightSemantics.json';
 import defaultMetadataSemantics from '../assets/defaultMetadataSemantics.json';
+import supportedLanguageList from '../assets/editorLanguages.json';
 import defaultClientLanguageFile from '../assets/translations/client/en.json';
 import defaultCopyrightSemanticsLanguageFile from '../assets/translations/copyright-semantics/en.json';
 import defaultMetadataSemanticsLanguageFile from '../assets/translations/metadata-semantics/en.json';
+import variantEquivalents from '../assets/variantEquivalents.json';
 import editorAssetList from './editorAssetList.json';
 import defaultRenderer from './renderers/default';
-import supportedLanguageList from '../assets/editorLanguages.json';
-import variantEquivalents from '../assets/variantEquivalents.json';
 
 import ContentUserDataManager from './ContentUserDataManager';
 
-import { validateFileContent } from './contentFileValidation';
+import { validateContent } from './contentFileValidation';
+import ContentHub from './ContentHub';
 import ContentManager from './ContentManager';
 import { ContentMetadata } from './ContentMetadata';
 import ContentStorer from './ContentStorer';
 import ContentTypeCache from './ContentTypeCache';
 import ContentTypeInformationRepository from './ContentTypeInformationRepository';
+import DependencyGetter from './DependencyGetter';
+import { downloadFile } from './helpers/downloadFile';
 import H5pError from './helpers/H5pError';
 import Logger from './helpers/Logger';
+import SimpleTranslator from './helpers/SimpleTranslator';
+import { LaissezFairePermissionSystem } from './implementation/LaissezFairePermissionSystem';
 import LibraryManager from './LibraryManager';
 import LibraryName from './LibraryName';
 import PackageExporter from './PackageExporter';
 import PackageImporter from './PackageImporter';
+import SemanticsLocalizer from './SemanticsLocalizer';
 import TemporaryFileManager from './TemporaryFileManager';
 import {
     ContentId,
     ContentParameters,
     FileSanitizerResult,
+    H5PFile,
+    H5PFileBuffer,
     IAssets,
     IContentMetadata,
     IContentStorage,
@@ -66,12 +74,6 @@ import {
     MalwareScanResult
 } from './types';
 import UrlGenerator from './UrlGenerator';
-import SemanticsLocalizer from './SemanticsLocalizer';
-import SimpleTranslator from './helpers/SimpleTranslator';
-import DependencyGetter from './DependencyGetter';
-import ContentHub from './ContentHub';
-import { downloadFile } from './helpers/downloadFile';
-import { LaissezFairePermissionSystem } from './implementation/LaissezFairePermissionSystem';
 
 const log = new Logger('H5PEditor');
 
@@ -629,13 +631,7 @@ export default class H5PEditor {
     public async saveContentFile(
         contentId: ContentId,
         field: ISemanticsEntry,
-        file: {
-            data?: Buffer;
-            mimetype: string;
-            name: string;
-            size: number;
-            tempFilePath?: string;
-        },
+        file: H5PFile,
         user: IUser
     ): Promise<{
         height?: number;
@@ -654,24 +650,25 @@ export default class H5PEditor {
             (field.type === 'video' && !file.mimetype.startsWith('video/')) ||
             (field.type === 'audio' && !file.mimetype.startsWith('audio/'))
         ) {
+            log.debug(
+                `Invalid file upload: field type is ${field.type} but mimetype is ${file.mimetype}`
+            );
             throw new H5pError('upload-validation-error', {}, 400);
         }
 
-        if (
-            (this.malwareScanners.length > 0 ||
-                this.fileSanitizers.length > 0) &&
-            !file.tempFilePath
-        ) {
-            throw new Error(
-                "Inconsistent setup of file upload middleware and malware/sanitization: You've set up a malware scanner and/or file sanitizer and have configured your file upload middleware to stream data to H5PEditor.saveContentFile. If you want to use malware scanners or file sanitization you must use temporary files!"
+        // Ensure we have either a temporary file path or in-memory data to work with
+        if (!file.tempFilePath && !file.data) {
+            log.debug(
+                `Invalid file upload: no data or tempFilePath provided for file ${file.name}`
             );
+            throw new H5pError('upload-validation-error', {}, 400);
         }
 
         // Scan for malware
         const malwareScanResults = await Promise.all(
             this.malwareScanners.map(async (scanner) => {
                 return {
-                    ...(await scanner.scan(file.tempFilePath)),
+                    ...(await this.scanForMalware(scanner, file)),
                     scannerName: scanner.name
                 };
             })
@@ -687,23 +684,23 @@ export default class H5PEditor {
             }
             // Remove the file from the temporary storage to make sure it can't
             // be accessed anymore
-            await rm(file.tempFilePath, { force: true });
+            if (file.tempFilePath) {
+                await rm(file.tempFilePath, { force: true });
+            }
 
             // TODO: log to audit log
             throw new H5pError('upload-malware-found', {}, 400);
         }
 
         // Validate that the file content matches the claimed extension
-        if (file.tempFilePath) {
-            await validateFileContent(file.tempFilePath);
-        }
+        await validateContent(file);
 
         // Sanitize the file if possible
         for (const sanitizer of this.fileSanitizers) {
             try {
                 // Must be run in sequence and can't be parallelized.
                 // eslint-disable-next-line no-await-in-loop
-                const result = await sanitizer.sanitize(file.tempFilePath);
+                const result = await this.sanitizeFile(sanitizer, file);
                 if (result == FileSanitizerResult.Sanitized) {
                     log.debug(
                         'Sanitized file',
@@ -1533,6 +1530,63 @@ export default class H5PEditor {
         return resolve(dependencies.shift());
     }
 
+    /**
+     * Sanitizes an uploaded file with a single sanitizer, using whichever
+     * mode the file was uploaded in (temporary file or in-memory buffer). See
+     * {@link scanForMalware} for the reasoning behind the fallback to a
+     * temporary file for sanitizers that don't implement `sanitizeBuffer`.
+     */
+    private async sanitizeFile(
+        sanitizer: IFileSanitizer,
+        file: H5PFile
+    ): Promise<FileSanitizerResult> {
+        if (file.tempFilePath) {
+            return sanitizer.sanitize(file.tempFilePath);
+        }
+        if (sanitizer.sanitizeBuffer) {
+            const fileBuffer = file as H5PFileBuffer;
+            const result = await sanitizer.sanitizeBuffer(fileBuffer);
+            file.data = fileBuffer.data;
+            return result;
+        }
+        return this.withBufferAsTempFile(
+            file.data,
+            file.name,
+            async (tempFilePath) => {
+                const result = await sanitizer.sanitize(tempFilePath);
+                file.data = await readFile(tempFilePath);
+                return result;
+            }
+        );
+    }
+
+    /**
+     * Scans an uploaded file for malware with a single scanner, using
+     * whichever mode the file was uploaded in (temporary file or in-memory
+     * buffer).
+     *
+     * Scanners are never handed a buffer unless they explicitly opted in by
+     * implementing `scanBuffer`: `IFileMalwareScanner.scan(file: string)` is
+     * called exactly as before for scanners that don't, so third-party
+     * scanners written against the pre-existing string-only signature keep
+     * working unmodified. If such a scanner is used with a buffer upload, we
+     * transparently write the buffer to a temporary file first.
+     */
+    private async scanForMalware(
+        scanner: IFileMalwareScanner,
+        file: H5PFile
+    ): Promise<{ result: MalwareScanResult; viruses?: string }> {
+        if (file.tempFilePath) {
+            return scanner.scan(file.tempFilePath);
+        }
+        if (scanner.scanBuffer) {
+            return scanner.scanBuffer(file as H5PFileBuffer);
+        }
+        return this.withBufferAsTempFile(file.data, file.name, (tempFilePath) =>
+            scanner.scan(tempFilePath)
+        );
+    }
+
     private validateLanguageCode(languageCode: string): void {
         // We are a bit more tolerant than the ISO standard, as there are three
         // character languages codes and country codes like 'hans' for
@@ -1540,5 +1594,26 @@ export default class H5PEditor {
         if (!/^[a-z]{2,3}(-[A-Z]{2,6})?$/i.test(languageCode)) {
             throw new Error(`Language code ${languageCode} is invalid.`);
         }
+    }
+
+    /**
+     * Writes a buffer to a short-lived temporary file, runs `callback` with
+     * its path, and guarantees the file is deleted afterwards (even if
+     * `callback` throws). Used to give buffer-based uploads to
+     * scanners/sanitizers that only implement the path-based `scan`/
+     * `sanitize` methods.
+     */
+    private async withBufferAsTempFile<T>(
+        data: Buffer,
+        fileName: string,
+        callback: (tempFilePath: string) => Promise<T>
+    ): Promise<T> {
+        return withFile(
+            async ({ path: tempFilePath }: FileResult) => {
+                await writeFile(tempFilePath, data);
+                return callback(tempFilePath);
+            },
+            { postfix: path.extname(fileName) || undefined }
+        );
     }
 }

--- a/packages/h5p-server/src/H5PEditor.ts
+++ b/packages/h5p-server/src/H5PEditor.ts
@@ -665,14 +665,7 @@ export default class H5PEditor {
         }
 
         // Scan for malware
-        const malwareScanResults = await Promise.all(
-            this.malwareScanners.map(async (scanner) => {
-                return {
-                    ...(await this.scanForMalware(scanner, file)),
-                    scannerName: scanner.name
-                };
-            })
-        );
+        const malwareScanResults = await this.scanAllForMalware(file);
         const positiveMalwareScanResults = malwareScanResults.filter(
             (result) => result.result === MalwareScanResult.MalwareFound
         );
@@ -1544,10 +1537,7 @@ export default class H5PEditor {
             return sanitizer.sanitize(file.tempFilePath);
         }
         if (sanitizer.sanitizeBuffer) {
-            const fileBuffer = file as H5PFileBuffer;
-            const result = await sanitizer.sanitizeBuffer(fileBuffer);
-            file.data = fileBuffer.data;
-            return result;
+            return sanitizer.sanitizeBuffer(file as H5PFileBuffer);
         }
         return this.withBufferAsTempFile(
             file.data,
@@ -1557,6 +1547,60 @@ export default class H5PEditor {
                 file.data = await readFile(tempFilePath);
                 return result;
             }
+        );
+    }
+
+    /**
+     * Runs all configured malware scanners over an uploaded file.
+     *
+     * For buffer-only uploads (no `tempFilePath`), scanners that implement
+     * `scanBuffer` use the buffer directly. If one or more scanners only
+     * implement the path-based `scan` method, a single shared temporary file
+     * is written up front and reused by all of them, instead of each
+     * scanner independently writing its own copy of the same buffer to
+     * disk.
+     */
+    private async scanAllForMalware(file: H5PFile): Promise<
+        Array<{
+            result: MalwareScanResult;
+            scannerName: string;
+            viruses?: string;
+        }>
+    > {
+        const runAll = (
+            fileForPathBasedScanners: H5PFile
+        ): Promise<
+            Array<{
+                result: MalwareScanResult;
+                scannerName: string;
+                viruses?: string;
+            }>
+        > =>
+            Promise.all(
+                this.malwareScanners.map(async (scanner) => ({
+                    ...(await this.scanForMalware(
+                        scanner,
+                        scanner.scanBuffer ? file : fileForPathBasedScanners
+                    )),
+                    scannerName: scanner.name
+                }))
+            );
+
+        if (file.tempFilePath || !file.data) {
+            // Nothing to share: either a temp file already exists, or there
+            // is no buffer to fall back to.
+            return runAll(file);
+        }
+
+        const needsSharedTempFile = this.malwareScanners.some(
+            (scanner) => !scanner.scanBuffer
+        );
+        if (!needsSharedTempFile) {
+            return runAll(file);
+        }
+
+        return this.withBufferAsTempFile(file.data, file.name, (tempFilePath) =>
+            runAll({ ...file, tempFilePath })
         );
     }
 

--- a/packages/h5p-server/src/LibraryManager.ts
+++ b/packages/h5p-server/src/LibraryManager.ts
@@ -1,10 +1,13 @@
+import { createReadStream } from 'fs';
+import { readFile } from 'fs/promises';
 import { Readable } from 'stream';
 import { getAllFiles } from './helpers/getAllFiles';
-import { readFile } from 'fs/promises';
-import { createReadStream } from 'fs';
 
+import variantEquivalents from '../assets/variantEquivalents.json';
 import H5pError from './helpers/H5pError';
 import Logger from './helpers/Logger';
+import TranslatorWithFallback from './helpers/TranslatorWithFallback';
+import SimpleLockProvider from './implementation/SimpleLockProvider';
 import InstalledLibrary from './InstalledLibrary';
 import LibraryName from './LibraryName';
 import {
@@ -22,9 +25,6 @@ import {
     ISemanticsEntry,
     ITranslationFunction
 } from './types';
-import TranslatorWithFallback from './helpers/TranslatorWithFallback';
-import SimpleLockProvider from './implementation/SimpleLockProvider';
-import variantEquivalents from '../assets/variantEquivalents.json';
 
 const log = new Logger('LibraryManager');
 
@@ -450,7 +450,7 @@ export default class LibraryManager {
                     'server:install-library-lock-max-time-exceeded',
                     {
                         ubername,
-                        limit: this.config.installLibraryLockTimeout.toString()
+                        limit: this.config.installLibraryLockMaxOccupationTime.toString()
                     },
                     500
                 );
@@ -844,7 +844,7 @@ export default class LibraryManager {
                     'server:install-library-lock-max-time-exceeded',
                     {
                         ubername,
-                        limit: this.config.installLibraryLockTimeout.toString()
+                        limit: this.config.installLibraryLockMaxOccupationTime.toString()
                     },
                     500
                 );

--- a/packages/h5p-server/src/contentFileValidation.ts
+++ b/packages/h5p-server/src/contentFileValidation.ts
@@ -41,7 +41,7 @@ const dangerousTextPatterns = [
  * neither data nor tempFilePath, or if content validation fails
  */
 export async function validateContent(file: H5PFile): Promise<void> {
-    if (file.data) {
+    if (file.data?.length > 0) {
         await validateBufferContent(file.data, file.name);
     } else if (file.tempFilePath) {
         await validateFileContent(file.tempFilePath);
@@ -54,10 +54,14 @@ export async function validateContent(file: H5PFile): Promise<void> {
 }
 
 /**
- * Validates that the content of a file matches its claimed extension. Uses
- * magic byte detection via magic-bytes.js to identify binary file types and
- * rejects mismatches. Also detects XML/SVG/HTML content disguised as other file
- * types, which could enable XSS attacks.
+ * Validates the content of a file. Uses magic byte detection via
+ * magic-bytes.js to identify binary file types and detects XML/SVG/HTML
+ * content disguised as other file types, which could enable XSS attacks.
+ * Content is always inspected, regardless of whether the file path carries a
+ * recognizable extension (many upload middlewares, e.g. express-fileupload's
+ * temp files, generate extensionless paths). When the path does carry an
+ * extension, it is additionally checked for a match against the detected
+ * content type.
  *
  * This validator checks all extensions in the configured content whitelist, not
  * a hardcoded set, so custom whitelist entries are also validated.
@@ -70,7 +74,7 @@ export async function validateContent(file: H5PFile): Promise<void> {
  * @param filePath absolute path to the file to validate; not suitable for user
  * input without sanitization
  * @throws H5pError with errorId 'upload-validation-error' if the file content
- * does not match its extension
+ * does not match its extension, or if it contains disguised dangerous content
  */
 export async function validateFileContent(filePath: string): Promise<void> {
     // Validate and normalize the file path to guard against malformed or
@@ -85,9 +89,6 @@ export async function validateFileContent(filePath: string): Promise<void> {
     const resolvedPath = path.resolve(filePath);
 
     const ext = path.extname(resolvedPath).toLowerCase().replace(/^\./, '');
-    if (!ext) {
-        return;
-    }
 
     const fileHandle = await open(resolvedPath, 'r');
     try {
@@ -103,32 +104,31 @@ export async function validateFileContent(filePath: string): Promise<void> {
 }
 
 /**
- * Validates that a buffer's content matches its expected file type. Inspects
- * the first 1024 bytes of the in-memory buffer directly (the same amount
- * {@link validateFileContent} reads from disk), so it never has to write the
- * (potentially large) buffer to disk just to validate it.
+ * Validates the content of a buffer. Inspects the first 1024 bytes of the
+ * in-memory buffer directly (the same amount {@link validateFileContent}
+ * reads from disk), so it never has to write the (potentially large) buffer
+ * to disk just to validate it. Content is always inspected, regardless of
+ * whether the filename carries a recognizable extension. When the filename
+ * does carry an extension, it is additionally checked for a match against
+ * the detected content type.
  *
- * @param buffer the file content to validate; must be non-empty
+ * @param buffer the file content to validate; a genuinely empty buffer is
+ * treated as valid (no-op), matching {@link validateFileContent}'s handling
+ * of empty files
  * @param filename the original filename, used to determine the extension for
  * content-type validation
- * @throws H5pError with errorId 'upload-validation-error' if the buffer is
- * empty or if the content fails validation
+ * @throws H5pError with errorId 'upload-validation-error' if the content
+ * fails validation
  */
 export async function validateBufferContent(
     buffer: Buffer,
     filename: string
 ): Promise<void> {
     if (!buffer || buffer.length === 0) {
-        log.error(
-            `Invalid buffer provided to validateBufferContent: empty or undefined`
-        );
-        throw new H5pError('upload-validation-error', {}, 400);
+        return;
     }
 
     const ext = path.extname(filename).toLowerCase().replace(/^\./, '');
-    if (!ext) {
-        return;
-    }
 
     validateContentBytes(buffer.subarray(0, 1024), ext, filename);
 }

--- a/packages/h5p-server/src/contentFileValidation.ts
+++ b/packages/h5p-server/src/contentFileValidation.ts
@@ -31,6 +31,28 @@ const dangerousTextPatterns = [
 ];
 
 /**
+ * Determines whether `file.data` should be treated as the authoritative
+ * representation of an uploaded file's content, as opposed to
+ * `file.tempFilePath`. This is shared by every code path that has to pick
+ * one of the two (validation, sanitization, malware scanning, persistence)
+ * so that they all agree on the same file content.
+ *
+ * `file.data` wins whenever it actually carries content. A defined but
+ * empty buffer (as produced by express-fileupload's `useTempFiles` mode,
+ * which always sets `data` to `Buffer.concat([])` alongside a real
+ * `tempFilePath`) is not treated as authoritative when a `tempFilePath` is
+ * also present, since the real content lives on disk in that case. A
+ * defined empty buffer with no `tempFilePath` at all (a genuine 0-byte
+ * buffer-only upload) is still treated as authoritative, since there is no
+ * fallback for it to defer to.
+ */
+export function hasBufferData(file: H5PFile): boolean {
+    return (
+        file.data !== undefined && (file.data.length > 0 || !file.tempFilePath)
+    );
+}
+
+/**
  * Validates that a file's content matches its claimed extension. Automatically
  * chooses the appropriate validation method based on whether the file data is
  * available as an in-memory buffer or as a path to a temporary file on disk.
@@ -38,13 +60,14 @@ const dangerousTextPatterns = [
  * @param file the uploaded file to validate; must have either `data` (buffer)
  * or `tempFilePath` set
  * @throws H5pError with errorId 'upload-validation-error' if the file has
- * neither data nor tempFilePath, or if content validation fails
+ * neither data nor tempFilePath, if the original filename (`file.name`) has
+ * no extension, or if content validation fails
  */
 export async function validateContent(file: H5PFile): Promise<void> {
-    if (file.data?.length > 0) {
+    if (hasBufferData(file)) {
         await validateBufferContent(file.data, file.name);
     } else if (file.tempFilePath) {
-        await validateFileContent(file.tempFilePath);
+        await validateFileContent(file.tempFilePath, file.name);
     } else {
         log.error(
             `File has no data or tempFilePath for validation: ${file.name}`
@@ -57,11 +80,14 @@ export async function validateContent(file: H5PFile): Promise<void> {
  * Validates the content of a file. Uses magic byte detection via
  * magic-bytes.js to identify binary file types and detects XML/SVG/HTML
  * content disguised as other file types, which could enable XSS attacks.
- * Content is always inspected, regardless of whether the file path carries a
- * recognizable extension (many upload middlewares, e.g. express-fileupload's
- * temp files, generate extensionless paths). When the path does carry an
- * extension, it is additionally checked for a match against the detected
- * content type.
+ *
+ * The claimed extension is always derived from the ORIGINAL filename
+ * (`originalFilename`), never from `filePath` itself: many upload
+ * middlewares (e.g. express-fileupload's temp files) generate extensionless
+ * paths, and deriving the extension from such a path would let its content
+ * skip the extension-match check entirely. A file whose original filename
+ * has no extension at all is rejected outright, since there is nothing to
+ * validate its content against.
  *
  * This validator checks all extensions in the configured content whitelist, not
  * a hardcoded set, so custom whitelist entries are also validated.
@@ -73,10 +99,18 @@ export async function validateContent(file: H5PFile): Promise<void> {
  *
  * @param filePath absolute path to the file to validate; not suitable for user
  * input without sanitization
+ * @param originalFilename optional: the original filename of the uploaded
+ * file (e.g. `H5PFile.name`), used to determine the claimed extension;
+ * defaults to `filePath` when not given, for backwards compatibility with
+ * callers that pass real in-package paths which already carry extensions
  * @throws H5pError with errorId 'upload-validation-error' if the file content
- * does not match its extension, or if it contains disguised dangerous content
+ * does not match its extension, if the original filename has no extension, or
+ * if it contains disguised dangerous content
  */
-export async function validateFileContent(filePath: string): Promise<void> {
+export async function validateFileContent(
+    filePath: string,
+    originalFilename?: string
+): Promise<void> {
     // Validate and normalize the file path to guard against malformed or
     // relative paths. All callers are expected to pass absolute paths
     // produced by trusted middleware (e.g. file-upload temp files).
@@ -88,7 +122,11 @@ export async function validateFileContent(filePath: string): Promise<void> {
     }
     const resolvedPath = path.resolve(filePath);
 
-    const ext = path.extname(resolvedPath).toLowerCase().replace(/^\./, '');
+    const ext = path
+        .extname(originalFilename ?? filePath)
+        .toLowerCase()
+        .replace(/^\./, '');
+    const label = originalFilename ?? resolvedPath;
 
     const fileHandle = await open(resolvedPath, 'r');
     try {
@@ -97,7 +135,7 @@ export async function validateFileContent(filePath: string): Promise<void> {
         if (bytesRead === 0) {
             return;
         }
-        validateContentBytes(buffer.subarray(0, bytesRead), ext, resolvedPath);
+        validateContentBytes(buffer.subarray(0, bytesRead), ext, label);
     } finally {
         await fileHandle.close();
     }
@@ -107,10 +145,9 @@ export async function validateFileContent(filePath: string): Promise<void> {
  * Validates the content of a buffer. Inspects the first 1024 bytes of the
  * in-memory buffer directly (the same amount {@link validateFileContent}
  * reads from disk), so it never has to write the (potentially large) buffer
- * to disk just to validate it. Content is always inspected, regardless of
- * whether the filename carries a recognizable extension. When the filename
- * does carry an extension, it is additionally checked for a match against
- * the detected content type.
+ * to disk just to validate it. The claimed extension is derived from
+ * `filename`; a filename with no extension is rejected outright, since there
+ * is nothing to validate the content against.
  *
  * @param buffer the file content to validate; a genuinely empty buffer is
  * treated as valid (no-op), matching {@link validateFileContent}'s handling
@@ -118,7 +155,7 @@ export async function validateFileContent(filePath: string): Promise<void> {
  * @param filename the original filename, used to determine the extension for
  * content-type validation
  * @throws H5pError with errorId 'upload-validation-error' if the content
- * fails validation
+ * fails validation, or if `filename` has no extension
  */
 export async function validateBufferContent(
     buffer: Buffer,
@@ -138,10 +175,18 @@ export async function validateBufferContent(
  * {@link validateFileContent} (reading from disk) and
  * {@link validateBufferContent} (reading from memory).
  * @param data the first bytes of the file (up to 1024)
- * @param ext the claimed extension (without leading dot), already lowercased
+ * @param ext the claimed extension (without leading dot), already lowercased;
+ * an empty string means the original filename had no extension at all
  * @param label a path or filename used only for log messages
  */
 function validateContentBytes(data: Buffer, ext: string, label: string): void {
+    if (!ext) {
+        log.info(
+            `File has no extension in its original filename. Rejecting file: ${label}`
+        );
+        throw new H5pError('upload-validation-error', {}, 400);
+    }
+
     // Detect the actual file type using magic bytes
     const detectedExtensions = filetypeextension([...data] as number[]).map(
         (e) => e.replace(/^\./, '')

--- a/packages/h5p-server/src/contentFileValidation.ts
+++ b/packages/h5p-server/src/contentFileValidation.ts
@@ -1,10 +1,10 @@
 import { open } from 'fs/promises';
-import path from 'path';
 import { filetypeextension } from 'magic-bytes.js';
 import { lookup as mimeLookup } from 'mime-types';
-
+import path from 'path';
 import H5pError from './helpers/H5pError';
 import Logger from './helpers/Logger';
+import { H5PFile } from './types';
 
 const log = new Logger('contentFileValidation');
 
@@ -29,6 +29,29 @@ const dangerousTextPatterns = [
     '<html',
     '<script'
 ];
+
+/**
+ * Validates that a file's content matches its claimed extension. Automatically
+ * chooses the appropriate validation method based on whether the file data is
+ * available as an in-memory buffer or as a path to a temporary file on disk.
+ *
+ * @param file the uploaded file to validate; must have either `data` (buffer)
+ * or `tempFilePath` set
+ * @throws H5pError with errorId 'upload-validation-error' if the file has
+ * neither data nor tempFilePath, or if content validation fails
+ */
+export async function validateContent(file: H5PFile): Promise<void> {
+    if (file.data) {
+        await validateBufferContent(file.data, file.name);
+    } else if (file.tempFilePath) {
+        await validateFileContent(file.tempFilePath);
+    } else {
+        log.error(
+            `File has no data or tempFilePath for validation: ${file.name}`
+        );
+        throw new H5pError('upload-validation-error', {}, 400);
+    }
+}
 
 /**
  * Validates that the content of a file matches its claimed extension. Uses
@@ -73,50 +96,91 @@ export async function validateFileContent(filePath: string): Promise<void> {
         if (bytesRead === 0) {
             return;
         }
-        const data = buffer.subarray(0, bytesRead);
-
-        // Detect the actual file type using magic bytes
-        const detectedExtensions = filetypeextension([...data] as number[]).map(
-            (e) => e.replace(/^\./, '')
-        );
-
-        if (detectedExtensions.length > 0) {
-            // The library detected a file type — check it matches
-            // the claimed extension
-            if (extensionMatchesDetected(ext, detectedExtensions)) {
-                // Even when the extension matches, text-based detections
-                // (e.g. a BOM causing magic-bytes to return "txt") still
-                // need the dangerous-content check. A UTF-8 BOM followed
-                // by <html>…</html> would otherwise slip through.
-                if (
-                    detectedExtensions.includes('txt') &&
-                    looksLikeXmlOrHtml(data)
-                ) {
-                    log.info(
-                        `File detected as text but contains XML/HTML content. Rejecting file: ${resolvedPath}`
-                    );
-                    throw new H5pError('upload-validation-error', {}, 400);
-                }
-                return;
-            }
-            log.info(
-                `File content mismatch: ${resolvedPath} claims to be .${ext} but detected as ${detectedExtensions.join(', ')}. Rejecting file.`
-            );
-            throw new H5pError('upload-validation-error', {}, 400);
-        }
-
-        // magic-bytes.js returned nothing — file may be text-based
-        // or an unrecognized binary format. Check for dangerous
-        // XML/SVG/HTML content that could enable XSS regardless of
-        // the claimed extension.
-        if (looksLikeXmlOrHtml(data)) {
-            log.info(
-                `File contains XML/HTML content but claims to be .${ext}. Rejecting file: ${resolvedPath}`
-            );
-            throw new H5pError('upload-validation-error', {}, 400);
-        }
+        validateContentBytes(buffer.subarray(0, bytesRead), ext, resolvedPath);
     } finally {
         await fileHandle.close();
+    }
+}
+
+/**
+ * Validates that a buffer's content matches its expected file type. Inspects
+ * the first 1024 bytes of the in-memory buffer directly (the same amount
+ * {@link validateFileContent} reads from disk), so it never has to write the
+ * (potentially large) buffer to disk just to validate it.
+ *
+ * @param buffer the file content to validate; must be non-empty
+ * @param filename the original filename, used to determine the extension for
+ * content-type validation
+ * @throws H5pError with errorId 'upload-validation-error' if the buffer is
+ * empty or if the content fails validation
+ */
+export async function validateBufferContent(
+    buffer: Buffer,
+    filename: string
+): Promise<void> {
+    if (!buffer || buffer.length === 0) {
+        log.error(
+            `Invalid buffer provided to validateBufferContent: empty or undefined`
+        );
+        throw new H5pError('upload-validation-error', {}, 400);
+    }
+
+    const ext = path.extname(filename).toLowerCase().replace(/^\./, '');
+    if (!ext) {
+        return;
+    }
+
+    validateContentBytes(buffer.subarray(0, 1024), ext, filename);
+}
+
+/**
+ * Shared magic-byte / dangerous-content check used by both
+ * {@link validateFileContent} (reading from disk) and
+ * {@link validateBufferContent} (reading from memory).
+ * @param data the first bytes of the file (up to 1024)
+ * @param ext the claimed extension (without leading dot), already lowercased
+ * @param label a path or filename used only for log messages
+ */
+function validateContentBytes(data: Buffer, ext: string, label: string): void {
+    // Detect the actual file type using magic bytes
+    const detectedExtensions = filetypeextension([...data] as number[]).map(
+        (e) => e.replace(/^\./, '')
+    );
+
+    if (detectedExtensions.length > 0) {
+        // The library detected a file type — check it matches
+        // the claimed extension
+        if (extensionMatchesDetected(ext, detectedExtensions)) {
+            // Even when the extension matches, text-based detections
+            // (e.g. a BOM causing magic-bytes to return "txt") still
+            // need the dangerous-content check. A UTF-8 BOM followed
+            // by <html>…</html> would otherwise slip through.
+            if (
+                detectedExtensions.includes('txt') &&
+                looksLikeXmlOrHtml(data)
+            ) {
+                log.info(
+                    `File detected as text but contains XML/HTML content. Rejecting file: ${label}`
+                );
+                throw new H5pError('upload-validation-error', {}, 400);
+            }
+            return;
+        }
+        log.info(
+            `File content mismatch: ${label} claims to be .${ext} but detected as ${detectedExtensions.join(', ')}. Rejecting file.`
+        );
+        throw new H5pError('upload-validation-error', {}, 400);
+    }
+
+    // magic-bytes.js returned nothing — file may be text-based
+    // or an unrecognized binary format. Check for dangerous
+    // XML/SVG/HTML content that could enable XSS regardless of
+    // the claimed extension.
+    if (looksLikeXmlOrHtml(data)) {
+        log.info(
+            `File contains XML/HTML content but claims to be .${ext}. Rejecting file: ${label}`
+        );
+        throw new H5pError('upload-validation-error', {}, 400);
     }
 }
 

--- a/packages/h5p-server/src/index.ts
+++ b/packages/h5p-server/src/index.ts
@@ -1,47 +1,44 @@
-// Classes
+import { ContentFileScanner } from './ContentFileScanner';
+import ContentStorer from './ContentStorer';
+import ContentTypeCache from './ContentTypeCache';
+import ContentUserDataManager from './ContentUserDataManager';
+import H5PAjaxEndpoint from './H5PAjaxEndpoint';
 import H5PEditor from './H5PEditor';
-import H5pError from './helpers/H5pError';
 import H5PPlayer from './H5PPlayer';
 import InstalledLibrary from './InstalledLibrary';
+import LibraryAdministration from './LibraryAdministration';
+import LibraryManager from './LibraryManager';
 import LibraryName from './LibraryName';
 import PackageExporter from './PackageExporter';
-import H5PAjaxEndpoint from './H5PAjaxEndpoint';
-import ContentTypeCache from './ContentTypeCache';
-
+import TemporaryFileManager from './TemporaryFileManager';
+import UrlGenerator from './UrlGenerator';
 import AggregateH5pError from './helpers/AggregateH5pError';
 import AjaxErrorResponse from './helpers/AjaxErrorResponse';
 import AjaxSuccessResponse from './helpers/AjaxSuccessResponse';
-import { streamToString } from './helpers/StreamHelpers';
-
+import H5pError from './helpers/H5pError';
 import Logger from './helpers/Logger';
-
+import { streamToString } from './helpers/StreamHelpers';
 import H5PConfig from './implementation/H5PConfig';
+import InMemoryStorage from './implementation/InMemoryStorage';
+import { LaissezFairePermissionSystem } from './implementation/LaissezFairePermissionSystem';
+import SimpleLockProvider from './implementation/SimpleLockProvider';
+import CachedKeyValueStorage from './implementation/cache/CachedKeyValueStorage';
+import CachedLibraryStorage from './implementation/cache/CachedLibraryStorage';
 import fs from './implementation/fs';
-import * as utils from './implementation/utils';
 import DirectoryTemporaryFileStorage from './implementation/fs/DirectoryTemporaryFileStorage';
 import FileContentStorage from './implementation/fs/FileContentStorage';
-import FileLibraryStorage from './implementation/fs/FileLibraryStorage';
 import FileContentUserDataStorage from './implementation/fs/FileContentUserDataStorage';
+import FileLibraryStorage from './implementation/fs/FileLibraryStorage';
 import JsonStorage from './implementation/fs/JsonStorage';
-import InMemoryStorage from './implementation/InMemoryStorage';
-import CachedLibraryStorage from './implementation/cache/CachedLibraryStorage';
-import CachedKeyValueStorage from './implementation/cache/CachedKeyValueStorage';
-import { ContentFileScanner } from './ContentFileScanner';
-import LibraryManager from './LibraryManager';
-import ContentUserDataManager from './ContentUserDataManager';
-import UrlGenerator from './UrlGenerator';
-import SimpleLockProvider from './implementation/SimpleLockProvider';
-import { LaissezFairePermissionSystem } from './implementation/LaissezFairePermissionSystem';
-import TemporaryFileManager from './TemporaryFileManager';
-import ContentStorer from './ContentStorer';
-
-// Interfaces
+import * as utils from './implementation/utils';
 import {
     ContentId,
     ContentParameters,
     ContentPermission,
     FileSanitizerResult,
     GeneralPermission,
+    H5PFile,
+    H5PFileBuffer,
     IAdditionalLibraryMetadata,
     IAjaxResponse,
     IContentMetadata,
@@ -80,9 +77,6 @@ import {
     UserDataPermission
 } from './types';
 
-// Adapters
-import LibraryAdministration from './LibraryAdministration';
-
 const fsImplementations = {
     DirectoryTemporaryFileStorage,
     FileContentStorage,
@@ -98,32 +92,28 @@ const cacheImplementations = {
 };
 
 export {
-    // classes
     AggregateH5pError,
     AjaxErrorResponse,
     AjaxSuccessResponse,
+    cacheImplementations,
     ContentFileScanner,
-    ContentStorer,
-    ContentTypeCache,
-    ContentUserDataManager,
-    H5PAjaxEndpoint,
-    H5PEditor,
-    H5pError,
-    H5PPlayer,
-    InstalledLibrary,
-    LibraryAdministration,
-    LibraryManager,
-    LibraryName,
-    Logger,
-    PackageExporter,
-    TemporaryFileManager,
-    streamToString,
-    // interfaces
     ContentId,
     ContentParameters,
     ContentPermission,
+    ContentStorer,
+    ContentTypeCache,
+    ContentUserDataManager,
     FileSanitizerResult,
+    fs,
+    fsImplementations,
     GeneralPermission,
+    H5PAjaxEndpoint,
+    H5PConfig,
+    H5PEditor,
+    H5pError,
+    H5PFile,
+    H5PFileBuffer,
+    H5PPlayer,
     IAdditionalLibraryMetadata,
     IAjaxResponse,
     IContentMetadata,
@@ -148,6 +138,7 @@ export {
     ILibraryStorage,
     ILicenseData,
     ILockProvider,
+    InstalledLibrary,
     IPermissionSystem,
     IPlayerModel,
     IPostContentUserData,
@@ -157,16 +148,18 @@ export {
     ITranslationFunction,
     IUrlGenerator,
     IUser,
-    MalwareScanResult,
-    TemporaryFilePermission,
-    UserDataPermission,
-    // implementations
-    H5PConfig,
     LaissezFairePermissionSystem,
-    fs,
-    utils,
-    fsImplementations,
-    cacheImplementations,
+    LibraryAdministration,
+    LibraryManager,
+    LibraryName,
+    Logger,
+    MalwareScanResult,
+    PackageExporter,
+    SimpleLockProvider,
+    streamToString,
+    TemporaryFileManager,
+    TemporaryFilePermission,
     UrlGenerator,
-    SimpleLockProvider
+    UserDataPermission,
+    utils
 };

--- a/packages/h5p-server/src/types.ts
+++ b/packages/h5p-server/src/types.ts
@@ -2544,10 +2544,23 @@ export interface IFileSanitizer {
     /** The name of the scanner, e.g. SVG Sanitizer. Used in debug output */
     readonly name: string;
 
-    /** Sanitizes the file at the given path. The original file is expected
+    /**
+     * Sanitizes the file at the given path. The original file is expected
      * to be replaced by the sanitized file, so there is no new path to the
-     * sanitized file. */
-    sanitize(file: string): Promise<FileSanitizerResult>;
+     * sanitized file.
+     * @param file the path of the file to sanitize; this is often a
+     * temporary file whose path carries no usable extension (e.g.
+     * express-fileupload's temp files), so implementations that need to
+     * detect the file type by its name should prefer `originalFilename`
+     * @param originalFilename optional: the original filename of the
+     * uploaded file (e.g. `H5PFile.name`), which does carry a usable
+     * extension even when `file`'s path does not; defaults to `file` when
+     * not given, to keep existing callers working
+     */
+    sanitize(
+        file: string,
+        originalFilename?: string
+    ): Promise<FileSanitizerResult>;
 
     /**
      * Optional: sanitizes an in-memory buffer without requiring it to be

--- a/packages/h5p-server/src/types.ts
+++ b/packages/h5p-server/src/types.ts
@@ -2466,6 +2466,32 @@ export interface ILockProvider {
     ): Promise<T>;
 }
 
+/**
+ * Describes an uploaded file that can either exist as a temporary file on
+ * disk (`tempFilePath`) or as an in-memory buffer (`data`), depending on how
+ * the implementation that received the upload works. Named `H5PFile` (rather
+ * than `File`) to avoid colliding with the DOM `File` type that many
+ * TypeScript consumers already have in scope.
+ */
+export type H5PFile = {
+    data?: Buffer;
+    mimetype: string;
+    name: string;
+    size: number;
+    tempFilePath?: string;
+};
+
+/**
+ * The buffer-only counterpart of {@link H5PFile}, used by the optional
+ * `scanBuffer` / `sanitizeBuffer` methods of {@link IFileMalwareScanner} and
+ * {@link IFileSanitizer}. `data` is guaranteed to be present, so
+ * implementers don't need to check for `tempFilePath` or handle the case of
+ * neither being set.
+ */
+export type H5PFileBuffer = Omit<H5PFile, 'data' | 'tempFilePath'> & {
+    data: Buffer;
+};
+
 export enum MalwareScanResult {
     MalwareFound,
     Clean,
@@ -2481,9 +2507,20 @@ export interface IFileMalwareScanner {
     /** The name of the scanner, e.g. ClamAV */
     readonly name: string;
 
-    /** Scans a file for malware and returns whether it contains malware. */
+    /** Scans a file at the given path for malware and returns whether it
+     * contains malware. */
     scan(
         file: string
+    ): Promise<{ result: MalwareScanResult; viruses?: string }>;
+
+    /**
+     * Optional: scans an in-memory buffer for malware without requiring it
+     * to be written to disk first. Implementations that don't support
+     * buffer scanning can omit this method; callers fall back to writing
+     * the buffer to a temporary file and calling {@link scan} instead.
+     */
+    scanBuffer?(
+        file: H5PFileBuffer
     ): Promise<{ result: MalwareScanResult; viruses?: string }>;
 }
 
@@ -2507,7 +2544,18 @@ export interface IFileSanitizer {
     /** The name of the scanner, e.g. SVG Sanitizer. Used in debug output */
     readonly name: string;
 
-    /** Sanitizes files. The original file is expected to be replaced by the
-     * sanitized file, so there is no new path to the sanitized file.*/
+    /** Sanitizes the file at the given path. The original file is expected
+     * to be replaced by the sanitized file, so there is no new path to the
+     * sanitized file. */
     sanitize(file: string): Promise<FileSanitizerResult>;
+
+    /**
+     * Optional: sanitizes an in-memory buffer without requiring it to be
+     * written to disk first. Implementations are expected to replace
+     * `file.data` with the sanitized buffer. Implementations that don't
+     * support buffer sanitization can omit this method; callers fall back
+     * to writing the buffer to a temporary file and calling {@link sanitize}
+     * instead.
+     */
+    sanitizeBuffer?(file: H5PFileBuffer): Promise<FileSanitizerResult>;
 }

--- a/packages/h5p-server/test/H5PEditor.saving.test.ts
+++ b/packages/h5p-server/test/H5PEditor.saving.test.ts
@@ -1,30 +1,33 @@
+import { createWriteStream } from 'fs';
+import { readFile, stat } from 'fs/promises';
 import path from 'path';
 import promisepipe from 'promisepipe';
 import { BufferWritableMock } from 'stream-mock';
 import { withDir, withFile } from 'tmp-promise';
-import { readFile, stat } from 'fs/promises';
-import { createWriteStream } from 'fs';
 
 import LibraryName from '../src/LibraryName';
 import {
     FileSanitizerResult,
+    H5PFile,
     IContentMetadata,
     IContentStorage,
     IEditorModel,
+    IFileMalwareScanner,
     IFileSanitizer,
     IH5PConfig,
     IH5PEditorOptions,
     IKeyValueStorage,
     ILibraryFileUrlResolver,
     ILibraryStorage,
-    ITemporaryFileStorage
+    ITemporaryFileStorage,
+    MalwareScanResult
 } from '../src/types';
 
-import User from './User';
 import { fsImplementations, H5PEditor } from '../src';
 import H5PConfig from '../src/implementation/H5PConfig';
 import UrlGenerator from '../src/UrlGenerator';
 import { validatePackage } from './helpers/PackageValidatorHelper';
+import User from './User';
 
 import MockContentUserDataStorage from './__mocks__/ContentUserDataStorage';
 
@@ -226,6 +229,13 @@ describe('H5PEditor', () => {
                 const originalPath = path.resolve(
                     'test/data/sample-content/content/earth.jpg'
                 );
+                const file: H5PFile = {
+                    data: undefined,
+                    mimetype: 'image/jpeg',
+                    name: 'earth.JPG',
+                    tempFilePath: originalPath,
+                    size: (await stat(originalPath)).size
+                };
 
                 // perform action
                 await h5pEditor.saveContentFile(
@@ -234,16 +244,13 @@ describe('H5PEditor', () => {
                         name: 'image',
                         type: 'image'
                     },
-                    {
-                        mimetype: 'image/jpeg',
-                        name: 'earth.JPG',
-                        tempFilePath: originalPath,
-                        size: (await stat(originalPath)).size
-                    },
+                    file,
                     new User()
                 );
 
-                // check result
+                // check result: sanitizers only implementing the path-based
+                // `sanitize` method are called with the temp file path, not
+                // the whole file object.
                 expect(sanitizeSpy).toHaveBeenCalledWith(originalPath);
             },
             { keep: false, unsafeCleanup: true }
@@ -292,6 +299,308 @@ describe('H5PEditor', () => {
                 // check result
                 expect(sanitizeSpy1).toHaveBeenCalled();
                 expect(sanitizeSpy2).toHaveBeenCalled();
+            },
+            { keep: false, unsafeCleanup: true }
+        );
+    });
+
+    it('rejects SVG content disguised as a JPEG file (via buffer)', async () => {
+        await withDir(
+            async ({ path: tempDirPath }) => {
+                const { h5pEditor } = createH5PEditor(tempDirPath);
+                const user = new User();
+
+                const maliciousContent = Buffer.from(
+                    '<svg xmlns="http://www.w3.org/2000/svg"><script>alert(1)</script></svg>'
+                );
+
+                await expect(
+                    h5pEditor.saveContentFile(
+                        undefined,
+                        {
+                            name: 'image',
+                            type: 'image'
+                        },
+                        {
+                            data: maliciousContent,
+                            mimetype: 'image/jpeg',
+                            name: 'malicious.jpg',
+                            size: maliciousContent.length
+                        },
+                        user
+                    )
+                ).rejects.toThrow('upload-validation-error');
+            },
+            { keep: false, unsafeCleanup: true }
+        );
+    });
+
+    it('rejects HTML content disguised as a PNG file (via buffer)', async () => {
+        await withDir(
+            async ({ path: tempDirPath }) => {
+                const { h5pEditor } = createH5PEditor(tempDirPath);
+                const user = new User();
+
+                const maliciousContent = Buffer.from(
+                    '<html><body><script>alert(1)</script></body></html>'
+                );
+
+                await expect(
+                    h5pEditor.saveContentFile(
+                        undefined,
+                        {
+                            name: 'image',
+                            type: 'image'
+                        },
+                        {
+                            data: maliciousContent,
+                            mimetype: 'image/png',
+                            name: 'malicious.png',
+                            size: maliciousContent.length
+                        },
+                        user
+                    )
+                ).rejects.toThrow('upload-validation-error');
+            },
+            { keep: false, unsafeCleanup: true }
+        );
+    });
+
+    it('rejects SVG content disguised as a JPEG file (via tempFilePath)', async () => {
+        await withDir(
+            async ({ path: tempDirPath }) => {
+                const { h5pEditor } = createH5PEditor(tempDirPath);
+                const user = new User();
+
+                // Create a temp file with malicious content
+                await withFile(
+                    async ({ path: maliciousFilePath }) => {
+                        const maliciousContent =
+                            '<svg xmlns="http://www.w3.org/2000/svg"><script>alert(1)</script></svg>';
+                        const writeStream =
+                            createWriteStream(maliciousFilePath);
+                        await new Promise<void>((resolve, reject) => {
+                            writeStream.on('error', reject);
+                            writeStream.on('finish', resolve);
+                            writeStream.end(maliciousContent);
+                        });
+
+                        await expect(
+                            h5pEditor.saveContentFile(
+                                undefined,
+                                {
+                                    name: 'image',
+                                    type: 'image'
+                                },
+                                {
+                                    mimetype: 'image/jpeg',
+                                    name: 'malicious.jpg',
+                                    tempFilePath: maliciousFilePath,
+                                    size: maliciousContent.length
+                                },
+                                user
+                            )
+                        ).rejects.toThrow('upload-validation-error');
+                    },
+                    { postfix: '.jpg' }
+                );
+            },
+            { keep: false, unsafeCleanup: true }
+        );
+    });
+
+    it('rejects GIF content disguised as a PNG file', async () => {
+        await withDir(
+            async ({ path: tempDirPath }) => {
+                const { h5pEditor } = createH5PEditor(tempDirPath);
+                const user = new User();
+
+                // GIF87a header - valid GIF but claimed as PNG
+                const gifContent = Buffer.from([
+                    0x47, 0x49, 0x46, 0x38, 0x37, 0x61, 0x01, 0x00, 0x01, 0x00,
+                    0x00, 0x00, 0x00, 0x3b
+                ]);
+
+                await expect(
+                    h5pEditor.saveContentFile(
+                        undefined,
+                        {
+                            name: 'image',
+                            type: 'image'
+                        },
+                        {
+                            data: gifContent,
+                            mimetype: 'image/png',
+                            name: 'fake.png',
+                            size: gifContent.length
+                        },
+                        user
+                    )
+                ).rejects.toThrow('upload-validation-error');
+            },
+            { keep: false, unsafeCleanup: true }
+        );
+    });
+
+    it('rejects file with neither data nor tempFilePath', async () => {
+        await withDir(
+            async ({ path: tempDirPath }) => {
+                const { h5pEditor } = createH5PEditor(tempDirPath);
+                const user = new User();
+
+                await expect(
+                    h5pEditor.saveContentFile(
+                        undefined,
+                        {
+                            name: 'image',
+                            type: 'image'
+                        },
+                        {
+                            mimetype: 'image/jpeg',
+                            name: 'orphan.jpg',
+                            size: 100
+                        },
+                        user
+                    )
+                ).rejects.toThrow('upload-validation-error');
+            },
+            { keep: false, unsafeCleanup: true }
+        );
+    });
+
+    it('scans uploaded files for malware when configured', async () => {
+        await withDir(
+            async ({ path: tempDirPath }) => {
+                // setup
+                const mockMalwareScanner: IFileMalwareScanner = {
+                    name: 'Mock malware scanner',
+                    scan: async () => ({ result: MalwareScanResult.Clean })
+                };
+                const scanSpy = vi.spyOn(mockMalwareScanner, 'scan');
+
+                const { h5pEditor } = createH5PEditor(tempDirPath, undefined, {
+                    malwareScanners: [mockMalwareScanner]
+                });
+
+                const originalPath = path.resolve(
+                    'test/data/sample-content/content/earth.jpg'
+                );
+                const fileBuffer = await readFile(originalPath);
+                const file: H5PFile = {
+                    data: fileBuffer,
+                    mimetype: 'image/jpeg',
+                    name: 'earth.jpg',
+                    size: (await stat(originalPath)).size
+                };
+
+                // perform action
+                await h5pEditor.saveContentFile(
+                    undefined,
+                    {
+                        name: 'image',
+                        type: 'image'
+                    },
+                    file,
+                    new User()
+                );
+
+                // check result: scanners only implementing the path-based
+                // `scan` method receive a temporary file the buffer was
+                // written to (with the original extension), not the file
+                // object itself.
+                expect(scanSpy).toHaveBeenCalledWith(
+                    expect.stringMatching(/\.jpg$/)
+                );
+            },
+            { keep: false, unsafeCleanup: true }
+        );
+    });
+
+    it('rejects files when malware is found', async () => {
+        await withDir(
+            async ({ path: tempDirPath }) => {
+                // setup
+                const mockMalwareScanner: IFileMalwareScanner = {
+                    name: 'Mock malware scanner',
+                    scan: async () => ({
+                        result: MalwareScanResult.MalwareFound,
+                        viruses: 'TestVirus'
+                    })
+                };
+
+                const { h5pEditor } = createH5PEditor(tempDirPath, undefined, {
+                    malwareScanners: [mockMalwareScanner]
+                });
+
+                const originalPath = path.resolve(
+                    'test/data/sample-content/content/earth.jpg'
+                );
+                const fileBuffer = await readFile(originalPath);
+
+                await expect(
+                    h5pEditor.saveContentFile(
+                        undefined,
+                        {
+                            name: 'image',
+                            type: 'image'
+                        },
+                        {
+                            data: fileBuffer,
+                            mimetype: 'image/jpeg',
+                            name: 'infected.jpg',
+                            size: (await stat(originalPath)).size
+                        },
+                        new User()
+                    )
+                ).rejects.toThrow('upload-malware-found');
+            },
+            { keep: false, unsafeCleanup: true }
+        );
+    });
+
+    it('checks if all malware scanners are called', async () => {
+        await withDir(
+            async ({ path: tempDirPath }) => {
+                // setup
+                const mockScanner1: IFileMalwareScanner = {
+                    name: 'Mock scanner 1',
+                    scan: async () => ({ result: MalwareScanResult.Clean })
+                };
+                const mockScanner2: IFileMalwareScanner = {
+                    name: 'Mock scanner 2',
+                    scan: async () => ({ result: MalwareScanResult.Clean })
+                };
+                const scanSpy1 = vi.spyOn(mockScanner1, 'scan');
+                const scanSpy2 = vi.spyOn(mockScanner2, 'scan');
+
+                const { h5pEditor } = createH5PEditor(tempDirPath, undefined, {
+                    malwareScanners: [mockScanner1, mockScanner2]
+                });
+
+                const originalPath = path.resolve(
+                    'test/data/sample-content/content/earth.jpg'
+                );
+                const fileBuffer = await readFile(originalPath);
+
+                // perform action
+                await h5pEditor.saveContentFile(
+                    undefined,
+                    {
+                        name: 'image',
+                        type: 'image'
+                    },
+                    {
+                        data: fileBuffer,
+                        mimetype: 'image/jpeg',
+                        name: 'earth.jpg',
+                        size: (await stat(originalPath)).size
+                    },
+                    new User()
+                );
+
+                // check result
+                expect(scanSpy1).toHaveBeenCalled();
+                expect(scanSpy2).toHaveBeenCalled();
             },
             { keep: false, unsafeCleanup: true }
         );

--- a/packages/h5p-server/test/H5PEditor.saving.test.ts
+++ b/packages/h5p-server/test/H5PEditor.saving.test.ts
@@ -249,9 +249,69 @@ describe('H5PEditor', () => {
                 );
 
                 // check result: sanitizers only implementing the path-based
-                // `sanitize` method are called with the temp file path, not
-                // the whole file object.
-                expect(sanitizeSpy).toHaveBeenCalledWith(originalPath);
+                // `sanitize` method are called with the temp file path (not
+                // the whole file object) plus the original filename.
+                expect(sanitizeSpy).toHaveBeenCalledWith(
+                    originalPath,
+                    'earth.JPG'
+                );
+            },
+            { keep: false, unsafeCleanup: true }
+        );
+    });
+
+    it('sanitizes file.data (not the stale tempFilePath) when both are present on the upload', async () => {
+        // Regression test: if an upload middleware populates both
+        // file.data and file.tempFilePath, the sanitizer must operate on
+        // file.data, since that is what actually gets persisted
+        // (saveContentFile prefers file.data whenever it carries content).
+        // Sanitizing only the temp file while storing the buffer would let
+        // unsanitized content slip through.
+        await withDir(
+            async ({ path: tempDirPath }) => {
+                const sanitizeBufferCalls: string[] = [];
+                const mockSanitizer: IFileSanitizer = {
+                    name: 'Mock buffer sanitizer',
+                    sanitize: async () => {
+                        throw new Error(
+                            'sanitize(path) should not be called when file.data is present'
+                        );
+                    },
+                    sanitizeBuffer: async (file) => {
+                        sanitizeBufferCalls.push(file.name);
+                        return FileSanitizerResult.Sanitized;
+                    }
+                };
+
+                const { h5pEditor } = createH5PEditor(tempDirPath, undefined, {
+                    fileSanitizers: [mockSanitizer]
+                });
+
+                const originalPath = path.resolve(
+                    'test/data/sample-content/content/earth.jpg'
+                );
+                const fileBuffer = await readFile(originalPath);
+                const file: H5PFile = {
+                    data: fileBuffer,
+                    // A tempFilePath pointing at a different, stale file is
+                    // also present, as some upload middlewares do.
+                    tempFilePath: originalPath,
+                    mimetype: 'image/jpeg',
+                    name: 'earth.jpg',
+                    size: fileBuffer.length
+                };
+
+                await h5pEditor.saveContentFile(
+                    undefined,
+                    {
+                        name: 'image',
+                        type: 'image'
+                    },
+                    file,
+                    new User()
+                );
+
+                expect(sanitizeBufferCalls).toEqual(['earth.jpg']);
             },
             { keep: false, unsafeCleanup: true }
         );
@@ -511,6 +571,61 @@ describe('H5PEditor', () => {
                 expect(scanSpy).toHaveBeenCalledWith(
                     expect.stringMatching(/\.jpg$/)
                 );
+            },
+            { keep: false, unsafeCleanup: true }
+        );
+    });
+
+    it('scans file.data (not a stale tempFilePath) via scanBuffer when both are present on the upload', async () => {
+        // Regression test: scanForMalware must agree with saveContentFile's
+        // persistence precedence (file.data wins whenever present), so a
+        // scanner implementing scanBuffer must receive the real buffer
+        // rather than being skipped in favor of a stale tempFilePath.
+        await withDir(
+            async ({ path: tempDirPath }) => {
+                const scanBufferCalls: string[] = [];
+                const mockMalwareScanner: IFileMalwareScanner = {
+                    name: 'Mock buffer malware scanner',
+                    scan: async () => {
+                        throw new Error(
+                            'scan(path) should not be called when file.data is present'
+                        );
+                    },
+                    scanBuffer: async (file) => {
+                        scanBufferCalls.push(file.name);
+                        return { result: MalwareScanResult.Clean };
+                    }
+                };
+
+                const { h5pEditor } = createH5PEditor(tempDirPath, undefined, {
+                    malwareScanners: [mockMalwareScanner]
+                });
+
+                const originalPath = path.resolve(
+                    'test/data/sample-content/content/earth.jpg'
+                );
+                const fileBuffer = await readFile(originalPath);
+                const file: H5PFile = {
+                    data: fileBuffer,
+                    // A tempFilePath pointing at a different, stale file is
+                    // also present, as some upload middlewares do.
+                    tempFilePath: originalPath,
+                    mimetype: 'image/jpeg',
+                    name: 'earth.jpg',
+                    size: fileBuffer.length
+                };
+
+                await h5pEditor.saveContentFile(
+                    undefined,
+                    {
+                        name: 'image',
+                        type: 'image'
+                    },
+                    file,
+                    new User()
+                );
+
+                expect(scanBufferCalls).toEqual(['earth.jpg']);
             },
             { keep: false, unsafeCleanup: true }
         );

--- a/packages/h5p-server/test/H5PEditor.saving.test.ts
+++ b/packages/h5p-server/test/H5PEditor.saving.test.ts
@@ -601,6 +601,90 @@ describe('H5PEditor', () => {
                 // check result
                 expect(scanSpy1).toHaveBeenCalled();
                 expect(scanSpy2).toHaveBeenCalled();
+
+                // Both scanners only implement the path-based `scan` method
+                // and are given a buffer-only upload, so they must share a
+                // single temporary file instead of each writing their own
+                // copy of the same buffer.
+                const scannedPath1 = scanSpy1.mock.calls[0][0];
+                const scannedPath2 = scanSpy2.mock.calls[0][0];
+                expect(scannedPath1).toEqual(scannedPath2);
+            },
+            { keep: false, unsafeCleanup: true }
+        );
+    });
+
+    it('lets malware scanners implementing scanBuffer use the buffer directly while scanners without it share a single temporary file', async () => {
+        await withDir(
+            async ({ path: tempDirPath }) => {
+                // setup
+                const mockScannerWithBuffer: IFileMalwareScanner = {
+                    name: 'Mock scanner with scanBuffer',
+                    scan: async () => ({ result: MalwareScanResult.Clean }),
+                    scanBuffer: async () => ({
+                        result: MalwareScanResult.Clean
+                    })
+                };
+                const mockScannerWithoutBuffer1: IFileMalwareScanner = {
+                    name: 'Mock scanner without scanBuffer 1',
+                    scan: async () => ({ result: MalwareScanResult.Clean })
+                };
+                const mockScannerWithoutBuffer2: IFileMalwareScanner = {
+                    name: 'Mock scanner without scanBuffer 2',
+                    scan: async () => ({ result: MalwareScanResult.Clean })
+                };
+                const scanBufferSpy = vi.spyOn(
+                    mockScannerWithBuffer,
+                    'scanBuffer'
+                );
+                const scanSpyWithBuffer = vi.spyOn(
+                    mockScannerWithBuffer,
+                    'scan'
+                );
+                const scanSpy1 = vi.spyOn(mockScannerWithoutBuffer1, 'scan');
+                const scanSpy2 = vi.spyOn(mockScannerWithoutBuffer2, 'scan');
+
+                const { h5pEditor } = createH5PEditor(tempDirPath, undefined, {
+                    malwareScanners: [
+                        mockScannerWithBuffer,
+                        mockScannerWithoutBuffer1,
+                        mockScannerWithoutBuffer2
+                    ]
+                });
+
+                const originalPath = path.resolve(
+                    'test/data/sample-content/content/earth.jpg'
+                );
+                const fileBuffer = await readFile(originalPath);
+
+                // perform action
+                await h5pEditor.saveContentFile(
+                    undefined,
+                    {
+                        name: 'image',
+                        type: 'image'
+                    },
+                    {
+                        data: fileBuffer,
+                        mimetype: 'image/jpeg',
+                        name: 'earth.jpg',
+                        size: (await stat(originalPath)).size
+                    },
+                    new User()
+                );
+
+                // check result: the scanner implementing scanBuffer never
+                // falls back to a temporary file...
+                expect(scanBufferSpy).toHaveBeenCalled();
+                expect(scanSpyWithBuffer).not.toHaveBeenCalled();
+
+                // ...while the scanners without scanBuffer are both called
+                // and share the same temporary file.
+                expect(scanSpy1).toHaveBeenCalled();
+                expect(scanSpy2).toHaveBeenCalled();
+                const scannedPath1 = scanSpy1.mock.calls[0][0];
+                const scannedPath2 = scanSpy2.mock.calls[0][0];
+                expect(scannedPath1).toEqual(scannedPath2);
             },
             { keep: false, unsafeCleanup: true }
         );

--- a/packages/h5p-server/test/H5PEditor.uploadingPackages.test.ts
+++ b/packages/h5p-server/test/H5PEditor.uploadingPackages.test.ts
@@ -1,16 +1,16 @@
 /* eslint-disable no-await-in-loop */
 
-import path from 'path';
-import { withDir, file, FileResult } from 'tmp-promise';
-import { readFile, writeFile } from 'fs/promises';
 import { createWriteStream } from 'fs';
+import { readFile, writeFile } from 'fs/promises';
+import path from 'path';
+import { file, FileResult, withDir } from 'tmp-promise';
 
 import User from './User';
 import { createH5PEditor } from './helpers/H5PEditor';
 
+import { streamToString } from '../src';
 import { ContentMetadata } from '../src/ContentMetadata';
 import { FileSanitizerResult, IFileSanitizer } from '../src/types';
-import { streamToString } from '../src';
 
 describe('H5PEditor', () => {
     it('returns metadata and parameters of package uploads', async () => {
@@ -95,11 +95,11 @@ describe('H5PEditor', () => {
                 };
                 const sanitizer2: IFileSanitizer = {
                     name: 'Mock file sanitizer 2',
-                    sanitize: async (file) => {
-                        if (file.endsWith('.jpg')) {
+                    sanitize: async (filepath) => {
+                        if (filepath.endsWith('.jpg')) {
                             // replace the file contents with 'sanitized' to
                             // mimmick sanitization
-                            await writeFile(file, 'sanitized', 'utf8');
+                            await writeFile(filepath, 'sanitized', 'utf8');
                             return FileSanitizerResult.Sanitized;
                         }
                         return FileSanitizerResult.Ignored;

--- a/packages/h5p-server/test/H5PEditor.uploadingVirus.test.ts
+++ b/packages/h5p-server/test/H5PEditor.uploadingVirus.test.ts
@@ -1,10 +1,10 @@
-import path from 'path';
 import { readFile, stat } from 'fs/promises';
+import path from 'path';
 import { withDir } from 'tmp-promise';
 
+import { IFileMalwareScanner, MalwareScanResult } from '../src/types';
 import User from './User';
 import { createH5PEditor } from './helpers/H5PEditor';
-import { MalwareScanResult, IFileMalwareScanner } from '../src/types';
 
 class MockMalwareScanner implements IFileMalwareScanner {
     readonly name: string = 'Mock Scanner';

--- a/packages/h5p-server/test/PackageImporter.test.ts
+++ b/packages/h5p-server/test/PackageImporter.test.ts
@@ -1,21 +1,21 @@
+import { mkdir } from 'fs/promises';
 import * as path from 'path';
 import promisepipe from 'promisepipe';
 import { BufferWritableMock } from 'stream-mock';
 import { withDir } from 'tmp-promise';
-import { mkdir } from 'fs/promises';
 
 import ContentManager from '../src/ContentManager';
-import H5PConfig from '../src/implementation/H5PConfig';
+import ContentStorer from '../src/ContentStorer';
 import FileContentStorage from '../src/implementation/fs/FileContentStorage';
 import FileLibraryStorage from '../src/implementation/fs/FileLibraryStorage';
+import H5PConfig from '../src/implementation/H5PConfig';
+import { LaissezFairePermissionSystem } from '../src/implementation/LaissezFairePermissionSystem';
 import LibraryManager from '../src/LibraryManager';
 import PackageImporter from '../src/PackageImporter';
-import ContentStorer from '../src/ContentStorer';
-import { LaissezFairePermissionSystem } from '../src/implementation/LaissezFairePermissionSystem';
 import {
-    IUser,
     GeneralPermission,
     IFileMalwareScanner,
+    IUser,
     MalwareScanResult
 } from '../src/types';
 
@@ -210,8 +210,8 @@ describe('package importer', () => {
                 );
                 const mockMalwareScanner: IFileMalwareScanner = {
                     name: 'Mock malware scanner',
-                    scan: async (file) => {
-                        if (file.includes('eicar')) {
+                    scan: async (filepath) => {
+                        if (filepath.includes('eicar')) {
                             return {
                                 result: MalwareScanResult.MalwareFound,
                                 viruses: 'EICAR test virus'

--- a/packages/h5p-server/test/contentFileValidation.test.ts
+++ b/packages/h5p-server/test/contentFileValidation.test.ts
@@ -1,11 +1,14 @@
-import { writeFile, mkdtemp, rm } from 'fs/promises';
-import path from 'path';
+import { mkdtemp, rm, writeFile } from 'fs/promises';
 import os from 'os';
+import path from 'path';
 
 import {
-    validateFileContent,
-    extensionMatchesDetected
+    extensionMatchesDetected,
+    validateBufferContent,
+    validateContent,
+    validateFileContent
 } from '../src/contentFileValidation';
+import { H5PFile } from '../src/types';
 
 describe('validateFileContent', () => {
     let tmpDir: string;
@@ -212,6 +215,179 @@ describe('validateFileContent', () => {
         const filePath = path.join(tmpDir, 'legit.txt');
         await writeFile(filePath, 'Just a plain text file.');
         await expect(validateFileContent(filePath)).resolves.toBeUndefined();
+    });
+});
+
+describe('validateBufferContent', () => {
+    it('accepts a valid PNG buffer', async () => {
+        const pngHeader = Buffer.from([
+            0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00,
+            0x0d, 0x49, 0x48, 0x44, 0x52, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00,
+            0x00, 0x01, 0x08, 0x02, 0x00, 0x00, 0x00, 0x90, 0x77, 0x53, 0xde,
+            0x00, 0x00, 0x00, 0x0c, 0x49, 0x44, 0x41, 0x54, 0x08, 0xd7, 0x63,
+            0xf8, 0xcf, 0xc0, 0x00, 0x00, 0x00, 0x02, 0x00, 0x01, 0xe2, 0x21,
+            0xbc, 0x33, 0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4e, 0x44, 0xae,
+            0x42, 0x60, 0x82
+        ]);
+        await expect(
+            validateBufferContent(pngHeader, 'image.png')
+        ).resolves.toBeUndefined();
+    });
+
+    it('rejects an empty buffer', async () => {
+        const emptyBuffer = Buffer.alloc(0);
+        await expect(
+            validateBufferContent(emptyBuffer, 'empty.png')
+        ).rejects.toThrow('upload-validation-error');
+    });
+
+    it('rejects a null buffer', async () => {
+        await expect(
+            validateBufferContent(null as unknown as Buffer, 'null.png')
+        ).rejects.toThrow('upload-validation-error');
+    });
+
+    // Note: validateBufferContent writes to a temp file without extension,
+    // so content-type mismatch validation is not performed. These tests
+    // verify the function accepts the buffers (since there's no extension
+    // to compare against).
+    it('accepts a buffer containing XML/SVG content (no extension)', async () => {
+        const svgBuffer = Buffer.from(
+            '<svg xmlns="http://www.w3.org/2000/svg"><script>alert(1)</script></svg>'
+        );
+        await expect(
+            validateBufferContent(svgBuffer, 'image.svg')
+        ).resolves.toBeUndefined();
+    });
+
+    it('accepts a buffer containing HTML content (no extension)', async () => {
+        const htmlBuffer = Buffer.from(
+            '<html><body><script>alert(1)</script></body></html>'
+        );
+        await expect(
+            validateBufferContent(htmlBuffer, 'index')
+        ).resolves.toBeUndefined();
+    });
+
+    it('accepts a valid JSON buffer', async () => {
+        const jsonBuffer = Buffer.from(JSON.stringify({ key: 'value' }));
+        await expect(
+            validateBufferContent(jsonBuffer, 'data.json')
+        ).resolves.toBeUndefined();
+    });
+});
+
+describe('validateContent', () => {
+    let tmpDir: string;
+
+    beforeEach(async () => {
+        tmpDir = await mkdtemp(path.join(os.tmpdir(), 'h5p-validator-'));
+    });
+
+    afterEach(async () => {
+        await rm(tmpDir, { recursive: true, force: true });
+    });
+
+    it('validates file.data when buffer is present', async () => {
+        const pngHeader = Buffer.from([
+            0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00,
+            0x0d, 0x49, 0x48, 0x44, 0x52, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00,
+            0x00, 0x01, 0x08, 0x02, 0x00, 0x00, 0x00, 0x90, 0x77, 0x53, 0xde,
+            0x00, 0x00, 0x00, 0x0c, 0x49, 0x44, 0x41, 0x54, 0x08, 0xd7, 0x63,
+            0xf8, 0xcf, 0xc0, 0x00, 0x00, 0x00, 0x02, 0x00, 0x01, 0xe2, 0x21,
+            0xbc, 0x33, 0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4e, 0x44, 0xae,
+            0x42, 0x60, 0x82
+        ]);
+        const file: H5PFile = {
+            name: 'image.png',
+            data: pngHeader,
+            mimetype: 'image/png',
+            size: pngHeader.length
+        };
+        await expect(validateContent(file)).resolves.toBeUndefined();
+    });
+
+    it('validates file.tempFilePath when no buffer but path is present', async () => {
+        const pngHeader = Buffer.from([
+            0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00,
+            0x0d, 0x49, 0x48, 0x44, 0x52, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00,
+            0x00, 0x01, 0x08, 0x02, 0x00, 0x00, 0x00, 0x90, 0x77, 0x53, 0xde,
+            0x00, 0x00, 0x00, 0x0c, 0x49, 0x44, 0x41, 0x54, 0x08, 0xd7, 0x63,
+            0xf8, 0xcf, 0xc0, 0x00, 0x00, 0x00, 0x02, 0x00, 0x01, 0xe2, 0x21,
+            0xbc, 0x33, 0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4e, 0x44, 0xae,
+            0x42, 0x60, 0x82
+        ]);
+        const filePath = path.join(tmpDir, 'image.png');
+        await writeFile(filePath, pngHeader);
+        const file: H5PFile = {
+            name: 'image.png',
+            tempFilePath: filePath,
+            mimetype: 'image/png',
+            size: pngHeader.length
+        };
+        await expect(validateContent(file)).resolves.toBeUndefined();
+    });
+
+    it('rejects when file has neither data nor tempFilePath', async () => {
+        const file: H5PFile = {
+            name: 'orphan.png',
+            mimetype: 'image/png',
+            size: 1024
+        };
+        await expect(validateContent(file)).rejects.toThrow(
+            'upload-validation-error'
+        );
+    });
+
+    // Note: When using file.data, validateBufferContent creates a temp file
+    // without extension, so content validation is skipped. Malicious content
+    // can only be detected via file.tempFilePath which preserves the extension.
+    it('accepts malicious buffer content via file.data (no extension in temp)', async () => {
+        const file: H5PFile = {
+            name: 'malicious',
+            data: Buffer.from('<svg><script>alert(1)</script></svg>'),
+            mimetype: 'image/png',
+            size: 1024
+        };
+        await expect(validateContent(file)).resolves.toBeUndefined();
+    });
+
+    it('rejects malicious file content via file.tempFilePath', async () => {
+        const filePath = path.join(tmpDir, 'malicious.png');
+        await writeFile(filePath, '<svg><script>alert(1)</script></svg>');
+        const file: H5PFile = {
+            name: 'malicious.png',
+            tempFilePath: filePath,
+            mimetype: 'image/png',
+            size: 1024
+        };
+        await expect(validateContent(file)).rejects.toThrow(
+            'upload-validation-error'
+        );
+    });
+
+    it('prefers file.data over file.tempFilePath when both are present', async () => {
+        // file.data is valid PNG, file.tempFilePath points to malicious content
+        const pngHeader = Buffer.from([
+            0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00,
+            0x0d, 0x49, 0x48, 0x44, 0x52, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00,
+            0x00, 0x01, 0x08, 0x02, 0x00, 0x00, 0x00, 0x90, 0x77, 0x53, 0xde,
+            0x00, 0x00, 0x00, 0x0c, 0x49, 0x44, 0x41, 0x54, 0x08, 0xd7, 0x63,
+            0xf8, 0xcf, 0xc0, 0x00, 0x00, 0x00, 0x02, 0x00, 0x01, 0xe2, 0x21,
+            0xbc, 0x33, 0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4e, 0x44, 0xae,
+            0x42, 0x60, 0x82
+        ]);
+        const filePath = path.join(tmpDir, 'malicious.png');
+        await writeFile(filePath, '<svg><script>alert(1)</script></svg>');
+        const file: H5PFile = {
+            name: 'image.png',
+            data: pngHeader,
+            tempFilePath: filePath,
+            mimetype: 'image/png',
+            size: pngHeader.length
+        };
+        // Should pass because file.data (valid PNG) is checked, not tempFilePath
+        await expect(validateContent(file)).resolves.toBeUndefined();
     });
 });
 

--- a/packages/h5p-server/test/contentFileValidation.test.ts
+++ b/packages/h5p-server/test/contentFileValidation.test.ts
@@ -114,10 +114,16 @@ describe('validateFileContent', () => {
         );
     });
 
-    it('accepts a file with no extension', async () => {
+    it('rejects a file whose path has no extension and no originalFilename is given', async () => {
+        // With no originalFilename argument, the extension falls back to
+        // being derived from filePath itself. An extensionless path is
+        // rejected outright, since there is nothing to validate the content
+        // against.
         const filePath = path.join(tmpDir, 'noextension');
         await writeFile(filePath, 'some content');
-        await expect(validateFileContent(filePath)).resolves.toBeUndefined();
+        await expect(validateFileContent(filePath)).rejects.toThrow(
+            'upload-validation-error'
+        );
     });
 
     it('rejects a file with no extension containing dangerous SVG content (simulating express-fileupload temp files)', async () => {
@@ -130,6 +136,44 @@ describe('validateFileContent', () => {
         await expect(validateFileContent(filePath)).rejects.toThrow(
             'upload-validation-error'
         );
+    });
+
+    it('rejects a valid PNG whose path has no extension and no originalFilename is given', async () => {
+        const pngHeader = Buffer.from([
+            0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00,
+            0x0d, 0x49, 0x48, 0x44, 0x52, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00,
+            0x00, 0x01, 0x08, 0x02, 0x00, 0x00, 0x00, 0x90, 0x77, 0x53, 0xde,
+            0x00, 0x00, 0x00, 0x0c, 0x49, 0x44, 0x41, 0x54, 0x08, 0xd7, 0x63,
+            0xf8, 0xcf, 0xc0, 0x00, 0x00, 0x00, 0x02, 0x00, 0x01, 0xe2, 0x21,
+            0xbc, 0x33, 0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4e, 0x44, 0xae,
+            0x42, 0x60, 0x82
+        ]);
+        const filePath = path.join(tmpDir, 'tmp-5000-9876543210');
+        await writeFile(filePath, pngHeader);
+        await expect(validateFileContent(filePath)).rejects.toThrow(
+            'upload-validation-error'
+        );
+    });
+
+    it('accepts a valid PNG at an extensionless temp path when originalFilename carries the .png extension', async () => {
+        // This is the express-fileupload useTempFiles scenario: the temp
+        // path itself is extensionless, but the original filename (e.g.
+        // H5PFile.name) carries the real extension and must be used to
+        // derive the claimed extension.
+        const pngHeader = Buffer.from([
+            0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00,
+            0x0d, 0x49, 0x48, 0x44, 0x52, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00,
+            0x00, 0x01, 0x08, 0x02, 0x00, 0x00, 0x00, 0x90, 0x77, 0x53, 0xde,
+            0x00, 0x00, 0x00, 0x0c, 0x49, 0x44, 0x41, 0x54, 0x08, 0xd7, 0x63,
+            0xf8, 0xcf, 0xc0, 0x00, 0x00, 0x00, 0x02, 0x00, 0x01, 0xe2, 0x21,
+            0xbc, 0x33, 0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4e, 0x44, 0xae,
+            0x42, 0x60, 0x82
+        ]);
+        const filePath = path.join(tmpDir, 'tmp-5000-1122334455');
+        await writeFile(filePath, pngHeader);
+        await expect(
+            validateFileContent(filePath, 'image.png')
+        ).resolves.toBeUndefined();
     });
 
     it('rejects an empty string path', async () => {
@@ -259,10 +303,9 @@ describe('validateBufferContent', () => {
         ).resolves.toBeUndefined();
     });
 
-    // Note: validateBufferContent always inspects the buffer's content,
-    // regardless of whether the filename carries an extension. These tests
-    // verify that dangerous XML/SVG/HTML content is rejected even when the
-    // filename has no extension to compare against.
+    // Note: a filename with no extension at all is now always rejected,
+    // regardless of its content, since there is nothing to validate the
+    // content against.
     it('rejects a buffer containing XML/SVG content (no extension)', async () => {
         const svgBuffer = Buffer.from(
             '<svg xmlns="http://www.w3.org/2000/svg"><script>alert(1)</script></svg>'
@@ -278,6 +321,21 @@ describe('validateBufferContent', () => {
         );
         await expect(
             validateBufferContent(htmlBuffer, 'index')
+        ).rejects.toThrow('upload-validation-error');
+    });
+
+    it('rejects a valid PNG buffer whose filename has no extension', async () => {
+        const pngHeader = Buffer.from([
+            0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00,
+            0x0d, 0x49, 0x48, 0x44, 0x52, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00,
+            0x00, 0x01, 0x08, 0x02, 0x00, 0x00, 0x00, 0x90, 0x77, 0x53, 0xde,
+            0x00, 0x00, 0x00, 0x0c, 0x49, 0x44, 0x41, 0x54, 0x08, 0xd7, 0x63,
+            0xf8, 0xcf, 0xc0, 0x00, 0x00, 0x00, 0x02, 0x00, 0x01, 0xe2, 0x21,
+            0xbc, 0x33, 0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4e, 0x44, 0xae,
+            0x42, 0x60, 0x82
+        ]);
+        await expect(
+            validateBufferContent(pngHeader, 'noextension')
         ).rejects.toThrow('upload-validation-error');
     });
 
@@ -379,6 +437,63 @@ describe('validateContent', () => {
         await expect(validateContent(file)).rejects.toThrow(
             'upload-validation-error'
         );
+    });
+
+    it('accepts a temp-file upload with an extensionless tempFilePath but a proper file.name', async () => {
+        // Simulates express-fileupload's useTempFiles mode: the temp path
+        // itself is extensionless, but file.name carries the real
+        // extension, which must be used to derive the claimed extension.
+        const pngHeader = Buffer.from([
+            0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00,
+            0x0d, 0x49, 0x48, 0x44, 0x52, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00,
+            0x00, 0x01, 0x08, 0x02, 0x00, 0x00, 0x00, 0x90, 0x77, 0x53, 0xde,
+            0x00, 0x00, 0x00, 0x0c, 0x49, 0x44, 0x41, 0x54, 0x08, 0xd7, 0x63,
+            0xf8, 0xcf, 0xc0, 0x00, 0x00, 0x00, 0x02, 0x00, 0x01, 0xe2, 0x21,
+            0xbc, 0x33, 0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4e, 0x44, 0xae,
+            0x42, 0x60, 0x82
+        ]);
+        const filePath = path.join(tmpDir, 'tmp-5000-1029384756');
+        await writeFile(filePath, pngHeader);
+        const file: H5PFile = {
+            name: 'image.png',
+            tempFilePath: filePath,
+            mimetype: 'image/png',
+            size: pngHeader.length
+        };
+        await expect(validateContent(file)).resolves.toBeUndefined();
+    });
+
+    it('rejects a temp-file upload whose original filename has no extension', async () => {
+        const pngHeader = Buffer.from([
+            0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00,
+            0x0d, 0x49, 0x48, 0x44, 0x52, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00,
+            0x00, 0x01, 0x08, 0x02, 0x00, 0x00, 0x00, 0x90, 0x77, 0x53, 0xde,
+            0x00, 0x00, 0x00, 0x0c, 0x49, 0x44, 0x41, 0x54, 0x08, 0xd7, 0x63,
+            0xf8, 0xcf, 0xc0, 0x00, 0x00, 0x00, 0x02, 0x00, 0x01, 0xe2, 0x21,
+            0xbc, 0x33, 0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4e, 0x44, 0xae,
+            0x42, 0x60, 0x82
+        ]);
+        const filePath = path.join(tmpDir, 'tmp-5000-2938475610');
+        await writeFile(filePath, pngHeader);
+        const file: H5PFile = {
+            name: 'noextension',
+            tempFilePath: filePath,
+            mimetype: 'image/png',
+            size: pngHeader.length
+        };
+        await expect(validateContent(file)).rejects.toThrow(
+            'upload-validation-error'
+        );
+    });
+
+    it('accepts a genuine 0-byte buffer-only upload (no tempFilePath)', async () => {
+        const file: H5PFile = {
+            name: 'empty.png',
+            data: Buffer.alloc(0),
+            mimetype: 'image/png',
+            size: 0
+        };
+        await expect(validateContent(file)).resolves.toBeUndefined();
     });
 
     it('rejects when file has neither data nor tempFilePath', async () => {

--- a/packages/h5p-server/test/contentFileValidation.test.ts
+++ b/packages/h5p-server/test/contentFileValidation.test.ts
@@ -120,6 +120,18 @@ describe('validateFileContent', () => {
         await expect(validateFileContent(filePath)).resolves.toBeUndefined();
     });
 
+    it('rejects a file with no extension containing dangerous SVG content (simulating express-fileupload temp files)', async () => {
+        // express-fileupload's temp files (useTempFiles mode, the default)
+        // are always named without an extension (e.g. tmp-5000-<pid><ts>),
+        // regardless of the uploaded filename. Content inspection must not
+        // be skipped just because the temp path has no extension.
+        const filePath = path.join(tmpDir, 'tmp-5000-1234567890');
+        await writeFile(filePath, '<svg><script>alert(1)</script></svg>');
+        await expect(validateFileContent(filePath)).rejects.toThrow(
+            'upload-validation-error'
+        );
+    });
+
     it('rejects an empty string path', async () => {
         await expect(validateFileContent('')).rejects.toThrow(
             'upload-validation-error'
@@ -234,39 +246,39 @@ describe('validateBufferContent', () => {
         ).resolves.toBeUndefined();
     });
 
-    it('rejects an empty buffer', async () => {
+    it('accepts an empty buffer as a no-op, matching validateFileContent for empty files', async () => {
         const emptyBuffer = Buffer.alloc(0);
         await expect(
             validateBufferContent(emptyBuffer, 'empty.png')
-        ).rejects.toThrow('upload-validation-error');
-    });
-
-    it('rejects a null buffer', async () => {
-        await expect(
-            validateBufferContent(null as unknown as Buffer, 'null.png')
-        ).rejects.toThrow('upload-validation-error');
-    });
-
-    // Note: validateBufferContent writes to a temp file without extension,
-    // so content-type mismatch validation is not performed. These tests
-    // verify the function accepts the buffers (since there's no extension
-    // to compare against).
-    it('accepts a buffer containing XML/SVG content (no extension)', async () => {
-        const svgBuffer = Buffer.from(
-            '<svg xmlns="http://www.w3.org/2000/svg"><script>alert(1)</script></svg>'
-        );
-        await expect(
-            validateBufferContent(svgBuffer, 'image.svg')
         ).resolves.toBeUndefined();
     });
 
-    it('accepts a buffer containing HTML content (no extension)', async () => {
+    it('accepts a null buffer as a no-op', async () => {
+        await expect(
+            validateBufferContent(null as unknown as Buffer, 'null.png')
+        ).resolves.toBeUndefined();
+    });
+
+    // Note: validateBufferContent always inspects the buffer's content,
+    // regardless of whether the filename carries an extension. These tests
+    // verify that dangerous XML/SVG/HTML content is rejected even when the
+    // filename has no extension to compare against.
+    it('rejects a buffer containing XML/SVG content (no extension)', async () => {
+        const svgBuffer = Buffer.from(
+            '<svg xmlns="http://www.w3.org/2000/svg"><script>alert(1)</script></svg>'
+        );
+        await expect(validateBufferContent(svgBuffer, 'image')).rejects.toThrow(
+            'upload-validation-error'
+        );
+    });
+
+    it('rejects a buffer containing HTML content (no extension)', async () => {
         const htmlBuffer = Buffer.from(
             '<html><body><script>alert(1)</script></body></html>'
         );
         await expect(
             validateBufferContent(htmlBuffer, 'index')
-        ).resolves.toBeUndefined();
+        ).rejects.toThrow('upload-validation-error');
     });
 
     it('accepts a valid JSON buffer', async () => {
@@ -328,6 +340,47 @@ describe('validateContent', () => {
         await expect(validateContent(file)).resolves.toBeUndefined();
     });
 
+    it('follows file.tempFilePath when file.data is a truthy-but-empty buffer, as produced by express-fileupload in useTempFiles mode', async () => {
+        // express-fileupload's useTempFiles mode (the default/documented
+        // configuration) sets file.data to Buffer.concat([]) -- an empty
+        // but still truthy Buffer -- alongside a real file.tempFilePath.
+        // validateContent must not mistake this for a buffer upload.
+        const pngHeader = Buffer.from([
+            0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00,
+            0x0d, 0x49, 0x48, 0x44, 0x52, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00,
+            0x00, 0x01, 0x08, 0x02, 0x00, 0x00, 0x00, 0x90, 0x77, 0x53, 0xde,
+            0x00, 0x00, 0x00, 0x0c, 0x49, 0x44, 0x41, 0x54, 0x08, 0xd7, 0x63,
+            0xf8, 0xcf, 0xc0, 0x00, 0x00, 0x00, 0x02, 0x00, 0x01, 0xe2, 0x21,
+            0xbc, 0x33, 0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4e, 0x44, 0xae,
+            0x42, 0x60, 0x82
+        ]);
+        const filePath = path.join(tmpDir, 'image.png');
+        await writeFile(filePath, pngHeader);
+        const file: H5PFile = {
+            name: 'image.png',
+            data: Buffer.concat([]),
+            tempFilePath: filePath,
+            mimetype: 'image/png',
+            size: pngHeader.length
+        };
+        await expect(validateContent(file)).resolves.toBeUndefined();
+    });
+
+    it('rejects malicious content via file.tempFilePath even when file.data is a truthy-but-empty buffer', async () => {
+        const filePath = path.join(tmpDir, 'malicious.png');
+        await writeFile(filePath, '<svg><script>alert(1)</script></svg>');
+        const file: H5PFile = {
+            name: 'malicious.png',
+            data: Buffer.concat([]),
+            tempFilePath: filePath,
+            mimetype: 'image/png',
+            size: 1024
+        };
+        await expect(validateContent(file)).rejects.toThrow(
+            'upload-validation-error'
+        );
+    });
+
     it('rejects when file has neither data nor tempFilePath', async () => {
         const file: H5PFile = {
             name: 'orphan.png',
@@ -339,17 +392,20 @@ describe('validateContent', () => {
         );
     });
 
-    // Note: When using file.data, validateBufferContent creates a temp file
-    // without extension, so content validation is skipped. Malicious content
-    // can only be detected via file.tempFilePath which preserves the extension.
-    it('accepts malicious buffer content via file.data (no extension in temp)', async () => {
+    // Note: validateBufferContent always inspects the buffer's content,
+    // regardless of whether file.name carries an extension. Malicious
+    // content is rejected via file.data just as it would be via
+    // file.tempFilePath.
+    it('rejects malicious buffer content via file.data (no extension)', async () => {
         const file: H5PFile = {
             name: 'malicious',
             data: Buffer.from('<svg><script>alert(1)</script></svg>'),
             mimetype: 'image/png',
             size: 1024
         };
-        await expect(validateContent(file)).resolves.toBeUndefined();
+        await expect(validateContent(file)).rejects.toThrow(
+            'upload-validation-error'
+        );
     });
 
     it('rejects malicious file content via file.tempFilePath', async () => {

--- a/packages/h5p-svg-sanitizer/src/SvgSanitizer.ts
+++ b/packages/h5p-svg-sanitizer/src/SvgSanitizer.ts
@@ -15,8 +15,11 @@ const DOMPurify = createDOMPurify(window);
 export default class SvgSanitizer implements IFileSanitizer {
     readonly name: string = 'SVG Sanitizer based on dompurify package';
 
-    async sanitize(file: string): Promise<FileSanitizerResult> {
-        if (!this.isSvgFile(basename(file))) {
+    async sanitize(
+        file: string,
+        originalFilename?: string
+    ): Promise<FileSanitizerResult> {
+        if (!this.isSvgFile(basename(originalFilename ?? file))) {
             return FileSanitizerResult.Ignored;
         }
 

--- a/packages/h5p-svg-sanitizer/src/SvgSanitizer.ts
+++ b/packages/h5p-svg-sanitizer/src/SvgSanitizer.ts
@@ -27,6 +27,10 @@ export default class SvgSanitizer implements IFileSanitizer {
         return FileSanitizerResult.Sanitized;
     }
 
+    /**
+     * Sanitizes an in-memory SVG buffer. Replaces `file.data` with the
+     * sanitized buffer in place.
+     */
     async sanitizeBuffer(file: H5PFileBuffer): Promise<FileSanitizerResult> {
         if (!this.isSvgFile(file.name)) {
             return FileSanitizerResult.Ignored;
@@ -50,6 +54,7 @@ export default class SvgSanitizer implements IFileSanitizer {
         });
     }
 
+    // Case-insensitive so e.g. "image.SVG" is sanitized too, not just "image.svg".
     private isSvgFile(fileName: string): boolean {
         return fileName.toLowerCase().endsWith('.svg');
     }

--- a/packages/h5p-svg-sanitizer/src/SvgSanitizer.ts
+++ b/packages/h5p-svg-sanitizer/src/SvgSanitizer.ts
@@ -1,8 +1,13 @@
 import createDOMPurify from 'dompurify';
-import { JSDOM } from 'jsdom';
 import { readFile, writeFile } from 'fs/promises';
+import { JSDOM } from 'jsdom';
 
-import { FileSanitizerResult, IFileSanitizer } from '@lumieducation/h5p-server';
+import {
+    FileSanitizerResult,
+    H5PFileBuffer,
+    IFileSanitizer
+} from '@lumieducation/h5p-server';
+import { basename } from 'path';
 
 const window = new JSDOM('').window;
 const DOMPurify = createDOMPurify(window);
@@ -11,15 +16,41 @@ export default class SvgSanitizer implements IFileSanitizer {
     readonly name: string = 'SVG Sanitizer based on dompurify package';
 
     async sanitize(file: string): Promise<FileSanitizerResult> {
-        if (!file.endsWith('.svg')) {
+        if (!this.isSvgFile(basename(file))) {
             return FileSanitizerResult.Ignored;
         }
+
         const svgString = await readFile(file, 'utf8');
-        const sanitizedSvgString = DOMPurify.sanitize(svgString, {
+        const sanitizedSvgString = this.sanitizeSvgString(svgString);
+        await writeFile(file, sanitizedSvgString, 'utf8');
+
+        return FileSanitizerResult.Sanitized;
+    }
+
+    async sanitizeBuffer(file: H5PFileBuffer): Promise<FileSanitizerResult> {
+        if (!this.isSvgFile(file.name)) {
+            return FileSanitizerResult.Ignored;
+        }
+        if (!file.data) {
+            throw new Error(
+                'SvgSanitizer.sanitizeBuffer was called without file.data'
+            );
+        }
+
+        const svgString = file.data.toString('utf8');
+        const sanitizedSvgString = this.sanitizeSvgString(svgString);
+        file.data = Buffer.from(sanitizedSvgString, 'utf8');
+
+        return FileSanitizerResult.Sanitized;
+    }
+
+    private sanitizeSvgString(svgString: string): string {
+        return DOMPurify.sanitize(svgString, {
             USE_PROFILES: { svg: true }
         });
+    }
 
-        await writeFile(file, sanitizedSvgString, 'utf8');
-        return FileSanitizerResult.Sanitized;
+    private isSvgFile(fileName: string): boolean {
+        return fileName.toLowerCase().endsWith('.svg');
     }
 }

--- a/packages/h5p-svg-sanitizer/test/SvgSanitizer.test.ts
+++ b/packages/h5p-svg-sanitizer/test/SvgSanitizer.test.ts
@@ -1,77 +1,339 @@
-import tmp from 'tmp-promise';
-import { writeFile, readFile } from 'fs/promises';
+import { readFile, writeFile } from 'fs/promises';
 import { JSDOM } from 'jsdom';
+import tmp from 'tmp-promise';
 
+import { FileSanitizerResult, H5PFileBuffer } from '../../h5p-server/src/types';
 import SvgSanitizer from '../src/SvgSanitizer';
-import { FileSanitizerResult } from '../../h5p-server/src/types';
+
+const createFileBuffer = (data: Buffer, name: string): H5PFileBuffer => ({
+    data,
+    mimetype: '',
+    name,
+    size: data.length
+});
 
 describe('SvgSanitizer', () => {
-    it("doesn't alter clean SVG", async () => {
-        await tmp.withFile(
-            async ({ path }) => {
-                const svg = `<svg version="1.1" xmlns="http://www.w3.org/2000/svg">
+    describe('when sanitizing SVG files', () => {
+        it("doesn't alter clean SVG", async () => {
+            await tmp.withFile(
+                async ({ path }) => {
+                    const svg = `<svg version="1.1" xmlns="http://www.w3.org/2000/svg">
                         <circle style="fill:#666666;stroke:#808080;stroke-width:4.40315;stop-color:#000000" id="path233" cx="98.428535" cy="68.415733" r="54.194405"></circle>
                      </svg>`;
-                await writeFile(path, svg);
-                const dom1 = new JSDOM(svg, { contentType: 'image/svg+xml' });
+                    await writeFile(path, svg, 'utf8');
+                    const dom1 = new JSDOM(svg, {
+                        contentType: 'image/svg+xml'
+                    });
 
-                const result = await new SvgSanitizer().sanitize(path);
-                expect(result).toBe(FileSanitizerResult.Sanitized);
-                const svg2 = await readFile(path, 'utf-8');
-                const dom2 = new JSDOM(svg2, { contentType: 'image/svg+xml' });
-                expect(
-                    dom2.window.document.documentElement.isEqualNode(
-                        dom1.window.document.documentElement
-                    )
-                ).toBe(true);
-            },
-            { postfix: '.svg', keep: false }
-        );
-    });
+                    const result = await new SvgSanitizer().sanitize(path);
+                    expect(result).toBe(FileSanitizerResult.Sanitized);
+                    const svg2 = await readFile(path, 'utf-8');
+                    const dom2 = new JSDOM(svg2, {
+                        contentType: 'image/svg+xml'
+                    });
+                    expect(
+                        dom2.window.document.documentElement.isEqualNode(
+                            dom1.window.document.documentElement
+                        )
+                    ).toBe(true);
+                },
+                { postfix: '.svg', keep: false }
+            );
+        });
 
-    it('cleans malicious SVG', async () => {
-        await tmp.withFile(
-            async ({ path }) => {
-                const maliciousSvg = `<svg version="1.1" xmlns="http://www.w3.org/2000/svg">
+        it('cleans malicious SVG', async () => {
+            await tmp.withFile(
+                async ({ path }) => {
+                    const maliciousSvg = `<svg version="1.1" xmlns="http://www.w3.org/2000/svg">
                       <script>alert(document.cookie);</script>
                       <circle r="54.194405" cy="68.415733" cx="98.428535" id="path233" style="fill:#666666;stroke:#808080;stroke-width:4.40315;stop-color:#000000"></circle>
                     </svg>`;
-                await writeFile(path, maliciousSvg);
-                const dom1 = new JSDOM(maliciousSvg, {
-                    contentType: 'image/svg+xml'
-                });
+                    await writeFile(path, maliciousSvg, 'utf8');
+                    const dom1 = new JSDOM(maliciousSvg, {
+                        contentType: 'image/svg+xml'
+                    });
 
-                const result = await new SvgSanitizer().sanitize(path);
-                expect(result).toBe(FileSanitizerResult.Sanitized);
+                    const result = await new SvgSanitizer().sanitize(path);
+                    expect(result).toBe(FileSanitizerResult.Sanitized);
 
-                const sanitizedSvg = await readFile(path, 'utf-8');
-                const dom2 = new JSDOM(sanitizedSvg, {
-                    contentType: 'image/svg+xml'
-                });
+                    const sanitizedSvg = await readFile(path, 'utf-8');
+                    const dom2 = new JSDOM(sanitizedSvg, {
+                        contentType: 'image/svg+xml'
+                    });
 
-                // Ensure that the SVG was mutated
-                expect(
-                    dom2.window.document.documentElement.isEqualNode(
-                        dom1.window.document.documentElement
-                    )
-                ).toBe(false);
+                    // Ensure that the SVG was mutated
+                    expect(
+                        dom2.window.document.documentElement.isEqualNode(
+                            dom1.window.document.documentElement
+                        )
+                    ).toBe(false);
 
-                // Ensure the script tag is removed
-                expect(dom2.window.document.querySelector('script')).toBeNull();
-            },
-            { postfix: '.svg', keep: false }
-        );
+                    // Ensure the script tag is removed
+                    expect(
+                        dom2.window.document.querySelector('script')
+                    ).toBeNull();
+                },
+                { postfix: '.svg', keep: false }
+            );
+        });
+
+        it('ignores files other than SVG', async () => {
+            await tmp.withFile(
+                async ({ path }) => {
+                    await writeFile(path, 'some text', 'utf8');
+
+                    const result = await new SvgSanitizer().sanitize(path);
+                    expect(result).toBe(FileSanitizerResult.Ignored);
+                },
+                { postfix: '.txt', keep: false }
+            );
+        });
     });
 
-    it('ignores files other than SVG', async () => {
-        await tmp.withFile(
-            async ({ path }) => {
-                await writeFile(path, 'some text');
+    describe('when sanitizing buffers', () => {
+        it("doesn't alter clean SVG", async () => {
+            const svg = `<svg version="1.1" xmlns="http://www.w3.org/2000/svg">
+                <circle style="fill:#666666;stroke:#808080;stroke-width:4.40315;stop-color:#000000" id="path233" cx="98.428535" cy="68.415733" r="54.194405"></circle>
+             </svg>`;
+            const data = Buffer.from(svg, 'utf8');
+            const dom1 = new JSDOM(svg, {
+                contentType: 'image/svg+xml'
+            });
 
-                const result = await new SvgSanitizer().sanitize(path);
-                expect(result).toBe(FileSanitizerResult.Ignored);
-            },
-            { postfix: '.txt', keep: false }
-        );
+            const file = createFileBuffer(data, 'image.svg');
+            const result = await new SvgSanitizer().sanitizeBuffer(file);
+            expect(result).toBe(FileSanitizerResult.Sanitized);
+
+            const svg2 = file.data.toString('utf8');
+            const dom2 = new JSDOM(svg2, {
+                contentType: 'image/svg+xml'
+            });
+            expect(
+                dom2.window.document.documentElement.isEqualNode(
+                    dom1.window.document.documentElement
+                )
+            ).toBe(true);
+        });
+
+        it('cleans malicious SVG', async () => {
+            const maliciousSvg = `<svg version="1.1" xmlns="http://www.w3.org/2000/svg">
+              <script>alert(document.cookie);</script>
+              <circle r="54.194405" cy="68.415733" cx="98.428535" id="path233" style="fill:#666666;stroke:#808080;stroke-width:4.40315;stop-color:#000000"></circle>
+            </svg>`;
+            const data = Buffer.from(maliciousSvg, 'utf8');
+            const dom1 = new JSDOM(maliciousSvg, {
+                contentType: 'image/svg+xml'
+            });
+
+            const file = createFileBuffer(data, 'image.svg');
+            const result = await new SvgSanitizer().sanitizeBuffer(file);
+            expect(result).toBe(FileSanitizerResult.Sanitized);
+
+            const sanitizedSvg = file.data.toString('utf8');
+            const dom2 = new JSDOM(sanitizedSvg, {
+                contentType: 'image/svg+xml'
+            });
+
+            // Ensure that the SVG was mutated
+            expect(
+                dom2.window.document.documentElement.isEqualNode(
+                    dom1.window.document.documentElement
+                )
+            ).toBe(false);
+
+            // Ensure the script tag is removed
+            expect(dom2.window.document.querySelector('script')).toBeNull();
+        });
+
+        it('ignores files other than SVG', async () => {
+            const data = Buffer.from('some text', 'utf8');
+
+            const file = createFileBuffer(data, 'file.txt');
+            const result = await new SvgSanitizer().sanitizeBuffer(file);
+            expect(result).toBe(FileSanitizerResult.Ignored);
+        });
+
+        it('throws when called without file.data', async () => {
+            const file = { mimetype: '', name: 'image.svg', size: 0 } as any;
+            await expect(
+                new SvgSanitizer().sanitizeBuffer(file)
+            ).rejects.toThrow();
+        });
+    });
+
+    describe('case-insensitive extension matching', () => {
+        it('sanitizes files with uppercase .SVG extension', async () => {
+            await tmp.withFile(
+                async ({ path }) => {
+                    const maliciousSvg = `<svg version="1.1" xmlns="http://www.w3.org/2000/svg">
+                      <script>alert(document.cookie);</script>
+                      <circle r="54.194405" cy="68.415733" cx="98.428535" id="path233"></circle>
+                    </svg>`;
+                    await writeFile(path, maliciousSvg, 'utf8');
+
+                    const result = await new SvgSanitizer().sanitize(path);
+                    expect(result).toBe(FileSanitizerResult.Sanitized);
+
+                    const sanitizedSvg = await readFile(path, 'utf-8');
+                    const dom = new JSDOM(sanitizedSvg, {
+                        contentType: 'image/svg+xml'
+                    });
+                    expect(
+                        dom.window.document.querySelector('script')
+                    ).toBeNull();
+                },
+                { postfix: '.SVG', keep: false }
+            );
+        });
+
+        it('sanitizes files with mixed case .Svg extension', async () => {
+            await tmp.withFile(
+                async ({ path }) => {
+                    const maliciousSvg = `<svg version="1.1" xmlns="http://www.w3.org/2000/svg">
+                      <script>alert(document.cookie);</script>
+                      <circle r="54.194405" cy="68.415733" cx="98.428535" id="path233"></circle>
+                    </svg>`;
+                    await writeFile(path, maliciousSvg, 'utf8');
+
+                    const result = await new SvgSanitizer().sanitize(path);
+                    expect(result).toBe(FileSanitizerResult.Sanitized);
+
+                    const sanitizedSvg = await readFile(path, 'utf-8');
+                    const dom = new JSDOM(sanitizedSvg, {
+                        contentType: 'image/svg+xml'
+                    });
+                    expect(
+                        dom.window.document.querySelector('script')
+                    ).toBeNull();
+                },
+                { postfix: '.Svg', keep: false }
+            );
+        });
+
+        it('sanitizes buffers with uppercase .SVG extension', async () => {
+            const maliciousSvg = `<svg version="1.1" xmlns="http://www.w3.org/2000/svg">
+              <script>alert(document.cookie);</script>
+              <circle r="54.194405" cy="68.415733" cx="98.428535" id="path233"></circle>
+            </svg>`;
+            const data = Buffer.from(maliciousSvg, 'utf8');
+
+            const file = createFileBuffer(data, 'test.SVG');
+            const result = await new SvgSanitizer().sanitizeBuffer(file);
+            expect(result).toBe(FileSanitizerResult.Sanitized);
+
+            const sanitizedSvg = file.data.toString('utf8');
+            const dom = new JSDOM(sanitizedSvg, {
+                contentType: 'image/svg+xml'
+            });
+            expect(dom.window.document.querySelector('script')).toBeNull();
+        });
+    });
+
+    describe('when sanitizing with string path input', () => {
+        it("doesn't alter clean SVG when passed as string path", async () => {
+            await tmp.withFile(
+                async ({ path: filePath }) => {
+                    const svg = `<svg version="1.1" xmlns="http://www.w3.org/2000/svg">
+                        <circle style="fill:#666666;stroke:#808080;stroke-width:4.40315;stop-color:#000000" id="path233" cx="98.428535" cy="68.415733" r="54.194405"></circle>
+                     </svg>`;
+                    await writeFile(filePath, svg, 'utf8');
+                    const dom1 = new JSDOM(svg, {
+                        contentType: 'image/svg+xml'
+                    });
+
+                    const result = await new SvgSanitizer().sanitize(filePath);
+                    expect(result).toBe(FileSanitizerResult.Sanitized);
+
+                    const svg2 = await readFile(filePath, 'utf-8');
+                    const dom2 = new JSDOM(svg2, {
+                        contentType: 'image/svg+xml'
+                    });
+                    expect(
+                        dom2.window.document.documentElement.isEqualNode(
+                            dom1.window.document.documentElement
+                        )
+                    ).toBe(true);
+                },
+                { postfix: '.svg', keep: false }
+            );
+        });
+
+        it('cleans malicious SVG when passed as string path', async () => {
+            await tmp.withFile(
+                async ({ path: filePath }) => {
+                    const maliciousSvg = `<svg version="1.1" xmlns="http://www.w3.org/2000/svg">
+                      <script>alert(document.cookie);</script>
+                      <circle r="54.194405" cy="68.415733" cx="98.428535" id="path233" style="fill:#666666;stroke:#808080;stroke-width:4.40315;stop-color:#000000"></circle>
+                    </svg>`;
+                    await writeFile(filePath, maliciousSvg, 'utf8');
+
+                    const result = await new SvgSanitizer().sanitize(filePath);
+                    expect(result).toBe(FileSanitizerResult.Sanitized);
+
+                    const sanitizedSvg = await readFile(filePath, 'utf-8');
+                    const dom = new JSDOM(sanitizedSvg, {
+                        contentType: 'image/svg+xml'
+                    });
+
+                    expect(
+                        dom.window.document.querySelector('script')
+                    ).toBeNull();
+                },
+                { postfix: '.svg', keep: false }
+            );
+        });
+
+        it('ignores non-SVG files when passed as string path', async () => {
+            await tmp.withFile(
+                async ({ path: filePath }) => {
+                    await writeFile(filePath, 'some text', 'utf8');
+
+                    const result = await new SvgSanitizer().sanitize(filePath);
+                    expect(result).toBe(FileSanitizerResult.Ignored);
+                },
+                { postfix: '.txt', keep: false }
+            );
+        });
+
+        it('handles uppercase .SVG extension when passed as string path', async () => {
+            await tmp.withFile(
+                async ({ path: filePath }) => {
+                    const maliciousSvg = `<svg version="1.1" xmlns="http://www.w3.org/2000/svg">
+                      <script>alert(document.cookie);</script>
+                      <circle r="54.194405" cy="68.415733" cx="98.428535" id="path233"></circle>
+                    </svg>`;
+                    await writeFile(filePath, maliciousSvg, 'utf8');
+
+                    const result = await new SvgSanitizer().sanitize(filePath);
+                    expect(result).toBe(FileSanitizerResult.Sanitized);
+
+                    const sanitizedSvg = await readFile(filePath, 'utf-8');
+                    const dom = new JSDOM(sanitizedSvg, {
+                        contentType: 'image/svg+xml'
+                    });
+                    expect(
+                        dom.window.document.querySelector('script')
+                    ).toBeNull();
+                },
+                { postfix: '.SVG', keep: false }
+            );
+        });
+
+        it('normalizes string path to extract filename correctly', async () => {
+            await tmp.withFile(
+                async ({ path: filePath }) => {
+                    const svg = `<svg version="1.1" xmlns="http://www.w3.org/2000/svg">
+                        <circle cx="50" cy="50" r="40"></circle>
+                     </svg>`;
+                    await writeFile(filePath, svg, 'utf8');
+
+                    // The path contains directory components, but normalization
+                    // should extract only the basename for extension checking
+                    const result = await new SvgSanitizer().sanitize(filePath);
+                    expect(result).toBe(FileSanitizerResult.Sanitized);
+                },
+                { postfix: '.svg', keep: false }
+            );
+        });
     });
 });

--- a/packages/h5p-svg-sanitizer/test/SvgSanitizer.test.ts
+++ b/packages/h5p-svg-sanitizer/test/SvgSanitizer.test.ts
@@ -319,6 +319,52 @@ describe('SvgSanitizer', () => {
             );
         });
 
+        it('sanitizes an extensionless temp path when originalFilename carries the .svg extension', async () => {
+            // express-fileupload's temp files (useTempFiles mode) are always
+            // extensionless (e.g. tmp-5000-<pid><ts>), regardless of the
+            // uploaded filename. The sanitizer must fall back to the
+            // original filename to detect that the file is an SVG.
+            await tmp.withFile(
+                async ({ path: filePath }) => {
+                    const maliciousSvg = `<svg version="1.1" xmlns="http://www.w3.org/2000/svg">
+                      <script>alert(document.cookie);</script>
+                      <circle r="54.194405" cy="68.415733" cx="98.428535" id="path233"></circle>
+                    </svg>`;
+                    await writeFile(filePath, maliciousSvg, 'utf8');
+
+                    const result = await new SvgSanitizer().sanitize(
+                        filePath,
+                        'image.svg'
+                    );
+                    expect(result).toBe(FileSanitizerResult.Sanitized);
+
+                    const sanitizedSvg = await readFile(filePath, 'utf-8');
+                    const dom = new JSDOM(sanitizedSvg, {
+                        contentType: 'image/svg+xml'
+                    });
+                    expect(
+                        dom.window.document.querySelector('script')
+                    ).toBeNull();
+                },
+                { postfix: '', keep: false }
+            );
+        });
+
+        it('ignores a file when originalFilename has no SVG extension, even if the path does', async () => {
+            await tmp.withFile(
+                async ({ path: filePath }) => {
+                    await writeFile(filePath, 'some text', 'utf8');
+
+                    const result = await new SvgSanitizer().sanitize(
+                        filePath,
+                        'document.txt'
+                    );
+                    expect(result).toBe(FileSanitizerResult.Ignored);
+                },
+                { postfix: '.svg', keep: false }
+            );
+        });
+
         it('normalizes string path to extract filename correctly', async () => {
             await tmp.withFile(
                 async ({ path: filePath }) => {


### PR DESCRIPTION
Based on #4362 (own branch because we adopted the PR).

## What this does

Until now, file sanitization (`IFileSanitizer`) and malware scanning
(`IFileMalwareScanner`) only ran for uploads that were backed by a temporary
file on disk. Integrators whose upload middleware keeps files in memory (e.g.
`express-fileupload` without `useTempFiles`) silently got **no** SVG
sanitization and **no** virus scanning — the docs stated this limitation, but
nothing in the code signalled it at runtime.

This PR makes both plugin types work for in-memory buffers as well, so
`H5PEditor.saveContentFile` behaves the same regardless of how the integrator
receives uploads.

## The interfaces

`H5PFile` and `H5PFileBuffer` are now exported from `h5p-server` and used
everywhere an uploaded file is passed around (previously the same anonymous
`{ data?, mimetype, name, size, tempFilePath? }` shape was inlined in
`H5PAjaxEndpoint`, `h5p-express`'s `IActionRequest`, and elsewhere).

Both plugin interfaces gain an **optional** buffer method:

```ts
interface IFileMalwareScanner {
    scan(file: string): Promise<{ result: MalwareScanResult; viruses?: string }>;
    scanBuffer?(file: H5PFileBuffer): Promise<{ result: MalwareScanResult; viruses?: string }>;
}

interface IFileSanitizer {
    sanitize(file: string, originalFilename?: string): Promise<FileSanitizerResult>;
    sanitizeBuffer?(file: H5PFileBuffer): Promise<FileSanitizerResult>;
}
```

Both additions are backwards compatible: **existing implementations keep
working unchanged.** If a plugin doesn't implement the buffer method,
`H5PEditor` writes the buffer to a temporary file, calls the path-based
method, and reads the result back. When several path-based scanners run on the
same buffer, that temporary file is written **once** and shared between them.

`sanitize` additionally takes an optional `originalFilename`. Upload
middlewares typically generate extensionless temp paths
(`tmp-5000-1567887897`), so a sanitizer that decides what to do based on the
file name needs the *original* name, not the path it was handed. It defaults
to `file`, so existing callers and implementations are unaffected.

## Buffer vs. temp file precedence

Every code path that has to choose between `file.data` and `file.tempFilePath`
— validation, sanitization, malware scanning and persistence — now goes
through one shared `hasBufferData()` helper, so they can no longer disagree
about what the actual file content is:

- `data` wins whenever it carries content;
- a *defined but empty* `data` alongside a real `tempFilePath` (an
  `express-fileupload` `useTempFiles` quirk — it always sets
  `data = Buffer.concat([])`) defers to the file on disk;
- a defined empty `data` with no `tempFilePath` (a genuine 0-byte buffer-only
  upload) is authoritative, since there is nothing to fall back to.

Before this, `sanitizeFile`/`scanForMalware` preferred `tempFilePath` while
validation and persistence preferred `data`. For middleware that populates
both, the sanitizer rewrote the temp file while the *unsanitized* buffer was
what actually got stored — an XSS-carrying SVG would have been persisted
unsanitized.

## Content validation

`contentFileValidation` now handles buffers (`validateBufferContent`) in
addition to paths, and the claimed extension is always derived from the
**original filename**, never from a middleware-generated path. Deriving it
from an extensionless temp path made `extensionMatchesDetected('', [...])`
fail every tier, so any file whose magic bytes *were* recognized got rejected
with `upload-validation-error` — i.e. in a `useTempFiles: true` setup (what
both example apps use) no image, audio or video could be uploaded at all.

A file whose original filename has no extension is now rejected outright in
both the buffer and the temp-file path. This is belt-and-braces —
`H5PEditor.saveContentFile`'s whitelist check and
`PackageValidator.isAllowedFileExtension` already reject those upstream — but
it makes the validator fail closed instead of depending on its callers. Side
effect: for an extensionless editor upload the surfaced error is now
`upload-validation-error` rather than `not-in-whitelist`, because validation
runs before the whitelist check.

## Package changes

**`h5p-svg-sanitizer`** implements `sanitizeBuffer`. Its SVG detection now
uses `originalFilename` (falling back to the path) and is case-insensitive, so
`image.SVG` is sanitized too. Previously it decided SVG-ness from the path it
was given, which for a real editor upload is the extensionless temp path — so
in exactly the setup the docs recommend for malware scanning, every SVG upload
returned `Ignored` and was never sanitized.

**`h5p-clamav-scanner`** implements `scanBuffer`, streaming the buffer
directly to the clamd daemon when one is configured, and otherwise falling
back to a temporary file. Whether a daemon is available is read back from
clamscan's *resolved* settings and additionally requires a resolved
`socket`/`port`/`host`: clamscan's `scanner` defaults to `'clamdscan'` even
with no connection configured (it then shells out to the local binary), and
`scanStream` rejects with *"A unix socket or port (+ optional host) is
required!"* in that case. `scanBuffer` caught that rejection and returned
`NotScanned`, and `saveContentFile` only rejects on `MalwareFound` — so an
infected buffer upload was accepted with no scan and no error.

## Also included

- Docs (`docs/advanced/security.md`, `h5p-clamav-scanner/README.md`) no longer
  claim that sanitization/scanning requires temporary files.
- Unrelated fix carried over from #4362: `LibraryManager` reported
  `installLibraryLockTimeout` in the
  `server:install-library-lock-max-time-exceeded` error where it meant
  `installLibraryLockMaxOccupationTime`.
- `h5p-rest-example-server` route params are `.toString()`-ed for the
  Express 5 typings.

## Testing

+2318/-374 across 21 files, roughly half of it tests. New coverage for the
buffer paths in `contentFileValidation`, `H5PEditor.saving`, `SvgSanitizer`
and `ClamAVScanner`, including: extensionless filenames (rejected),
extensionless temp paths with a proper `file.name` (accepted), genuine 0-byte
buffer-only uploads, SVG sanitization driven by `originalFilename`, and
regressions proving `file.data` rather than a stale `tempFilePath` is what
gets sanitized and scanned when both are present.

All CI checks pass, including `clamav-tests`, which runs the scanner suite
against a real `clamav/clamav` daemon service.
