### PR TITLE
feat: set `embedCode` and `resizeCode` when render player model

### DIFF
--- a/packages/h5p-server/src/H5PPlayer.ts
+++ b/packages/h5p-server/src/H5PPlayer.ts
@@ -163,6 +163,8 @@ export default class H5PPlayer {
             showCopyButton?: boolean;
             showDownloadButton?: boolean;
             showEmbedButton?: boolean;
+            embedCode?: string;
+            resizeCode?: string;
             showFrame?: boolean;
             showH5PIcon?: boolean;
             showLicenseButton?: boolean;
@@ -259,6 +261,8 @@ export default class H5PPlayer {
                     showCopyButton: options?.showCopyButton ?? false,
                     showDownloadButton: options?.showDownloadButton ?? false,
                     showEmbedButton: options?.showEmbedButton ?? false,
+                    embedCode: options?.embedCode,
+                    resizeCode: options?.resizeCode,
                     showFrame: options?.showFrame ?? false,
                     showH5PIcon: options?.showH5PIcon ?? false,
                     showLicenseButton: options?.showLicenseButton ?? false
@@ -397,6 +401,8 @@ export default class H5PPlayer {
             showCopyButton: boolean;
             showDownloadButton: boolean;
             showEmbedButton: boolean;
+            embedCode?: string;
+            resizeCode?: string;
             showFrame: boolean;
             showH5PIcon: boolean;
             showLicenseButton: boolean;
@@ -458,7 +464,12 @@ export default class H5PPlayer {
                     scripts: assets.scripts,
                     styles: assets.styles,
                     url: this.urlGenerator.uniqueContentUrl(contentId),
-                    exportUrl: this.urlGenerator.downloadPackage(contentId)
+                    exportUrl: this.urlGenerator.downloadPackage(contentId),
+                    embedCode: displayOptions.embedCode?.replace(
+                        ':contentId',
+                        contentId
+                    ),
+                    resizeCode: displayOptions.resizeCode
                 }
             },
             core: {

--- a/packages/h5p-server/src/H5PPlayer.ts
+++ b/packages/h5p-server/src/H5PPlayer.ts
@@ -149,7 +149,17 @@ export default class H5PPlayer {
         in the URL of the content state Ajax call. The h5p-express adapter
         ignores posts that have this query parameter. You should, however, still
         prevent malicious users from writing other users' states in the
-        permission system! 
+        permission system!
+     * @param options.embedCode (optional) the HTML embed code (e.g. an
+        `<iframe>` tag) that is exposed to the H5P core client as
+        `H5PIntegration.contents[cid].embedCode` and used by the "Embed"
+        button. Any occurrence of the placeholder `:contentId` is replaced
+        with the actual content id, so the same template can be reused across
+        content items.
+     * @param options.resizeCode (optional) the `<script>` tag that is exposed
+        as `H5PIntegration.contents[cid].resizeCode` and included alongside
+        the embed code to make the embedded iframe resize to the available
+        width.
      * @returns a HTML string that you can insert into your page
      */
     public async render(
@@ -465,7 +475,7 @@ export default class H5PPlayer {
                     styles: assets.styles,
                     url: this.urlGenerator.uniqueContentUrl(contentId),
                     exportUrl: this.urlGenerator.downloadPackage(contentId),
-                    embedCode: displayOptions.embedCode?.replace(
+                    embedCode: displayOptions.embedCode?.replaceAll(
                         ':contentId',
                         contentId
                     ),

--- a/packages/h5p-server/test/H5PPlayer.render.test.ts
+++ b/packages/h5p-server/test/H5PPlayer.render.test.ts
@@ -470,4 +470,38 @@ describe('H5P.render()', () => {
             })
         ).rejects.toThrow('h5p-server:user-state-missing-view-permission');
     });
+
+    it('replaces all occurrences of :contentId in embedCode and sets resizeCode', async () => {
+        const contentId = 'foo';
+        const contentObject = {};
+        const metadata: any = {};
+
+        const config = new H5PConfig(undefined);
+        const user = new User();
+
+        const player = new H5PPlayer(undefined, undefined, config);
+        player.setRenderer((model) => model);
+        const playerModel: IPlayerModel = await player.render(
+            contentId,
+            user,
+            'en',
+            {
+                parametersOverride: contentObject,
+                metadataOverride: metadata as any,
+                embedCode:
+                    '<iframe src="https://example.org/h5p/embed/:contentId" data-content-id=":contentId"></iframe>',
+                resizeCode:
+                    '<script src="https://example.org/h5p/resizer.js"></script>'
+            }
+        );
+
+        expect(
+            playerModel.integration.contents[`cid-${contentId}`].embedCode
+        ).toEqual(
+            '<iframe src="https://example.org/h5p/embed/foo" data-content-id="foo"></iframe>'
+        );
+        expect(
+            playerModel.integration.contents[`cid-${contentId}`].resizeCode
+        ).toEqual('<script src="https://example.org/h5p/resizer.js"></script>');
+    });
 });


### PR DESCRIPTION
## Summary
- Continues #3320 (originally by @donnguyen) after rebasing onto current master and fixing an issue found in review.
- `H5PPlayer.render()` now accepts `embedCode`/`resizeCode` options and passes them through to `integration.contents[cid]`, which the H5P core client uses for the "Embed" button and iframe resizing.
- Fixed: the `:contentId` placeholder substitution used `String.prototype.replace`, which only replaces the first match. Switched to `replaceAll` so templates that reference `:contentId` more than once (e.g. in both a URL and an attribute) are fully substituted.
- Added JSDoc documenting the new `embedCode`/`resizeCode` options and the `:contentId` placeholder contract.
- Added a test covering an embed template with `:contentId` appearing twice.

## Test plan
- [x] `vitest run packages/h5p-server/test/H5PPlayer.render.test.ts` (13/13 passing)
- [x] `tsc --noEmit`
- [x] lint/format hooks

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017ugd42kfVy24fFaNamHVJG