### PR TITLE
feat(h5p-examples): try next port if demo server port is in use

### DIFF
--- a/packages/h5p-examples/src/express.ts
+++ b/packages/h5p-examples/src/express.ts
@@ -22,7 +22,7 @@ import startPageRenderer from './startPageRenderer';
 import expressRoutes from './expressRoutes';
 import User from './User';
 import createH5PEditor from './createH5PEditor';
-import { displayIps, clearTempFiles } from './utils';
+import { displayIps, clearTempFiles, listenOnAvailablePort } from './utils';
 
 let tmpDir: DirectoryResult;
 
@@ -249,13 +249,15 @@ const start = async (): Promise<void> => {
         );
     }
 
-    const port = process.env.PORT || '8080';
+    const requestedPort = parseInt(process.env.PORT || '8080', 10);
+
+    // If the requested port is already in use, we try the next port number
+    // up until we find one that is free.
+    const { port } = await listenOnAvailablePort(server, requestedPort);
 
     // For developer convenience we display a list of IPs, the server is running
     // on. You can then simply click on it in the terminal.
-    displayIps(port);
-
-    server.listen(port);
+    displayIps(port.toString());
 };
 
 // We can't use await outside a an async function, so we use the start()

--- a/packages/h5p-examples/src/utils.ts
+++ b/packages/h5p-examples/src/utils.ts
@@ -1,6 +1,7 @@
 import os from 'os';
-import { Request } from 'express';
+import { Request, Express } from 'express';
 import { rm } from 'fs/promises';
+import { Server } from 'http';
 
 /**
  * Displays links to the server at all available IP addresses.
@@ -22,6 +23,34 @@ export function displayIps(port: string): void {
                 )
             );
     }
+}
+
+/**
+ * Starts listening on the given port. If the port is already in use, it
+ * tries the next port number up, and keeps doing so until it finds a free
+ * one.
+ * @param app the Express app to start listening with
+ * @param port the port to start trying from
+ * @returns the http.Server instance and the port it is actually listening on
+ */
+export function listenOnAvailablePort(
+    app: Express,
+    port: number
+): Promise<{ server: Server; port: number }> {
+    return new Promise((resolve, reject) => {
+        const server = app.listen(port);
+        server.once('listening', () => {
+            resolve({ server, port });
+        });
+        server.once('error', (error: NodeJS.ErrnoException) => {
+            if (error.code === 'EADDRINUSE') {
+                server.close();
+                resolve(listenOnAvailablePort(app, port + 1));
+            } else {
+                reject(error);
+            }
+        });
+    });
 }
 
 /**


### PR DESCRIPTION
## Summary
- The h5p-examples demo server previously crashed with `EADDRINUSE` if port 8080 (or the `PORT` env var) was already taken.
- It now tries the next port number up, repeating until it finds a free one, and reports the actual port it bound to.

## Test plan
- [x] `tsc --noEmit` on the h5p-examples server tsconfig
- [x] `eslint` on changed files (no new errors)
- [x] Manually occupied port 8080 with a dummy server and confirmed the demo server started on 8081 instead
- [x] Full unit test suite (pre-push hook, 360 tests) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012K3oh6jZpTMyhSjC3kzS1E