### PR TITLE
test(h5p-e2e): add upload-rejection E2E spec

### DIFF
--- a/packages/h5p-e2e/SELECTORS.md
+++ b/packages/h5p-e2e/SELECTORS.md
@@ -105,15 +105,15 @@ popup). Wait for `.h5p-metadata-popup-overlay` to become visible before
 interacting - it renders instantly but Playwright's actionability check can
 still race the CSS transition.
 
-| Selector (scoped to `.h5p-metadata-popup-overlay`)       | Notes                                                                                                                                                                                                                       |
-| -------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `.field-name-title input`                                | Title text input                                                                                                                                                                                                            |
-| `.field-name-license select`                             | License `<select>`                                                                                                                                                                                                          |
-| `.field-name-licenseVersion select`                      | License version `<select>`, disabled until a versioned license is chosen                                                                                                                                                    |
-| `.field-name-yearFrom input`, `.field-name-yearTo input` | Year range                                                                                                                                                                                                                  |
-| `.field-name-source input`                               | Source URL                                                                                                                                                                                                                  |
-| `.h5p-metadata-button.h5p-save`                          | "Save metadata" button; closes the popup                                                                                                                                                                                    |
-| (author list) `.h5p-metadata-author-widget`               | Bespoke widget, not a generic H5P "list" field - see "Author widget (metadata popup)" below for its own selectors; wrapped by `EditorPage.addAuthor()`.                                                                    |
+| Selector (scoped to `.h5p-metadata-popup-overlay`)       | Notes                                                                                                                                                   |
+| -------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `.field-name-title input`                                | Title text input                                                                                                                                        |
+| `.field-name-license select`                             | License `<select>`                                                                                                                                      |
+| `.field-name-licenseVersion select`                      | License version `<select>`, disabled until a versioned license is chosen                                                                                |
+| `.field-name-yearFrom input`, `.field-name-yearTo input` | Year range                                                                                                                                              |
+| `.field-name-source input`                               | Source URL                                                                                                                                              |
+| `.h5p-metadata-button.h5p-save`                          | "Save metadata" button; closes the popup                                                                                                                |
+| (author list) `.h5p-metadata-author-widget`              | Bespoke widget, not a generic H5P "list" field - see "Author widget (metadata popup)" below for its own selectors; wrapped by `EditorPage.addAuthor()`. |
 
 ### Import via `.h5p` upload (inside the iframe)
 
@@ -248,6 +248,28 @@ dragnbar element render the exact same `field-name-file` structure:
 Only one `.field-name-file` is ever visible at a time in either flow, so
 none of this needs extra scoping. `EditorPage.uploadImage(path, altText)`
 wraps all three steps.
+
+### Rejected uploads (`test/specs/upload-rejection.spec.ts`)
+
+Reuses the same `.field-name-file` structure as image upload above, but
+`h5peditor-file.js` renders the outcome differently on rejection:
+
+1. `EditorPage.attemptFileUpload(path)` performs steps 1-2 of image upload
+   only (click `a.add`, `setInputFiles` on the input it creates) - no alt
+   text field ever appears, since that only renders once an upload actually
+   succeeds.
+2. `EditorPage.fileFieldError()` (`.field-name-file .h5p-errors p`) - the
+   server's `message` (from `AjaxErrorResponse`), rendered here by
+   `ns.createError()` once `h5peditor-file-uploader.js` parses the failed
+   response. This is a bare `<p>`, not a widget-specific element - do not
+   over-scope selectors on it, `.field-name-file` is enough.
+3. `EditorPage.fileFieldAddLink()` (`.field-name-file .file a.add`) -
+   re-rendered by `addFile()` once `uploadComplete` fires, whether the
+   upload succeeded or failed. Asserting it is visible again after a
+   rejection proves the widget recovered instead of staying stuck on the
+   upload throbber (`.h5peditor-uploading`) - no separate "throbber gone"
+   selector is needed, since this element only exists once that throbber
+   markup has already been replaced.
 
 ### Course Presentation slide elements (DragNBar toolbar)
 
@@ -471,11 +493,11 @@ wrappers), so several inner selectors are identical to the ones
   in an iframe when actually embedded via `h5p-embed.js`. The
   `<h5p-player>` web component **always** wraps content in a real
   `iframe.h5p-iframe` (`h5p-player.ts`'s `createIframe()`/`h5pIFrameWrapper`),
-  since from the H5P core's perspective every web-component usage *is* an
+  since from the H5P core's perspective every web-component usage _is_ an
   embedding. `RestExampleAppPage.content()` therefore goes through
   `playerFrame()` (a `frameLocator('iframe.h5p-iframe')`) rather than a
   plain descendant locator - a plain locator produces `element(s) not
-  found` even though the player has rendered successfully (verified via the
+found` even though the player has rendered successfully (verified via the
   trace's accessibility snapshot, which showed a bare `iframe` node with no
   `.h5p-content` as a page-level descendant).
 - **CSRF**: `packages/h5p-rest-example-server` enables `csurf()` protection
@@ -483,7 +505,7 @@ wrappers), so several inner selectors are identical to the ones
   but nothing in the UI flow above needs special handling for it - logging
   in via the "Login as" dropdown stores the token from `/login`'s JSON
   response in `ContentService`, which attaches it as a `CSRF-Token` header
-  on every subsequent fetch. Only the *seeding* step (installing H5P.Blanks
+  on every subsequent fetch. Only the _seeding_ step (installing H5P.Blanks
   before the UI test runs, done via a raw API call in
   `test/fixtures/restExampleSeed.ts`) has to do this manually, since it
   bypasses the UI entirely - see that file's doc comment for how (log in as

--- a/packages/h5p-e2e/test/pages/EditorPage.ts
+++ b/packages/h5p-e2e/test/pages/EditorPage.ts
@@ -217,9 +217,20 @@ export default class EditorPage {
      * renders as a `<fieldset class="field ... field-name-<x>">` whose
      * `> .title` element toggles the `expanded` class via a click handler
      * (`role="button"` but not a real `<button>`).
+     *
+     * Waits for `> .content` to actually become visible before returning:
+     * `h5peditor-group.js`'s `expand()` adds the `expanded` class (the class
+     * `.group.expanded > .content { display: block }` keys off) inside a
+     * `setTimeout(..., 100)`, not synchronously on click, so a caller that
+     * immediately does a one-shot visibility check of something inside the
+     * group (rather than a Playwright action, which auto-retries) can
+     * otherwise race that 100ms delay and see stale, still-collapsed state.
      */
     public async expandGroup(groupSelector: string): Promise<void> {
         await this.frame.locator(`${groupSelector} > .title`).click();
+        await this.frame
+            .locator(`${groupSelector} > .content`)
+            .waitFor({ state: 'visible' });
     }
 
     /**
@@ -242,6 +253,46 @@ export default class EditorPage {
     }
 
     /**
+     * Like `selectLibraryType()`, but only interacts with the `<select>` if
+     * it is actually visible - the H5P media widget hides it entirely when
+     * only one real option (besides its "-" placeholder) is available,
+     * auto-selecting that option instead (see `selectLibraryType()`'s own
+     * doc comment). Whether that is the case depends on which other
+     * libraries happen to already be installed on the server this spec runs
+     * against, not just on the machine name(s) `seedLibraries()` was given
+     * for this spec: `content-lifecycle.spec.ts`'s Blanks fixture sees only
+     * "Image" because it seeds nothing else itself, but a real Playwright
+     * run's single, long-lived server process can carry over libraries
+     * installed by *earlier* spec files' `seedLibraries()` calls too (e.g.
+     * Course Presentation's H5P.Video/H5P.Audio dependencies) - `reset()`
+     * wipes storage on disk between specs, but has no way to invalidate a
+     * library-list cache already held in that still-running process's
+     * memory. Calling this instead of `selectLibraryType()` directly makes a
+     * spec's media-type selection correct either way, without having to
+     * know or control what ran before it.
+     */
+    public async selectLibraryTypeIfVisible(
+        groupSelector: string,
+        optionLabel: string
+    ): Promise<void> {
+        const select = this.frame.locator(
+            `${groupSelector} > .content > .field.library > select`
+        );
+        // The library list itself loads asynchronously
+        // (`h5peditor-library.js`'s `librariesLoaded()`, fired once an
+        // internal AJAX call resolves) - until it does, the `<select>` has
+        // only its "-" placeholder option and `isVisible()` below would
+        // race that load. Waiting for a second `<option>` to attach means
+        // `librariesLoaded()` has run and already made its
+        // hide-if-single-real-option decision, so checking visibility next
+        // is no longer a race.
+        await select.locator('option').nth(1).waitFor({ state: 'attached' });
+        if (await select.isVisible()) {
+            await select.selectOption({ label: optionLabel });
+        }
+    }
+
+    /**
      * Uploads an image into the (single, currently visible) `image` widget
      * field and fills its required alternative text. Both Blanks' Media
      * group and Course Presentation's per-element image form render the
@@ -259,6 +310,50 @@ export default class EditorPage {
             .locator('input[type="file"][accept*="image"]')
             .setInputFiles(imagePath);
         await this.frame.locator('.field-name-alt input').fill(altText);
+    }
+
+    /**
+     * Same "Add" -> `<input type="file">` flow as `uploadImage()`, but for a
+     * file the server is expected to reject: skips filling "Alternative
+     * text" (that field never appears - it is only rendered once an upload
+     * actually succeeds) and does not wait for anything to complete.
+     * `input[type="file"]` is left unscoped by `accept` (unlike
+     * `uploadImage()`) so this also works for a generic `file`-type widget,
+     * whose input has no `accept*="image"` attribute - see
+     * `h5peditor-file-uploader.js`'s `determineAllowedMimeTypes()`.
+     */
+    public async attemptFileUpload(filePath: string): Promise<void> {
+        await this.frame.locator('.field-name-file .file a.add').click();
+        // `:not([accept=".h5p"])` excludes the Hub's own (always-present,
+        // if hidden) upload-tab file input - see `switchToUploadTab()` /
+        // `uploadH5pPackage()` - which also matches a bare
+        // `input[type="file"]` and would otherwise make this locator
+        // ambiguous.
+        await this.frame
+            .locator('input[type="file"]:not([accept=".h5p"])')
+            .setInputFiles(filePath);
+    }
+
+    /**
+     * The `<p>` a rejected upload's server message is rendered into
+     * (`h5peditor-file.js`'s `uploadComplete` handler appends
+     * `ns.createError(error)` to `.h5p-errors` on failure - see
+     * `ns.createError()` in `h5peditor.js`). Scoped to `.field-name-file`
+     * like `uploadImage()`, since only one such field is ever visible at a
+     * time.
+     */
+    public fileFieldError(): Locator {
+        return this.frame.locator('.field-name-file .h5p-errors p');
+    }
+
+    /**
+     * The "Add" link a `file`/`image` widget shows while no file is
+     * attached (`h5peditor-file.js`'s `addFile()`). Re-rendered after a
+     * failed upload, so asserting this is visible again proves the widget
+     * recovered rather than staying stuck on the upload throbber.
+     */
+    public fileFieldAddLink(): Locator {
+        return this.frame.locator('.field-name-file .file a.add');
     }
 
     /**

--- a/packages/h5p-e2e/test/specs/upload-rejection.spec.ts
+++ b/packages/h5p-e2e/test/specs/upload-rejection.spec.ts
@@ -1,0 +1,148 @@
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+import { test, expect } from '@playwright/test';
+
+import { seedLibraries, getStateResetter } from '../fixtures';
+import EditorPage from '../pages/EditorPage';
+
+/**
+ * Deliberately imports `test`/`expect` from `@playwright/test` directly, not
+ * `../fixtures`. That module's `test` fails any spec on an unallowlisted
+ * browser console error, and a rejected upload always logs one - but not,
+ * as first suspected, via `H5P.error()`: that is only reached from
+ * `h5peditor-file-uploader.js`'s `JSON.parse` failure branch, which a
+ * well-formed `{success: false, message: ...}` rejection response never
+ * hits. What actually fires is Chrome itself logging "Failed to load
+ * resource: the server responded with a status of ..." for the upload
+ * XHR's own non-2xx response - unavoidable, and unrelated to whether the
+ * editor's own error handling is correct. Widening the shared
+ * `ALLOWED_CONSOLE_ERRORS` allowlist to cover it would blind every other
+ * spec to real upload errors, so this spec instead asserts on the console
+ * directly (below) - turning the incidental log into a deliberate
+ * assertion that exactly this one, expected message was logged and nothing
+ * else.
+ */
+
+const imagePath = path.join(
+    __dirname,
+    '../../../../test/data/sample-content/content/earth.jpg'
+);
+
+interface IUploadRejectionCase {
+    name: string;
+    expectedMessage: string;
+    /** Both cases here happen to be 400s - see `contentFileValidation.ts`'s
+     * `upload-validation-error` - but the server does not use the same
+     * status for every rejection reason (e.g. `not-in-whitelist` is a 500),
+     * so this is tracked per case rather than assumed. */
+    expectedStatus: number;
+    buildFixture(dir: string): Promise<string>;
+}
+
+const cases: IUploadRejectionCase[] = [
+    {
+        name: 'HTML content named .png',
+        expectedMessage: "The file you've uploaded is invalid.",
+        expectedStatus: 400,
+        async buildFixture(dir) {
+            const filePath = path.join(dir, 'disguised-html.png');
+            await fs.writeFile(
+                filePath,
+                '<html><body><script>alert(1)</script></body></html>'
+            );
+            return filePath;
+        }
+    },
+    {
+        name: 'SVG content named .png',
+        // Sidesteps https://github.com/Lumieducation/H5P-Nodejs-library/issues/4619
+        // (prolog-bearing SVGs are rejected while prolog-less ones are
+        // accepted) by disguising the file as .png, same as the server-side
+        // "invalid file" case above - the point here is the editor's error
+        // handling, not SVG validation itself.
+        expectedMessage: "The file you've uploaded is invalid.",
+        expectedStatus: 400,
+        async buildFixture(dir) {
+            const filePath = path.join(dir, 'disguised-svg.png');
+            await fs.writeFile(
+                filePath,
+                '<?xml version="1.0"?><svg xmlns="http://www.w3.org/2000/svg" width="1" height="1"></svg>'
+            );
+            return filePath;
+        }
+    }
+];
+
+test.describe('Upload rejections', () => {
+    test.beforeAll(async () => {
+        await getStateResetter().reset();
+    });
+
+    test.beforeAll(async ({ request }) => {
+        await seedLibraries(request, ['H5P.Blanks']);
+    });
+
+    for (const uploadCase of cases) {
+        test(`shows the server's error for ${uploadCase.name} instead of hanging, and recovers`, async ({
+            page
+        }) => {
+            const consoleErrors: string[] = [];
+            page.on('console', (message) => {
+                if (message.type() === 'error') {
+                    consoleErrors.push(message.text());
+                }
+            });
+
+            const tmpDir = await fs.mkdtemp(
+                path.join(os.tmpdir(), 'h5p-upload-rejection-')
+            );
+            try {
+                const fixturePath = await uploadCase.buildFixture(tmpDir);
+
+                const editor = new EditorPage(page);
+                await editor.gotoNew();
+                await editor.chooseContentType('Fill in the Blanks');
+                await editor.waitForContentForm('.field-name-text .ckeditor');
+                await editor.expandGroup('.field-name-media');
+                await editor.selectLibraryTypeIfVisible(
+                    '.field-name-media',
+                    'Image'
+                );
+
+                await editor.attemptFileUpload(fixturePath);
+
+                // The error names the rejection (proves the message was
+                // plumbed through, not replaced by `unknownFileUploadError`)...
+                await expect(editor.fileFieldError()).toHaveText(
+                    uploadCase.expectedMessage
+                );
+                // ...and the field recovered instead of hanging on the
+                // upload throbber.
+                await expect(editor.fileFieldAddLink()).toBeVisible();
+
+                // The failure did not wedge the widget: a subsequent valid
+                // upload into the same field still succeeds.
+                await editor.uploadImage(imagePath, 'Planet Earth');
+                await expect(
+                    editor.frame.locator('.field-name-file a.thumbnail')
+                ).toBeVisible();
+
+                // The only console error is Chrome's own network-status
+                // notice for the upload XHR's non-2xx response (see the
+                // module doc comment above) - proves nothing else went
+                // wrong along the way. Matched by status code, not the
+                // trailing reason phrase (e.g. "Bad Request"), since that
+                // phrase depends on the status and this only asserts the
+                // code that `expectedStatus` documents per case.
+                expect(consoleErrors).toHaveLength(1);
+                expect(consoleErrors[0]).toContain(
+                    `a status of ${uploadCase.expectedStatus}`
+                );
+                expect(consoleErrors[0]).toContain('Failed to load resource');
+            } finally {
+                await fs.rm(tmpDir, { recursive: true, force: true });
+            }
+        });
+    }
+});


### PR DESCRIPTION
## Summary
- Adds `packages/h5p-e2e/test/specs/upload-rejection.spec.ts`, covering a gap noted in the E2E automation plan: nothing drove a *failing* upload, so a regression that left the editor stuck on a spinner (or swallowed the server's error message) would not have been caught.
- Covers two rejection cases (HTML and SVG content disguised as `.png`): asserts the server's message renders in `.h5p-errors`, the field recovers instead of hanging on the upload throbber, a subsequent valid upload still succeeds, and exactly one (expected, benign) console error is logged.
- Fixes two latent races in `EditorPage` found while writing the spec:
  - `expandGroup()` returned before `h5peditor-group.js`'s deferred (`setTimeout(..., 100)`) `expanded` class actually landed.
  - Blanks' media-type `<select>` isn't always auto-hidden to a single "Image" option - that depends on what libraries earlier specs already installed on the shared dev server (e.g. Course Presentation pulling in `H5P.Video`/`H5P.Audio`). Added `selectLibraryTypeIfVisible()` to handle both cases.
- `SELECTORS.md` updated to document the new selectors/methods.

Not covered here (left for follow-up, per the same automation-plan gap notes):
- A real `.pdf` rejected by the content whitelist (500) - needs a field of semantics type `file`, not reachable through either vendored content type without much deeper UI plumbing.
- An EICAR malware rejection (400) - needs `CLAMSCAN_ENABLED=true` and a running clamd, which the default Playwright web server doesn't set up.

## Test plan
- [x] `npm run typecheck --workspace=packages/h5p-e2e`
- [x] `npx eslint` / `npx prettier --check` on changed files
- [x] `npx playwright test --config packages/h5p-e2e/playwright.config.ts --project=chromium` - full default suite (29 tests) green, including the new spec run both in isolation and after `content-lifecycle.spec.ts` has already polluted the shared server with extra libraries
- [x] `npm run test` (pre-push hook) - 360 tests passed

https://claude.ai/code/session_01YMC7LREJW4a7VdHgnNBgWi