### PR TITLE
fix(test): raise hookTimeout and dedupe upload in H5PAjaxExpressRouter test

### DIFF
--- a/packages/h5p-express/test/H5PAjaxExpressRouter.test.ts
+++ b/packages/h5p-express/test/H5PAjaxExpressRouter.test.ts
@@ -377,51 +377,42 @@ describe('Express Ajax endpoint adapter', () => {
         ]);
     });
 
-    describe('tests requiring uploaded files', () => {
-        let mockApp;
-        let uploadResult: any;
-        beforeEach(async () => {
-            mockApp = supertest(app);
-            uploadResult = await mockApp
-                .post(`/ajax?action=library-upload`)
-                .attach('h5p', path.resolve('test/data/validator/valid2.h5p'), {
-                    contentType: 'application/zip',
-                    filename: 'valid2.h5p'
-                });
-        });
+    it('should upload h5p packages successfully and make their temporary files accessible', async () => {
+        const mockApp = supertest(app);
+        const uploadResult = await mockApp
+            .post(`/ajax?action=library-upload`)
+            .attach('h5p', path.resolve('test/data/validator/valid2.h5p'), {
+                contentType: 'application/zip',
+                filename: 'valid2.h5p'
+            });
 
-        it('should upload h5p packages successfully', async () => {
-            expect(uploadResult.status).toBe(200);
-            const returned = JSON.parse(uploadResult.text);
-            expect(returned.data.content).toMatchObject({
-                greeting: 'Hello world!',
-                image: {
-                    copyright: { license: 'U' },
-                    height: 300,
-                    width: 300
+        expect(uploadResult.status).toBe(200);
+        const returned = JSON.parse(uploadResult.text);
+        expect(returned.data.content).toMatchObject({
+            greeting: 'Hello world!',
+            image: {
+                copyright: { license: 'U' },
+                height: 300,
+                width: 300
+            }
+        });
+        expect(returned.data.h5p).toMatchObject({
+            embedTypes: ['div'],
+            language: 'und',
+            license: 'U',
+            mainLibrary: 'H5P.GreetingCard',
+            preloadedDependencies: [
+                {
+                    machineName: 'H5P.GreetingCard',
+                    majorVersion: '1',
+                    minorVersion: '0'
                 }
-            });
-            expect(returned.data.h5p).toMatchObject({
-                embedTypes: ['div'],
-                language: 'und',
-                license: 'U',
-                mainLibrary: 'H5P.GreetingCard',
-                preloadedDependencies: [
-                    {
-                        machineName: 'H5P.GreetingCard',
-                        majorVersion: '1',
-                        minorVersion: '0'
-                    }
-                ]
-            });
+            ]
         });
 
-        it('temporary files of uploaded packages should be accessible', async () => {
-            const returned = JSON.parse(uploadResult.text);
-            const imagePath = returned.data.content.image.path;
-            const imageResult = await mockApp.get(`/temp-files/${imagePath}`);
-            expect(imageResult.status).toBe(200);
-        });
+        const imagePath = returned.data.content.image.path;
+        const imageResult = await mockApp.get(`/temp-files/${imagePath}`);
+        expect(imageResult.status).toBe(200);
     });
 
     it('returns 200 on filter requests', async () => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
         globals: true,
         environment: 'node',
         testTimeout: Number(process.env.TEST_TIMEOUT) || 45000,
+        hookTimeout: Number(process.env.TEST_TIMEOUT) || 45000,
         clearMocks: true,
         include: [
             'packages/h5p-server/test/**/*.test.ts',


### PR DESCRIPTION
## Summary
- `vitest.config.ts` raised `testTimeout` to 45s but left `hookTimeout` at Vitest's 10s default, so the I/O-heavy `beforeEach` in `H5PAjaxExpressRouter.test.ts` (a real `.h5p` upload through the full validation/extraction pipeline) could intermittently exceed the hook timeout under machine load.
- Aligned `hookTimeout` with `testTimeout` in the root Vitest config so hooks get the same headroom as tests everywhere in the repo, not just this one file.
- Merged the two tests in the `'tests requiring uploaded files'` block into a single test, so the expensive upload happens once per run instead of twice, reducing the exposure to the flake further.

Fixes #4601

## Test plan
- [x] `npx vitest run H5PAjaxExpressRouter` — 21 tests passed
- [x] `npm run lint` / `npm run format:check` — clean (pre-commit hook)
- [x] `npm test` (full suite via pre-push hook) — 358 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BK5YkCrczYNkLFk7fyH9Pv