### PR TITLE
fix(h5p-express): stream error handler throws ERR_HTTP_HEADERS_SENT after writeHead

### DIFF
--- a/packages/h5p-express/src/H5PAjaxRouter/H5PAjaxExpressController.ts
+++ b/packages/h5p-express/src/H5PAjaxRouter/H5PAjaxExpressController.ts
@@ -219,7 +219,11 @@ export default class H5PAjaxExpressController {
         });
 
         readStream.on('error', (err) => {
-            response.status(404).end();
+            if (!response.headersSent) {
+                response.status(404).end();
+            } else {
+                response.end();
+            }
         });
         response.on('close', () => readStream.destroy());
         readStream.pipe(response);
@@ -249,7 +253,11 @@ export default class H5PAjaxExpressController {
         });
 
         readStream.on('error', (err) => {
-            response.status(404).end();
+            if (!response.headersSent) {
+                response.status(404).end();
+            } else {
+                response.end();
+            }
         });
         response.on('close', () => readStream.destroy());
         readStream.pipe(response);


### PR DESCRIPTION
## Summary
- `writeHead` is always called before `.pipe()` in `pipeStreamToPartialResponse` and `pipeStreamToResponse`, so headers are already sent by the time a stream `'error'` event can fire (e.g. a storage backend connection drop mid-transfer)
- The error handlers unconditionally called `response.status(404).end()`, which throws `ERR_HTTP_HEADERS_SENT` once headers are sent, potentially crashing the process
- Both handlers now check `response.headersSent` and call `response.end()` instead when headers were already sent

Fixes #4426

## Test plan
- [x] `npm run lint` and `npm run format:check` pass (pre-commit hook)
- [x] `npm test` passes (359 tests, pre-push hook)