### PR TITLE
fix(h5p-mongos3): honor byte range requests starting at 0

### DIFF
--- a/packages/h5p-mongos3/src/MongoS3ContentStorage.ts
+++ b/packages/h5p-mongos3/src/MongoS3ContentStorage.ts
@@ -407,7 +407,7 @@ export default class MongoS3ContentStorage implements IContentStorage {
                 Bucket: this.options.s3Bucket,
                 Key: MongoS3ContentStorage.getS3Key(contentId, filename),
                 Range:
-                    rangeStart && rangeEnd
+                    rangeStart !== undefined && rangeEnd !== undefined
                         ? `bytes=${rangeStart}-${rangeEnd}`
                         : undefined
             })

--- a/packages/h5p-mongos3/src/S3TemporaryFileStorage.ts
+++ b/packages/h5p-mongos3/src/S3TemporaryFileStorage.ts
@@ -195,7 +195,7 @@ export default class S3TemporaryFileStorage implements ITemporaryFileStorage {
                 Bucket: this.options?.s3Bucket,
                 Key: filename,
                 Range:
-                    rangeStart && rangeEnd
+                    rangeStart !== undefined && rangeEnd !== undefined
                         ? `bytes=${rangeStart}-${rangeEnd}`
                         : undefined
             })


### PR DESCRIPTION
## Summary
- `getFileStream` in both `S3TemporaryFileStorage` and `MongoS3ContentStorage` used `rangeStart && rangeEnd` to decide whether to set the S3 `Range` header.
- Since `0` is falsy in JavaScript, a range request with `rangeStart === 0` (e.g. streaming the beginning of a file, or the first chunk of a video seek) silently dropped the `Range` header and returned the entire object instead of the requested byte range.
- Changed the condition to `rangeStart !== undefined && rangeEnd !== undefined` so range 0 is honored correctly.

## Test plan
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm test` (359 tests passing via pre-push hook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YDFgekTx6FTCqB9Dtwgc73