### PR TITLE
fix(h5p-html-exporter): stop dropping modern CSS when minifying styles

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -314,7 +314,7 @@ jobs:
                   docker run -d --name minio -p 9000:9000 -p 9001:9001 \
                       -e MINIO_ROOT_USER=minioaccesskey \
                       -e MINIO_ROOT_PASSWORD=miniosecret \
-                      minio/minio:RELEASE.2025-09-07T16-13-09Z server /data --console-address :9001
+                      quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z server /data --console-address :9001
                   timeout 30 sh -c 'until curl -sf http://localhost:9000/minio/health/live; do sleep 1; done'
             - run: npm run test:h5p-mongos3 -- --coverage
             - run: npm run test:h5p-redis-lock

--- a/.github/workflows/e2e-nightly.yml
+++ b/.github/workflows/e2e-nightly.yml
@@ -170,7 +170,7 @@ jobs:
                   docker run -d --name minio -p 9000:9000 -p 9001:9001 \
                       -e MINIO_ROOT_USER=minioaccesskey \
                       -e MINIO_ROOT_PASSWORD=miniosecret \
-                      minio/minio:RELEASE.2025-09-07T16-13-09Z server /data --console-address :9001
+                      quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z server /data --console-address :9001
                   timeout 30 sh -c 'until curl -sf http://localhost:9000/minio/health/live; do sleep 1; done'
             - name: Start Redis
               # Only the mongo-s3-redis permutation needs this (see

--- a/package-lock.json
+++ b/package-lock.json
@@ -9258,16 +9258,6 @@
             "version": "2.5.1",
             "license": "MIT"
         },
-        "node_modules/clean-css": {
-            "version": "4.2.4",
-            "license": "MIT",
-            "dependencies": {
-                "source-map": "~0.6.0"
-            },
-            "engines": {
-                "node": ">= 4.0"
-            }
-        },
         "node_modules/clean-stack": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
@@ -18114,86 +18104,6 @@
                 "node": "^10 || ^12 || >=14"
             }
         },
-        "node_modules/postcss-clean": {
-            "version": "1.2.2",
-            "license": "MIT",
-            "dependencies": {
-                "clean-css": "^4.x",
-                "postcss": "^6.x"
-            },
-            "engines": {
-                "node": ">=4.0.0"
-            }
-        },
-        "node_modules/postcss-clean/node_modules/ansi-styles": {
-            "version": "3.2.1",
-            "license": "MIT",
-            "dependencies": {
-                "color-convert": "^1.9.0"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/postcss-clean/node_modules/chalk": {
-            "version": "2.4.2",
-            "license": "MIT",
-            "dependencies": {
-                "ansi-styles": "^3.2.1",
-                "escape-string-regexp": "^1.0.5",
-                "supports-color": "^5.3.0"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/postcss-clean/node_modules/color-convert": {
-            "version": "1.9.3",
-            "license": "MIT",
-            "dependencies": {
-                "color-name": "1.1.3"
-            }
-        },
-        "node_modules/postcss-clean/node_modules/color-name": {
-            "version": "1.1.3",
-            "license": "MIT"
-        },
-        "node_modules/postcss-clean/node_modules/escape-string-regexp": {
-            "version": "1.0.5",
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.8.0"
-            }
-        },
-        "node_modules/postcss-clean/node_modules/has-flag": {
-            "version": "3.0.0",
-            "license": "MIT",
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/postcss-clean/node_modules/postcss": {
-            "version": "6.0.23",
-            "license": "MIT",
-            "dependencies": {
-                "chalk": "^2.4.1",
-                "source-map": "^0.6.1",
-                "supports-color": "^5.4.0"
-            },
-            "engines": {
-                "node": ">=4.0.0"
-            }
-        },
-        "node_modules/postcss-clean/node_modules/supports-color": {
-            "version": "5.5.0",
-            "license": "MIT",
-            "dependencies": {
-                "has-flag": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
         "node_modules/postcss-import": {
             "version": "17.0.0",
             "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-17.0.0.tgz",
@@ -19606,6 +19516,7 @@
         },
         "node_modules/source-map": {
             "version": "0.6.1",
+            "devOptional": true,
             "license": "BSD-3-Clause",
             "engines": {
                 "node": ">=0.10.0"
@@ -22572,7 +22483,6 @@
                 "esbuild": "^0.28.0",
                 "mime-types": "^3.0.0",
                 "postcss": "^8.4.23",
-                "postcss-clean": "^1.2.2",
                 "postcss-import": "^17.0.0",
                 "postcss-safe-parser": "^7.0.0",
                 "postcss-url": "^10.1.3"

--- a/packages/h5p-html-exporter/package.json
+++ b/packages/h5p-html-exporter/package.json
@@ -51,7 +51,6 @@
         "esbuild": "^0.28.0",
         "mime-types": "^3.0.0",
         "postcss": "^8.4.23",
-        "postcss-clean": "^1.2.2",
         "postcss-import": "^17.0.0",
         "postcss-safe-parser": "^7.0.0",
         "postcss-url": "^10.1.3"

--- a/packages/h5p-html-exporter/src/HtmlExporter.ts
+++ b/packages/h5p-html-exporter/src/HtmlExporter.ts
@@ -2,7 +2,6 @@ import path from 'path';
 import postCss, { CssSyntaxError } from 'postcss';
 import postCssUrl from 'postcss-url';
 import postCssImport from 'postcss-import';
-import postCssClean from 'postcss-clean';
 import mimetypes from 'mime-types';
 import { transformSync, transform } from 'esbuild';
 import postCssSafeParser from 'postcss-safe-parser';
@@ -80,7 +79,7 @@ export type IExporterTemplate = (
  * full license text).
  *
  * (important!) You need to install these NPM packages for the exporter to work:
- * postcss, postcss-clean, postcss-url, postcss-safe-parser, esbuild
+ * postcss, postcss-import, postcss-url, postcss-safe-parser, esbuild
  */
 
 export default class HtmlExporter {
@@ -284,8 +283,8 @@ export default class HtmlExporter {
      * @param editor
      * @param library
      * @returns a multi-line comment with the license information. The comment
-     * is marked as important and includes @license so that esbuild and
-     * postcss-clean leave it in.
+     * is marked as important and includes @license so that esbuild leaves
+     * it in.
      */
     private async generateLicenseText(
         filename: string,
@@ -520,8 +519,7 @@ export default class HtmlExporter {
                                     core,
                                     usedFiles
                                 )
-                            }),
-                            postCssClean()
+                            })
                         ]
                     }),
                     postCssRemoveRedundantUrls(
@@ -543,8 +541,7 @@ export default class HtmlExporter {
                             core,
                             usedFiles
                         )
-                    }),
-                    postCssClean()
+                    })
                 );
                 let oldCwd;
                 try {
@@ -585,10 +582,36 @@ export default class HtmlExporter {
                         process.chdir(oldCwd);
                     }
                 }
-                styleTexts[style] = processedCss;
+                styleTexts[style] = await this.minifyCss(processedCss);
             })
         );
         return model.styles.map((style) => styleTexts[style]).join('\n');
+    }
+
+    /**
+     * Minifies a stylesheet. We deliberately don't lower modern CSS syntax
+     * (nesting, `@container`, `color-mix`, ...) to older equivalents, as the
+     * regular H5P player serves the very same stylesheets unchanged, so the
+     * exported HTML supports exactly the same browsers as the player does.
+     * @param css the stylesheet to minify
+     * @returns the minified stylesheet; the unchanged input if minification
+     * failed
+     */
+    private async minifyCss(css: string): Promise<string> {
+        try {
+            return (
+                await transform(css, {
+                    loader: 'css',
+                    minify: true,
+                    // keeps the /*!@license ... */ comments we added
+                    legalComments: 'inline'
+                })
+            ).code;
+        } catch {
+            // Minification is an optimization, not a requirement, so we rather
+            // bundle the unminified stylesheet than fail the whole export.
+            return css;
+        }
     }
 
     /**


### PR DESCRIPTION
## Problem

Exported HTML loses styling that the regular H5P player renders fine — e.g. buttons missing their rounding and other properties.

The cause is `postcss-clean`, which wraps `clean-css@4.2.4` (last released 2020). It predates CSS nesting and `@container`, and **silently deletes** what it cannot parse — no warning, no error:

```
in:  .h5p-joubelui-button { background: blue; border-radius: 2em;
                            &:hover { background: red }
                            .icon  { color: white } }
     @container card (width < 480px) { .a { color: red } }

out: .h5p-joubelui-button{background:#00f;border-radius:2em}
```

In a real export this was visible as `@container` appearing zero times in the bundle, and the nested `@media (prefers-reduced-motion)` block of `h5p-confirmation-dialog.css` coming out mangled (children flattened into the parent rule). Newer H5P core and library stylesheets use nesting, so any styling written inside a nested block disappears from the export.

Note this is **not** caused by the `uglify-js` → `esbuild` swap in #4399. Building the same content both ways produces functionally identical pages; the JS bundle is fine.

## Fix

Replace `postcss-clean` with esbuild's CSS minifier. esbuild is already a dependency of this package, so no new packages are added, and it understands nesting, `@container`, `color-mix()` and `hsl(from ...)`.

- both `postCssClean()` plugin entries are removed from the postcss pipeline
- a `minifyCss()` step runs esbuild `{ loader: 'css', minify: true, legalComments: 'inline' }` over the finished stylesheet; `legalComments: 'inline'` preserves the `/*!@license ... */` comments the exporter injects
- if minification ever throws, the unminified CSS is bundled instead, so an export cannot fail on minification alone
- no `target` is set, so nothing is lowered — the regular player serves these stylesheets unchanged, so the export keeps exactly the same browser support as the player

## Verification

- `@container` rules and nested rules survive in the generated bundle
- bundle size unchanged (~1.79 MB for the `H5P.Blanks` hub sample, dominated by inlined data URIs)
- `npx vitest run --config packages/h5p-html-exporter/vitest.config.ts` — 63/63 passing
- lint and format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TCVwWnQ9aXRkhuuyTJ9G2C